### PR TITLE
feat: remaining load strategies (round-robin, random, failover)

### DIFF
--- a/.superpowers/2026-04-16-model-mapping-strategy/admin-api-remaining.md
+++ b/.superpowers/2026-04-16-model-mapping-strategy/admin-api-remaining.md
@@ -2,7 +2,11 @@
 
 ## validateRule 扩展
 
-在 `src/admin/groups.ts` 的 `validateRule` 函数中，为三种新策略增加验证：
+在 `src/admin/groups.ts` 的 `validateRule` 函数中：
+
+### 策略名白名单校验（优先）
+
+首先检查 `strategy` 是否在 `STRATEGY_NAMES` 的值集合中，对未知策略名返回错误。
 
 ### round-robin / random
 
@@ -14,7 +18,6 @@
 ### failover
 
 - 同上，但 targets 至少 2 个元素
-- 因为故障转移需要至少一个备选
 
 ## 无需新 migration
 

--- a/.superpowers/2026-04-16-model-mapping-strategy/admin-api-remaining.md
+++ b/.superpowers/2026-04-16-model-mapping-strategy/admin-api-remaining.md
@@ -1,0 +1,21 @@
+# Admin API 剩余策略
+
+## validateRule 扩展
+
+在 `src/admin/groups.ts` 的 `validateRule` 函数中，为三种新策略增加验证：
+
+### round-robin / random
+
+- rule 解析为 `{ targets: Target[] }`
+- targets 必须是数组，至少 1 个元素
+- 每个 target 必须有 backend_model 和 provider_id
+- provider_id 对应的 provider 必须存在
+
+### failover
+
+- 同上，但 targets 至少 2 个元素
+- 因为故障转移需要至少一个备选
+
+## 无需新 migration
+
+mapping_groups 表的 strategy 和 rule 字段已经是 TEXT，足够灵活。

--- a/.superpowers/2026-04-16-model-mapping-strategy/failover-integration.md
+++ b/.superpowers/2026-04-16-model-mapping-strategy/failover-integration.md
@@ -26,7 +26,16 @@
 - 新的 provider（从 resolveMapping 获取新的 provider_id）
 - 新的 body.model（resolved.backend_model）
 - 新的 apiKey（解密新 provider 的 api_key）
-- 正常记录日志（is_retry = 1）
+- 日志中 is_retry = 1（语义为"重试请求"，不区分同 provider 重试和跨 provider 故障转移）
+
+## 流式请求限制
+
+failover 循环**仅在 response headers 发送前**生效。一旦 proxyStream 开始向客户端写入 headers 或 pipe 数据，无法切换 target。
+
+具体实现：
+- 在 failover 循环入口检查 `reply.raw.headersSent`
+- 流式请求如果 headers 已发送，直接返回当前结果，不再尝试下一个 target
+- 这意味着流式请求的 failover 仅在连接建立失败、上游返回错误且未开始流式传输时生效
 
 ## 限制
 

--- a/.superpowers/2026-04-16-model-mapping-strategy/failover-integration.md
+++ b/.superpowers/2026-04-16-model-mapping-strategy/failover-integration.md
@@ -1,0 +1,34 @@
+# proxy-core 故障转移集成
+
+## 改动位置
+
+`src/proxy/proxy-core.ts` 的 `handleProxyPost` 函数。
+
+## 流程
+
+```
+1. resolveMapping(clientModel, { now }) → primary target
+2. 执行 proxy 请求（含 retryableCall）
+3. 如果最终结果失败且策略为 failover：
+   a. 将当前 target 加入 excludeTargets
+   b. resolveMapping(clientModel, { now, excludeTargets }) → next target
+   c. 如果有 next target，用新 provider/model 重新发起请求
+   d. 循环直到成功或无更多 target
+```
+
+## 判断"最终结果失败"
+
+- retryableCall 的最后一次 attempt 的 statusCode >= 400
+- 或 retryableCall 抛出异常
+
+## 每次切换 target
+
+- 新的 provider（从 resolveMapping 获取新的 provider_id）
+- 新的 body.model（resolved.backend_model）
+- 新的 apiKey（解密新 provider 的 api_key）
+- 正常记录日志（is_retry = 1）
+
+## 限制
+
+- 非 failover 策略完全不受影响，走原有路径
+- failover 循环上限 = targets 数量（最多尝试所有 target）

--- a/.superpowers/2026-04-16-model-mapping-strategy/frontend-remaining.md
+++ b/.superpowers/2026-04-16-model-mapping-strategy/frontend-remaining.md
@@ -17,8 +17,8 @@ scheduled / round-robin / random / failover
 ### targets 列表组件
 
 每个 target 项：
-- Select: 供应商
-- Select: 后端模型（联动供应商的 models 列表）
+- Select: 供应商（数据来源：`api.getProviders()` 返回的 providers 列表）
+- Select: 后端模型（联动供应商的 models 字段，数据来源：provider.models JSON 数组，已在 migration 012 中添加）
 - 删除按钮
 
 failover 额外：上移/下移按钮

--- a/.superpowers/2026-04-16-model-mapping-strategy/frontend-remaining.md
+++ b/.superpowers/2026-04-16-model-mapping-strategy/frontend-remaining.md
@@ -1,0 +1,40 @@
+# 前端 UI 剩余策略
+
+## MappingGroupFormDialog.vue 改动
+
+### 策略下拉
+
+```
+scheduled / round-robin / random / failover
+```
+
+### 按策略切换表单
+
+- **scheduled**：保持现有 default + windows 表单
+- **round-robin / random**：targets 列表（添加/删除 target，每项含 provider + model 选择）
+- **failover**：有序 targets 列表（上下箭头排序 + 添加/删除）
+
+### targets 列表组件
+
+每个 target 项：
+- Select: 供应商
+- Select: 后端模型（联动供应商的 models 列表）
+- 删除按钮
+
+failover 额外：上移/下移按钮
+
+## ModelMappings.vue 改动
+
+分组列表展示按策略类型显示不同内容：
+- scheduled：默认模型 + 时间窗口
+- round-robin / random：targets 列表（模型名 + 供应商名）
+- failover：有序 targets 列表（带序号）
+
+## DEFAULT_FORM 调整
+
+策略切换时重置表单结构：
+
+```
+scheduled → { default, windows }
+round-robin / random / failover → { targets: [{backend_model, provider_id}] }
+```

--- a/.superpowers/2026-04-16-model-mapping-strategy/plan-remaining-strategies.md
+++ b/.superpowers/2026-04-16-model-mapping-strategy/plan-remaining-strategies.md
@@ -1,0 +1,1065 @@
+# 剩余负载策略 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 为模型映射分组实现轮询 (round-robin)、随机 (random)、故障转移 (failover) 三种负载策略。
+
+**Architecture:** 在现有 `MappingStrategy` 接口基础上新增三个策略实现类，通过 `STRATEGIES` 注册表注册。故障转移通过扩展 `ResolveContext` 的 `excludeTargets` 字段，在 `proxy-core` 层面实现跨 target 重试循环。
+
+**Tech Stack:** TypeScript, Vitest, Fastify, Vue 3, shadcn-vue
+
+**Spec:** `.superpowers/2026-04-16-model-mapping-strategy/spec-remaining-strategies.md`
+
+---
+
+## File Structure
+
+| 操作 | 文件 | 职责 |
+|------|------|------|
+| Modify | `src/proxy/strategy/types.ts` | 扩展 ResolveContext、STRATEGY_NAMES |
+| Create | `src/proxy/strategy/round-robin.ts` | 轮询策略实现 |
+| Create | `src/proxy/strategy/random.ts` | 随机策略实现 |
+| Create | `src/proxy/strategy/failover.ts` | 故障转移策略实现 |
+| Modify | `src/proxy/mapping-resolver.ts` | 注册新策略 |
+| Modify | `src/proxy/proxy-core.ts` | failover 跨 target 重试循环 |
+| Modify | `src/admin/groups.ts` | validateRule 扩展新策略 |
+| Modify | `frontend/src/views/ModelMappings.vue` | 展示新策略的 targets |
+| Modify | `frontend/src/components/mappings/MappingGroupFormDialog.vue` | 策略选择 + targets 表单 |
+| Create | `tests/round-robin-strategy.test.ts` | 轮询策略单元测试 |
+| Create | `tests/random-strategy.test.ts` | 随机策略单元测试 |
+| Create | `tests/failover-strategy.test.ts` | 故障转移策略单元测试 |
+| Modify | `tests/mapping-resolver.test.ts` | 新策略的 resolveMapping 集成测试 |
+| Modify | `tests/admin-groups.test.ts` | Admin API 新策略验证测试 |
+
+---
+
+### Task 1: 扩展策略类型定义
+
+**Files:**
+- Modify: `src/proxy/strategy/types.ts`
+
+- [ ] **Step 1: 更新 types.ts**
+
+在现有文件中扩展 `ResolveContext` 和 `STRATEGY_NAMES`：
+
+```typescript
+export const STRATEGY_NAMES = {
+  SCHEDULED: "scheduled",
+  ROUND_ROBIN: "round-robin",
+  RANDOM: "random",
+  FAILOVER: "failover",
+} as const;
+
+export interface Target {
+  backend_model: string;
+  provider_id: string;
+}
+
+export interface ResolveContext {
+  now: Date;
+  excludeTargets?: Target[];
+}
+
+export interface MappingStrategy {
+  select(rule: unknown, context: ResolveContext): Target | undefined;
+}
+```
+
+- [ ] **Step 2: 运行现有测试确认无回归**
+
+Run: `npx vitest run tests/scheduled-strategy.test.ts tests/mapping-resolver.test.ts`
+Expected: 全部 PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/proxy/strategy/types.ts
+git commit -m "feat(strategy): extend ResolveContext with excludeTargets and add strategy names"
+```
+
+---
+
+### Task 2: 实现 RoundRobinStrategy
+
+**Files:**
+- Create: `src/proxy/strategy/round-robin.ts`
+- Create: `tests/round-robin-strategy.test.ts`
+
+- [ ] **Step 1: 编写 failing test**
+
+创建 `tests/round-robin-strategy.test.ts`：
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { RoundRobinStrategy } from "../src/proxy/strategy/round-robin.js";
+import type { Target } from "../src/proxy/strategy/types.js";
+
+const t1: Target = { backend_model: "gpt-4", provider_id: "p1" };
+const t2: Target = { backend_model: "claude-3", provider_id: "p2" };
+const t3: Target = { backend_model: "gemini", provider_id: "p3" };
+
+function makeContext() {
+  return { now: new Date() };
+}
+
+describe("RoundRobinStrategy", () => {
+  it("cycles through targets in order", () => {
+    const strategy = new RoundRobinStrategy();
+    const rule = { targets: [t1, t2, t3] };
+    expect(strategy.select(rule, makeContext())).toEqual(t1);
+    expect(strategy.select(rule, makeContext())).toEqual(t2);
+    expect(strategy.select(rule, makeContext())).toEqual(t3);
+    expect(strategy.select(rule, makeContext())).toEqual(t1);
+  });
+
+  it("returns undefined for empty targets", () => {
+    const strategy = new RoundRobinStrategy();
+    expect(strategy.select({ targets: [] }, makeContext())).toBeUndefined();
+  });
+
+  it("skips excluded targets", () => {
+    const strategy = new RoundRobinStrategy();
+    const rule = { targets: [t1, t2, t3] };
+    strategy.select(rule, makeContext()); // t1
+    strategy.select(rule, makeContext()); // t2
+    // exclude t3, should cycle back to t1
+    const result = strategy.select(rule, { ...makeContext(), excludeTargets: [t3] });
+    expect(result).toEqual(t1);
+  });
+
+  it("returns undefined when all targets excluded", () => {
+    const strategy = new RoundRobinStrategy();
+    const rule = { targets: [t1, t2] };
+    const result = strategy.select(rule, { ...makeContext(), excludeTargets: [t1, t2] });
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined for invalid rule", () => {
+    const strategy = new RoundRobinStrategy();
+    expect(strategy.select(null, makeContext())).toBeUndefined();
+    expect(strategy.select({ targets: "not-array" }, makeContext())).toBeUndefined();
+    expect(strategy.select({ targets: [null] }, makeContext())).toBeUndefined();
+  });
+
+  it("maintains independent state per client model", () => {
+    const strategy = new RoundRobinStrategy();
+    const ruleA = { targets: [t1, t2] };
+    const ruleB = { targets: [t3, t1] };
+    expect(strategy.select(ruleA, makeContext(), "model-a")).toEqual(t1);
+    expect(strategy.select(ruleB, makeContext(), "model-b")).toEqual(t3);
+    expect(strategy.select(ruleA, makeContext(), "model-a")).toEqual(t2);
+    expect(strategy.select(ruleB, makeContext(), "model-b")).toEqual(t1);
+  });
+});
+```
+
+注意：test 中 `select` 需要第三个参数 `clientModel`，在步骤 2 实现时添加。
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/round-robin-strategy.test.ts`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: 实现 RoundRobinStrategy**
+
+创建 `src/proxy/strategy/round-robin.ts`：
+
+```typescript
+import type { MappingStrategy, ResolveContext, Target } from "./types.js";
+
+interface TargetsRule {
+  targets: Target[];
+}
+
+function isTarget(value: unknown): value is Target {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "backend_model" in value &&
+    typeof (value as Target).backend_model === "string" &&
+    "provider_id" in value &&
+    typeof (value as Target).provider_id === "string"
+  );
+}
+
+function isTargetsRule(value: unknown): value is TargetsRule {
+  if (typeof value !== "object" || value === null) return false;
+  const r = value as TargetsRule;
+  return Array.isArray(r.targets) && r.targets.every(isTarget);
+}
+
+export class RoundRobinStrategy implements MappingStrategy {
+  private indexMap = new Map<string, number>();
+
+  select(rule: unknown, context: ResolveContext, clientModel?: string): Target | undefined {
+    if (!isTargetsRule(rule)) return undefined;
+
+    const key = clientModel ?? JSON.stringify(rule);
+    const filtered = rule.targets.filter(
+      (t) => !context.excludeTargets?.some(
+        (e) => e.backend_model === t.backend_model && e.provider_id === t.provider_id
+      )
+    );
+    if (filtered.length === 0) return undefined;
+
+    const lastIndex = this.indexMap.get(key) ?? -1;
+    const nextIndex = (lastIndex + 1) % filtered.length;
+    this.indexMap.set(key, nextIndex);
+    return filtered[nextIndex];
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run tests/round-robin-strategy.test.ts`
+Expected: 全部 PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/proxy/strategy/round-robin.ts tests/round-robin-strategy.test.ts
+git commit -m "feat(strategy): implement round-robin strategy with memory-based index"
+```
+
+---
+
+### Task 3: 实现 RandomStrategy
+
+**Files:**
+- Create: `src/proxy/strategy/random.ts`
+- Create: `tests/random-strategy.test.ts`
+
+- [ ] **Step 1: 编写 failing test**
+
+创建 `tests/random-strategy.test.ts`：
+
+```typescript
+import { describe, it, expect, vi } from "vitest";
+import { RandomStrategy } from "../src/proxy/strategy/random.js";
+import type { Target } from "../src/proxy/strategy/types.js";
+
+const t1: Target = { backend_model: "gpt-4", provider_id: "p1" };
+const t2: Target = { backend_model: "claude-3", provider_id: "p2" };
+const t3: Target = { backend_model: "gemini", provider_id: "p3" };
+
+function makeContext() {
+  return { now: new Date() };
+}
+
+describe("RandomStrategy", () => {
+  it("returns a target from the list", () => {
+    const strategy = new RandomStrategy();
+    const rule = { targets: [t1, t2, t3] };
+    const result = strategy.select(rule, makeContext());
+    expect([t1, t2, t3]).toContainEqual(result);
+  });
+
+  it("returns undefined for empty targets", () => {
+    const strategy = new RandomStrategy();
+    expect(strategy.select({ targets: [] }, makeContext())).toBeUndefined();
+  });
+
+  it("skips excluded targets", () => {
+    const strategy = new RandomStrategy();
+    const rule = { targets: [t1, t2] };
+    const result = strategy.select(rule, { ...makeContext(), excludeTargets: [t1] });
+    expect(result).toEqual(t2);
+  });
+
+  it("returns undefined when all excluded", () => {
+    const strategy = new RandomStrategy();
+    const rule = { targets: [t1, t2] };
+    const result = strategy.select(rule, { ...makeContext(), excludeTargets: [t1, t2] });
+    expect(result).toBeUndefined();
+  });
+
+  it("returns single target when only one remains after exclude", () => {
+    const strategy = new RandomStrategy();
+    const rule = { targets: [t1, t2, t3] };
+    const result = strategy.select(rule, { ...makeContext(), excludeTargets: [t1, t3] });
+    expect(result).toEqual(t2);
+  });
+
+  it("returns undefined for invalid rule", () => {
+    const strategy = new RandomStrategy();
+    expect(strategy.select(null, makeContext())).toBeUndefined();
+    expect(strategy.select({ targets: "not-array" }, makeContext())).toBeUndefined();
+    expect(strategy.select({ targets: [123] }, makeContext())).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/random-strategy.test.ts`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: 实现 RandomStrategy**
+
+创建 `src/proxy/strategy/random.ts`：
+
+```typescript
+import type { MappingStrategy, ResolveContext, Target } from "./types.js";
+
+interface TargetsRule {
+  targets: Target[];
+}
+
+function isTarget(value: unknown): value is Target {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "backend_model" in value &&
+    typeof (value as Target).backend_model === "string" &&
+    "provider_id" in value &&
+    typeof (value as Target).provider_id === "string"
+  );
+}
+
+function isTargetsRule(value: unknown): value is TargetsRule {
+  if (typeof value !== "object" || value === null) return false;
+  const r = value as TargetsRule;
+  return Array.isArray(r.targets) && r.targets.every(isTarget);
+}
+
+export class RandomStrategy implements MappingStrategy {
+  select(rule: unknown, context: ResolveContext): Target | undefined {
+    if (!isTargetsRule(rule)) return undefined;
+
+    const filtered = rule.targets.filter(
+      (t) => !context.excludeTargets?.some(
+        (e) => e.backend_model === t.backend_model && e.provider_id === t.provider_id
+      )
+    );
+    if (filtered.length === 0) return undefined;
+
+    return filtered[Math.floor(Math.random() * filtered.length)];
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run tests/random-strategy.test.ts`
+Expected: 全部 PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/proxy/strategy/random.ts tests/random-strategy.test.ts
+git commit -m "feat(strategy): implement random strategy with exclude support"
+```
+
+---
+
+### Task 4: 实现 FailoverStrategy
+
+**Files:**
+- Create: `src/proxy/strategy/failover.ts`
+- Create: `tests/failover-strategy.test.ts`
+
+- [ ] **Step 1: 编写 failing test**
+
+创建 `tests/failover-strategy.test.ts`：
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { FailoverStrategy } from "../src/proxy/strategy/failover.js";
+import type { Target } from "../src/proxy/strategy/types.js";
+
+const t1: Target = { backend_model: "gpt-4", provider_id: "p1" };
+const t2: Target = { backend_model: "claude-3", provider_id: "p2" };
+const t3: Target = { backend_model: "gemini", provider_id: "p3" };
+
+function makeContext() {
+  return { now: new Date() };
+}
+
+describe("FailoverStrategy", () => {
+  it("returns first target by default", () => {
+    const strategy = new FailoverStrategy();
+    const rule = { targets: [t1, t2, t3] };
+    expect(strategy.select(rule, makeContext())).toEqual(t1);
+  });
+
+  it("returns second target when first is excluded", () => {
+    const strategy = new FailoverStrategy();
+    const rule = { targets: [t1, t2, t3] };
+    const result = strategy.select(rule, { ...makeContext(), excludeTargets: [t1] });
+    expect(result).toEqual(t2);
+  });
+
+  it("returns third target when first two are excluded", () => {
+    const strategy = new FailoverStrategy();
+    const rule = { targets: [t1, t2, t3] };
+    const result = strategy.select(rule, { ...makeContext(), excludeTargets: [t1, t2] });
+    expect(result).toEqual(t3);
+  });
+
+  it("returns undefined when all targets excluded", () => {
+    const strategy = new FailoverStrategy();
+    const rule = { targets: [t1, t2] };
+    const result = strategy.select(rule, { ...makeContext(), excludeTargets: [t1, t2] });
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined for invalid rule", () => {
+    const strategy = new FailoverStrategy();
+    expect(strategy.select(null, makeContext())).toBeUndefined();
+    expect(strategy.select({ targets: "not-array" }, makeContext())).toBeUndefined();
+    expect(strategy.select({ targets: [null] }, makeContext())).toBeUndefined();
+  });
+
+  it("returns undefined for empty targets", () => {
+    const strategy = new FailoverStrategy();
+    expect(strategy.select({ targets: [] }, makeContext())).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/failover-strategy.test.ts`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: 实现 FailoverStrategy**
+
+创建 `src/proxy/strategy/failover.ts`：
+
+```typescript
+import type { MappingStrategy, ResolveContext, Target } from "./types.js";
+
+interface TargetsRule {
+  targets: Target[];
+}
+
+function isTarget(value: unknown): value is Target {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "backend_model" in value &&
+    typeof (value as Target).backend_model === "string" &&
+    "provider_id" in value &&
+    typeof (value as Target).provider_id === "string"
+  );
+}
+
+function isTargetsRule(value: unknown): value is TargetsRule {
+  if (typeof value !== "object" || value === null) return false;
+  const r = value as TargetsRule;
+  return Array.isArray(r.targets) && r.targets.every(isTarget);
+}
+
+export class FailoverStrategy implements MappingStrategy {
+  select(rule: unknown, context: ResolveContext): Target | undefined {
+    if (!isTargetsRule(rule)) return undefined;
+
+    for (const t of rule.targets) {
+      const excluded = context.excludeTargets?.some(
+        (e) => e.backend_model === t.backend_model && e.provider_id === t.provider_id
+      );
+      if (!excluded) return t;
+    }
+    return undefined;
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run tests/failover-strategy.test.ts`
+Expected: 全部 PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/proxy/strategy/failover.ts tests/failover-strategy.test.ts
+git commit -m "feat(strategy): implement failover strategy with exclude-based selection"
+```
+
+---
+
+### Task 5: 注册新策略到 mapping-resolver
+
+**Files:**
+- Modify: `src/proxy/mapping-resolver.ts`
+- Modify: `tests/mapping-resolver.test.ts`
+
+- [ ] **Step 1: 添加 failing test**
+
+在 `tests/mapping-resolver.test.ts` 末尾（`describe` 块内）追加：
+
+```typescript
+it("resolves round-robin strategy", () => {
+  const rule = JSON.stringify({
+    targets: [
+      { backend_model: "gpt-4", provider_id: "p1" },
+      { backend_model: "claude-3", provider_id: "p2" },
+    ],
+  });
+  // 先插入 provider（resolveMapping 不校验 provider，但以防未来变更）
+  db.prepare("INSERT INTO mapping_groups (id, client_model, strategy, rule, created_at) VALUES (?, ?, ?, ?, ?)")
+    .run("g1", "my-model", "round-robin", rule, new Date().toISOString());
+
+  const result = resolveMapping(db, "my-model", { now: new Date() });
+  // 第一次应该返回 targets[0]
+  expect(result).toEqual({ backend_model: "gpt-4", provider_id: "p1" });
+});
+
+it("resolves random strategy", () => {
+  const rule = JSON.stringify({
+    targets: [
+      { backend_model: "gpt-4", provider_id: "p1" },
+      { backend_model: "claude-3", provider_id: "p2" },
+    ],
+  });
+  db.prepare("INSERT INTO mapping_groups (id, client_model, strategy, rule, created_at) VALUES (?, ?, ?, ?, ?)")
+    .run("g1", "my-model", "random", rule, new Date().toISOString());
+
+  const result = resolveMapping(db, "my-model", { now: new Date() });
+  expect(result?.backend_model).toBeDefined();
+  expect(result?.provider_id).toBeDefined();
+});
+
+it("resolves failover strategy", () => {
+  const rule = JSON.stringify({
+    targets: [
+      { backend_model: "gpt-4", provider_id: "p1" },
+      { backend_model: "claude-3", provider_id: "p2" },
+    ],
+  });
+  db.prepare("INSERT INTO mapping_groups (id, client_model, strategy, rule, created_at) VALUES (?, ?, ?, ?, ?)")
+    .run("g1", "my-model", "failover", rule, new Date().toISOString());
+
+  const result = resolveMapping(db, "my-model", { now: new Date() });
+  expect(result).toEqual({ backend_model: "gpt-4", provider_id: "p1" });
+});
+
+it("resolves failover with excludeTargets", () => {
+  const rule = JSON.stringify({
+    targets: [
+      { backend_model: "gpt-4", provider_id: "p1" },
+      { backend_model: "claude-3", provider_id: "p2" },
+    ],
+  });
+  db.prepare("INSERT INTO mapping_groups (id, client_model, strategy, rule, created_at) VALUES (?, ?, ?, ?, ?)")
+    .run("g1", "my-model", "failover", rule, new Date().toISOString());
+
+  const result = resolveMapping(db, "my-model", {
+    now: new Date(),
+    excludeTargets: [{ backend_model: "gpt-4", provider_id: "p1" }],
+  });
+  expect(result).toEqual({ backend_model: "claude-3", provider_id: "p2" });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/mapping-resolver.test.ts`
+Expected: 新测试 FAIL（策略未注册）
+
+- [ ] **Step 3: 注册策略**
+
+修改 `src/proxy/mapping-resolver.ts`：
+
+```typescript
+import Database from "better-sqlite3";
+import type { Target, ResolveContext } from "./strategy/types.js";
+import { STRATEGY_NAMES } from "./strategy/types.js";
+import { ScheduledStrategy } from "./strategy/scheduled.js";
+import { RoundRobinStrategy } from "./strategy/round-robin.js";
+import { RandomStrategy } from "./strategy/random.js";
+import { FailoverStrategy } from "./strategy/failover.js";
+import { getMappingGroup } from "../db/index.js";
+
+const STRATEGIES: Record<string, import("./strategy/types.js").MappingStrategy> = {
+  [STRATEGY_NAMES.SCHEDULED]: new ScheduledStrategy(),
+  [STRATEGY_NAMES.ROUND_ROBIN]: new RoundRobinStrategy(),
+  [STRATEGY_NAMES.RANDOM]: new RandomStrategy(),
+  [STRATEGY_NAMES.FAILOVER]: new FailoverStrategy(),
+};
+
+// resolveMapping 函数保持不变
+```
+
+同时需要给 `resolveMapping` 添加 `clientModel` 参数传递给 `strategy.select()`（RoundRobinStrategy 需要用 clientModel 维护 index）：
+
+```typescript
+export function resolveMapping(
+  db: Database.Database,
+  clientModel: string,
+  context: ResolveContext,
+): Target | null {
+  const group = getMappingGroup(db, clientModel);
+  if (!group) return null;
+
+  let rule: unknown;
+  try { rule = JSON.parse(group.rule); } catch { console.warn(`[mapping-resolver] Failed to parse rule for client_model '${group.client_model}'`); return null; }
+
+  const strategy = STRATEGIES[group.strategy];
+  if (!strategy) return null;
+
+  // RoundRobinStrategy 的 select 签名支持可选的 clientModel 参数
+  return (strategy as any).select(rule, context, clientModel) ?? null;
+}
+```
+
+> 注意：这里用 `as any` 是因为 `MappingStrategy` 接口的 `select` 只定义了两个参数。如果 RoundRobinStrategy 的第三个参数 `clientModel` 需要更正式地支持，应扩展 `MappingStrategy` 接口。但考虑到只有 RoundRobinStrategy 需要这个参数，用可选参数 + `as any` 是合理的临时方案。实现时可以选择扩展接口。
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run tests/mapping-resolver.test.ts`
+Expected: 全部 PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/proxy/mapping-resolver.ts tests/mapping-resolver.test.ts
+git commit -m "feat(resolver): register round-robin, random, failover strategies"
+```
+
+---
+
+### Task 6: Admin API validateRule 扩展
+
+**Files:**
+- Modify: `src/admin/groups.ts`
+- Modify: `tests/admin-groups.test.ts`
+
+- [ ] **Step 1: 添加 failing test**
+
+在 `tests/admin-groups.test.ts` 的 `describe("Mapping Group CRUD")` 块内追加：
+
+```typescript
+it("POST creates round-robin group", async () => {
+  const res = await app.inject({
+    method: "POST",
+    url: "/admin/api/mapping-groups",
+    headers: { cookie, "content-type": "application/json" },
+    payload: {
+      client_model: "gpt-4",
+      strategy: "round-robin",
+      rule: JSON.stringify({
+        targets: [
+          { backend_model: "gpt-4-turbo", provider_id: providerId },
+          { backend_model: "gpt-4o", provider_id: providerId },
+        ],
+      }),
+    },
+  });
+  expect(res.statusCode).toBe(201);
+});
+
+it("POST creates random group", async () => {
+  const res = await app.inject({
+    method: "POST",
+    url: "/admin/api/mapping-groups",
+    headers: { cookie, "content-type": "application/json" },
+    payload: {
+      client_model: "gpt-4",
+      strategy: "random",
+      rule: JSON.stringify({
+        targets: [
+          { backend_model: "gpt-4-turbo", provider_id: providerId },
+        ],
+      }),
+    },
+  });
+  expect(res.statusCode).toBe(201);
+});
+
+it("POST creates failover group", async () => {
+  const res = await app.inject({
+    method: "POST",
+    url: "/admin/api/mapping-groups",
+    headers: { cookie, "content-type": "application/json" },
+    payload: {
+      client_model: "gpt-4",
+      strategy: "failover",
+      rule: JSON.stringify({
+        targets: [
+          { backend_model: "gpt-4-turbo", provider_id: providerId },
+          { backend_model: "gpt-4o", provider_id: providerId },
+        ],
+      }),
+    },
+  });
+  expect(res.statusCode).toBe(201);
+});
+
+it("POST failover with single target returns 400", async () => {
+  const res = await app.inject({
+    method: "POST",
+    url: "/admin/api/mapping-groups",
+    headers: { cookie, "content-type": "application/json" },
+    payload: {
+      client_model: "gpt-4",
+      strategy: "failover",
+      rule: JSON.stringify({
+        targets: [
+          { backend_model: "gpt-4-turbo", provider_id: providerId },
+        ],
+      }),
+    },
+  });
+  expect(res.statusCode).toBe(400);
+});
+
+it("POST round-robin with empty targets returns 400", async () => {
+  const res = await app.inject({
+    method: "POST",
+    url: "/admin/api/mapping-groups",
+    headers: { cookie, "content-type": "application/json" },
+    payload: {
+      client_model: "gpt-4",
+      strategy: "round-robin",
+      rule: JSON.stringify({ targets: [] }),
+    },
+  });
+  expect(res.statusCode).toBe(400);
+});
+
+it("POST with unknown strategy returns 400", async () => {
+  const res = await app.inject({
+    method: "POST",
+    url: "/admin/api/mapping-groups",
+    headers: { cookie, "content-type": "application/json" },
+    payload: {
+      client_model: "gpt-4",
+      strategy: "unknown-strategy",
+      rule: JSON.stringify({ targets: [] }),
+    },
+  });
+  expect(res.statusCode).toBe(400);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/admin-groups.test.ts`
+Expected: 新测试 FAIL
+
+- [ ] **Step 3: 扩展 validateRule**
+
+修改 `src/admin/groups.ts` 的 `validateRule` 函数：
+
+1. 添加策略名白名单校验（在函数最前面）
+
+```typescript
+const VALID_STRATEGIES = new Set(Object.values(STRATEGY_NAMES));
+if (!VALID_STRATEGIES.has(strategy)) {
+  return `Unknown strategy '${strategy}'. Valid: ${[...VALID_STRATEGIES].join(", ")}`;
+}
+```
+
+2. 添加 targets 类策略的验证（在 scheduled 验证之后）
+
+```typescript
+if (strategy === STRATEGY_NAMES.ROUND_ROBIN || strategy === STRATEGY_NAMES.RANDOM || strategy === STRATEGY_NAMES.FAILOVER) {
+  const r = rule as { targets?: unknown[] };
+  if (!Array.isArray(r.targets) || r.targets.length === 0) {
+    return "rule.targets must be a non-empty array";
+  }
+  const minTargets = strategy === STRATEGY_NAMES.FAILOVER ? 2 : 1;
+  if (r.targets.length < minTargets) {
+    return `strategy '${strategy}' requires at least ${minTargets} target(s)`;
+  }
+  for (let i = 0; i < r.targets.length; i++) {
+    const t = r.targets[i] as any;
+    if (!t.backend_model || !t.provider_id) {
+      return `targets[${i}] missing backend_model or provider_id`;
+    }
+    const p = getProviderById(db, t.provider_id);
+    if (!p) {
+      return `targets[${i}] provider_id '${t.provider_id}' not found`;
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run tests/admin-groups.test.ts`
+Expected: 全部 PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/admin/groups.ts tests/admin-groups.test.ts
+git commit -m "feat(admin): validate round-robin, random, failover rules with strategy whitelist"
+```
+
+---
+
+### Task 7: proxy-core failover 跨 target 重试
+
+**Files:**
+- Modify: `src/proxy/proxy-core.ts`
+
+这是最复杂的改动。需要在 `handleProxyPost` 中增加 failover 循环。
+
+- [ ] **Step 1: 理解改动范围**
+
+当前 `handleProxyPost` 流程（`src/proxy/proxy-core.ts:400-560`）：
+1. resolveMapping → 获取 target
+2. getProviderById → 获取 provider
+3. retryableCall → 执行 proxy 请求（含重试）
+4. 记录日志、返回结果
+
+Failover 需要在外层增加循环：当结果失败且策略为 failover 时，排除当前 target 重新 resolve。
+
+- [ ] **Step 2: 提取 proxy 执行逻辑为内部函数**
+
+将 `handleProxyPost` 中从 `resolveMapping` 到 `return reply` 的逻辑重构为一个 `executeProxyWithTarget` 内部函数（或直接用循环），减少嵌套。
+
+推荐方式：在 `handleProxyPost` 中用 `while` 循环 + `excludeTargets` 数组：
+
+```typescript
+export async function handleProxyPost(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  apiType: "openai" | "anthropic",
+  upstreamPath: string,
+  errors: ProxyErrorFormatter,
+  deps: ProxyHandlerDeps,
+  options?: { beforeSendProxy?: (body: Record<string, unknown>, isStream: boolean) => void; },
+): Promise<FastifyReply> {
+  const { db, streamTimeoutMs, retryMaxAttempts, retryBaseDelayMs, matcher } = deps;
+
+  request.raw.socket.on("error", (err) => request.log.debug({ err }, "client socket error"));
+  const startTime = Date.now();
+  const logId = randomUUID();
+  const routerKeyId = request.routerKey?.id ?? null;
+  const body = request.body as Record<string, unknown>;
+  const originalBody = JSON.parse(JSON.stringify(body));
+  const clientModel = (body.model as string) || "unknown";
+
+  // --- Failover 循环 ---
+  const excludeTargets: Target[] = [];
+  let isFailover = false;
+
+  while (true) {
+    const resolved = resolveMapping(db, clientModel, { now: new Date(), excludeTargets });
+    if (!resolved) {
+      if (isFailover && excludeTargets.length > 0) {
+        // 所有 failover target 都已尝试，返回最后一次的错误（已经在上一轮发送了 reply）
+        // 这种情况不应该发生，因为上一轮已经 return 了
+        break;
+      }
+      const e = errors.modelNotFound(clientModel);
+      return reply.status(e.statusCode).send(e.body);
+    }
+
+    // 检查 failover 策略（仅在第一次 resolve 时检查）
+    if (excludeTargets.length === 0) {
+      const group = getMappingGroup(db, clientModel);
+      isFailover = group?.strategy === "failover";
+    }
+
+    // ... 原有的 provider 校验、proxy 请求、日志记录逻辑 ...
+    // ... 将整个 try/catch 块放在这里 ...
+
+    // 在 try 块成功返回后，如果结果不是成功且是 failover：
+    // 在 catch 或 非 2xx 时：检查是否需要 failover
+    // 具体实现见步骤 3
+  }
+}
+```
+
+> 注意：这是一个复杂重构，实现时需要仔细处理。关键是确保：
+> 1. 非 failover 策略走原有路径（无循环）
+> 2. failover 仅在 headers 未发送时重试
+> 3. 每次重试使用新的 provider/model/apiKey
+> 4. 所有日志正常记录
+
+- [ ] **Step 3: 实现完整的 failover 循环**
+
+核心改动逻辑：
+- 将原有 `resolveMapping` → `proxy` → `log` → `return` 包裹在 `while(true)` 循环中
+- 每次循环开始时 `resolveMapping(db, clientModel, { now, excludeTargets })`
+- 在 `retryableCall` 返回后，检查是否需要 failover：
+  - 非 failover 策略：直接 break/return（与原逻辑相同）
+  - failover + 失败 + headers 未发送：将当前 target 加入 excludeTargets，continue
+  - failover + 成功 或 headers 已发送：break/return
+
+- [ ] **Step 4: Run 全部 proxy 测试**
+
+Run: `npx vitest run tests/openai-proxy.test.ts tests/anthropic-proxy.test.ts tests/integration.test.ts`
+Expected: 全部 PASS（确保无回归）
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/proxy/proxy-core.ts
+git commit -m "feat(proxy): add failover loop across targets in handleProxyPost"
+```
+
+---
+
+### Task 8: 前端 — 策略下拉和 targets 表单
+
+**Files:**
+- Modify: `frontend/src/components/mappings/MappingGroupFormDialog.vue`
+- Modify: `frontend/src/views/ModelMappings.vue`
+
+- [ ] **Step 1: 在 MappingGroupFormDialog.vue 中扩展策略下拉**
+
+将策略 SelectContent 从只有 `scheduled` 扩展为四个选项：
+
+```html
+<SelectContent>
+  <SelectItem value="scheduled">定时切换 (scheduled)</SelectItem>
+  <SelectItem value="round-robin">轮询 (round-robin)</SelectItem>
+  <SelectItem value="random">随机 (random)</SelectItem>
+  <SelectItem value="failover">故障转移 (failover)</SelectItem>
+</SelectContent>
+```
+
+- [ ] **Step 2: 根据策略切换表单区域**
+
+在表单中增加条件渲染：
+- `v-if="form.strategy === 'scheduled'"` → 保持现有的 default + windows 表单
+- `v-else` → targets 列表表单
+
+targets 列表表单结构：
+
+```html
+<div v-else class="border rounded-lg p-3 space-y-3">
+  <div class="flex items-center justify-between">
+    <div class="text-sm font-medium text-foreground">目标列表</div>
+    <Button type="button" variant="outline" size="sm" @click="emit('addTarget')">添加目标</Button>
+  </div>
+  <div v-for="(t, idx) in form.targets" :key="idx" class="border rounded-md p-2 space-y-2">
+    <div class="flex items-center gap-2">
+      <div class="flex-1">
+        <Label class="block text-xs text-muted-foreground mb-1">供应商</Label>
+        <Select :model-value="t.provider_id" @update:model-value="onTargetProviderChange(idx, $event)">
+          <!-- 同现有的 provider select -->
+        </Select>
+      </div>
+      <div class="flex-1">
+        <Label class="block text-xs text-muted-foreground mb-1">后端模型</Label>
+        <Select v-model="t.backend_model">
+          <!-- 同现有的 model select -->
+        </Select>
+      </div>
+      <div v-if="form.strategy === 'failover'" class="flex flex-col gap-1">
+        <Button type="button" variant="ghost" size="sm" :disabled="idx === 0" @click="emit('moveTargetUp', idx)">↑</Button>
+        <Button type="button" variant="ghost" size="sm" :disabled="idx === form.targets.length - 1" @click="emit('moveTargetDown', idx)">↓</Button>
+      </div>
+      <Button type="button" variant="ghost" size="sm" class="text-destructive shrink-0" @click="emit('removeTarget', idx)">删除</Button>
+    </div>
+  </div>
+  <div v-if="form.targets.length === 0" class="text-sm text-muted-foreground">暂无目标</div>
+</div>
+```
+
+- [ ] **Step 3: 更新 FormData 和 emits**
+
+扩展 `FormData` interface：
+
+```typescript
+interface FormData {
+  client_model: string;
+  strategy: string;
+  // scheduled
+  default: { backend_model: string; provider_id: string };
+  windows: RuleWindow[];
+  // round-robin / random / failover
+  targets: { backend_model: string; provider_id: string }[];
+}
+```
+
+更新 `DEFAULT_FORM` 和 emits（增加 `addTarget`, `removeTarget`, `moveTargetUp`, `moveTargetDown`）。
+
+- [ ] **Step 4: 更新 ModelMappings.vue 中的展示逻辑**
+
+在分组列表中，根据策略类型显示不同内容：
+
+- scheduled：现有逻辑（default + windows）
+- round-robin / random / failover：遍历 targets 显示
+
+```html
+<div v-if="g.strategy === 'scheduled'" class="space-y-3">
+  <!-- 现有的 scheduled 展示 -->
+</div>
+<div v-else class="space-y-2">
+  <div v-for="(t, idx) in g.parsedRule.targets" :key="idx" class="flex items-center gap-2 text-sm">
+    <span v-if="g.strategy === 'failover'" class="text-muted-foreground text-xs">{{ idx + 1 }}.</span>
+    <span class="font-mono">{{ t.backend_model }}</span>
+    <span class="text-muted-foreground">/</span>
+    <span>{{ providerNameMap.get(t.provider_id) || t.provider_id }}</span>
+  </div>
+</div>
+```
+
+- [ ] **Step 5: 更新 handleSave 中的 rule 构造**
+
+```typescript
+async function handleSave() {
+  try {
+    let ruleJson: string;
+    if (form.value.strategy === 'scheduled') {
+      ruleJson = JSON.stringify({
+        default: form.value.default,
+        windows: form.value.windows,
+      });
+    } else {
+      ruleJson = JSON.stringify({
+        targets: form.value.targets,
+      });
+    }
+    const payload = {
+      client_model: form.value.client_model,
+      strategy: form.value.strategy,
+      rule: ruleJson,
+    };
+    // ... rest same
+  }
+}
+```
+
+- [ ] **Step 6: 启动前端验证**
+
+Run: `cd frontend && npm run dev`
+
+手动验证：
+1. 创建 round-robin 分组，添加多个 target
+2. 创建 random 分组
+3. 创建 failover 分组，拖拽排序 target
+4. 确认 scheduled 策略仍正常工作
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add frontend/src/components/mappings/MappingGroupFormDialog.vue frontend/src/views/ModelMappings.vue
+git commit -m "feat(frontend): add round-robin, random, failover strategy UI"
+```
+
+---
+
+### Task 9: 全量测试 + 最终验证
+
+- [ ] **Step 1: Run 全部后端测试**
+
+Run: `npm test`
+Expected: 全部 PASS
+
+- [ ] **Step 2: Run 前端构建**
+
+Run: `cd frontend && npm run build`
+Expected: 构建成功，无 TS 错误
+
+- [ ] **Step 3: 端到端手动验证**
+
+1. `npm run dev` 启动后端
+2. `cd frontend && npm run dev` 启动前端
+3. 在管理后台创建各策略分组，通过 curl 发送代理请求验证行为
+
+- [ ] **Step 4: 最终 Commit**
+
+```bash
+git add -A
+git commit -m "chore: final verification for remaining load strategies"
+```

--- a/.superpowers/2026-04-16-model-mapping-strategy/plan-remaining-strategies.md
+++ b/.superpowers/2026-04-16-model-mapping-strategy/plan-remaining-strategies.md
@@ -61,7 +61,7 @@ export interface ResolveContext {
 }
 
 export interface MappingStrategy {
-  select(rule: unknown, context: ResolveContext): Target | undefined;
+  select(rule: unknown, context: ResolveContext, clientModel?: string): Target | undefined;
 }
 ```
 
@@ -583,7 +583,7 @@ const STRATEGIES: Record<string, import("./strategy/types.js").MappingStrategy> 
 // resolveMapping 函数保持不变
 ```
 
-同时需要给 `resolveMapping` 添加 `clientModel` 参数传递给 `strategy.select()`（RoundRobinStrategy 需要用 clientModel 维护 index）：
+同时修改 `resolveMapping` 传递 `clientModel` 给 `strategy.select()`（Task 1 已扩展 MappingStrategy 接口添加可选 `clientModel` 参数）：
 
 ```typescript
 export function resolveMapping(
@@ -600,12 +600,11 @@ export function resolveMapping(
   const strategy = STRATEGIES[group.strategy];
   if (!strategy) return null;
 
-  // RoundRobinStrategy 的 select 签名支持可选的 clientModel 参数
-  return (strategy as any).select(rule, context, clientModel) ?? null;
+  return strategy.select(rule, context, clientModel) ?? null;
 }
 ```
 
-> 注意：这里用 `as any` 是因为 `MappingStrategy` 接口的 `select` 只定义了两个参数。如果 RoundRobinStrategy 的第三个参数 `clientModel` 需要更正式地支持，应扩展 `MappingStrategy` 接口。但考虑到只有 RoundRobinStrategy 需要这个参数，用可选参数 + `as any` 是合理的临时方案。实现时可以选择扩展接口。
+> 注意：`clientModel` 参数在 Task 1 中已加入 `MappingStrategy` 接口，所有策略的 `select` 方法都接受可选的第三参数。`ScheduledStrategy`、`RandomStrategy`、`FailoverStrategy` 忽略该参数，只有 `RoundRobinStrategy` 使用它来维护独立的轮询 index。
 
 - [ ] **Step 4: Run test to verify it passes**
 
@@ -799,21 +798,22 @@ git commit -m "feat(admin): validate round-robin, random, failover rules with st
 
 这是最复杂的改动。需要在 `handleProxyPost` 中增加 failover 循环。
 
-- [ ] **Step 1: 理解改动范围**
+- [ ] **Step 1: 新增 import**
 
-当前 `handleProxyPost` 流程（`src/proxy/proxy-core.ts:400-560`）：
-1. resolveMapping → 获取 target
-2. getProviderById → 获取 provider
-3. retryableCall → 执行 proxy 请求（含重试）
-4. 记录日志、返回结果
+在 `src/proxy/proxy-core.ts` 顶部添加：
 
-Failover 需要在外层增加循环：当结果失败且策略为 failover 时，排除当前 target 重新 resolve。
+```typescript
+import { getMappingGroup } from "../db/index.js";
+import type { Target } from "./strategy/types.js";
+```
 
-- [ ] **Step 2: 提取 proxy 执行逻辑为内部函数**
+- [ ] **Step 2: 重构 handleProxyPost**
 
-将 `handleProxyPost` 中从 `resolveMapping` 到 `return reply` 的逻辑重构为一个 `executeProxyWithTarget` 内部函数（或直接用循环），减少嵌套。
+将现有的 `handleProxyPost` 函数（约 400-560 行）重构为带 failover 循环的版本。
 
-推荐方式：在 `handleProxyPost` 中用 `while` 循环 + `excludeTargets` 数组：
+核心思路：将 resolveMapping → provider 获取 → proxy 请求 → 日志记录包裹在一个 `while(true)` 循环中。成功时 return，失败时检查是否需要 failover。
+
+具体实现：
 
 ```typescript
 export async function handleProxyPost(
@@ -828,60 +828,125 @@ export async function handleProxyPost(
   const { db, streamTimeoutMs, retryMaxAttempts, retryBaseDelayMs, matcher } = deps;
 
   request.raw.socket.on("error", (err) => request.log.debug({ err }, "client socket error"));
-  const startTime = Date.now();
-  const logId = randomUUID();
-  const routerKeyId = request.routerKey?.id ?? null;
-  const body = request.body as Record<string, unknown>;
-  const originalBody = JSON.parse(JSON.stringify(body));
-  const clientModel = (body.model as string) || "unknown";
+  const clientModel = ((request.body as Record<string, unknown>).model as string) || "unknown";
 
-  // --- Failover 循环 ---
+  // 查询分组策略（只查一次）
+  const group = getMappingGroup(db, clientModel);
+  const isFailover = group?.strategy === "failover";
   const excludeTargets: Target[] = [];
-  let isFailover = false;
 
   while (true) {
+    const startTime = Date.now();
+    const logId = randomUUID();
+    const routerKeyId = request.routerKey?.id ?? null;
+    const body = request.body as Record<string, unknown>;
+    const originalBody = JSON.parse(JSON.stringify(body));
+
     const resolved = resolveMapping(db, clientModel, { now: new Date(), excludeTargets });
     if (!resolved) {
       if (isFailover && excludeTargets.length > 0) {
-        // 所有 failover target 都已尝试，返回最后一次的错误（已经在上一轮发送了 reply）
-        // 这种情况不应该发生，因为上一轮已经 return 了
-        break;
+        // 所有 failover target 都已尝试，reply 已在上一轮发送
+        return reply;
       }
       const e = errors.modelNotFound(clientModel);
       return reply.status(e.statusCode).send(e.body);
     }
 
-    // 检查 failover 策略（仅在第一次 resolve 时检查）
-    if (excludeTargets.length === 0) {
-      const group = getMappingGroup(db, clientModel);
-      isFailover = group?.strategy === "failover";
+    const provider = getProviderById(db, resolved.provider_id);
+    if (!provider || !provider.is_active) {
+      const e = errors.providerUnavailable();
+      return reply.status(e.statusCode).send(e.body);
+    }
+    if (provider.api_type !== apiType) {
+      const e = errors.providerTypeMismatch();
+      return reply.status(e.statusCode).send(e.body);
     }
 
-    // ... 原有的 provider 校验、proxy 请求、日志记录逻辑 ...
-    // ... 将整个 try/catch 块放在这里 ...
+    body.model = resolved.backend_model;
+    const apiKey = decrypt(provider.api_key, getSetting(db, "encryption_key")!);
+    const isStream = body.stream === true;
+    options?.beforeSendProxy?.(body, isStream);
 
-    // 在 try 块成功返回后，如果结果不是成功且是 failover：
-    // 在 catch 或 非 2xx 时：检查是否需要 failover
-    // 具体实现见步骤 3
+    const reqBodyStr = JSON.stringify(body);
+    const cliHdrs: RawHeaders = request.headers as RawHeaders;
+    const clientReq = JSON.stringify({ headers: cliHdrs, body: originalBody });
+    const retryConfig = buildRetryConfig(retryMaxAttempts, retryBaseDelayMs, matcher);
+    const upstreamReqBase = JSON.stringify({ url: `${provider.base_url}${upstreamPath}`, headers: buildUpstreamHeaders(cliHdrs, apiKey, Buffer.byteLength(reqBodyStr)), body: reqBodyStr });
+
+    try {
+      const { result: r, attempts } = isStream
+        ? await retryableCall(() => { const mt = new SSEMetricsTransform(apiType, startTime); return proxyStream(provider, apiKey, body, cliHdrs, reply, streamTimeoutMs, upstreamPath, mt); }, retryConfig, reply)
+        : await retryableCall(() => proxyNonStream(provider, apiKey, body, cliHdrs, upstreamPath), retryConfig, reply);
+
+      // 记录所有尝试的日志（同现有逻辑）
+      let lastSuccessLogId = logId;
+      for (const attempt of attempts) {
+        const isOriginal = attempt.attemptIndex === 0;
+        const attemptLogId = isOriginal ? logId : randomUUID();
+        if (attempt.error) {
+          insertRequestLog(db, { id: attemptLogId, api_type: apiType, model: clientModel, provider_id: provider.id, status_code: HTTP_BAD_GATEWAY, latency_ms: attempt.latencyMs, is_stream: isStream ? 1 : 0, error_message: attempt.error, created_at: new Date().toISOString(), request_body: reqBodyStr, client_request: clientReq, upstream_request: upstreamReqBase, is_retry: isOriginal ? 0 : 1, original_request_id: isOriginal ? null : logId, router_key_id: routerKeyId });
+        } else if (attempt.statusCode !== UPSTREAM_SUCCESS) {
+          insertRequestLog(db, { id: attemptLogId, api_type: apiType, model: clientModel, provider_id: provider.id, status_code: attempt.statusCode, latency_ms: attempt.latencyMs, is_stream: isStream ? 1 : 0, error_message: null, created_at: new Date().toISOString(), request_body: reqBodyStr, response_body: attempt.responseBody, client_request: clientReq, upstream_request: upstreamReqBase, upstream_response: JSON.stringify({ statusCode: attempt.statusCode, body: attempt.responseBody }), client_response: JSON.stringify({ statusCode: attempt.statusCode, body: attempt.responseBody }), is_retry: isOriginal ? 0 : 1, original_request_id: isOriginal ? null : logId, router_key_id: routerKeyId });
+        } else {
+          const h = isStream ? ((r as StreamProxyResult).upstreamResponseHeaders ?? {}) : ((r as ProxyResult).headers);
+          insertSuccessLog(db, apiType, attemptLogId, clientModel, provider, isStream, startTime, reqBodyStr, clientReq, upstreamReqBase, r.statusCode, attempt.responseBody, h, h, !isOriginal, isOriginal ? null : logId, routerKeyId);
+          lastSuccessLogId = attemptLogId;
+        }
+      }
+
+      // --- Failover 检查 ---
+      // 如果最终状态码不是 2xx，且是 failover 策略，且 headers 未发送
+      const finalStatus = r.statusCode;
+      if (isFailover && finalStatus >= 400 && !reply.raw.headersSent) {
+        excludeTargets.push(resolved);
+        continue; // 尝试下一个 target
+      }
+
+      // 非 failover 或成功：发送响应
+      if (isStream) {
+        if (r.statusCode !== UPSTREAM_SUCCESS) {
+          for (const [k, v] of Object.entries((r as StreamProxyResult).upstreamResponseHeaders ?? {})) reply.header(k, v);
+          reply.status(r.statusCode).send((r as StreamProxyResult).responseBody);
+        }
+      } else {
+        const pr = r as ProxyResult;
+        for (const [k, v] of Object.entries(pr.headers)) reply.header(k, v);
+        return reply.status(pr.statusCode).send(pr.body);
+      }
+
+      if (r.statusCode === UPSTREAM_SUCCESS) {
+        if (isStream) {
+          const sr = r as StreamProxyResult;
+          if (sr.metricsResult) { try { insertMetrics(db, { ...sr.metricsResult, request_log_id: lastSuccessLogId, provider_id: provider.id, backend_model: resolved.backend_model, api_type: apiType }); } catch (err) { request.log.error({ err }, "Failed to insert metrics"); } }
+        } else {
+          try { const mr = MetricsExtractor.fromNonStreamResponse(apiType, (r as ProxyResult).body); if (mr) insertMetrics(db, { ...mr, request_log_id: lastSuccessLogId, provider_id: provider.id, backend_model: resolved.backend_model, api_type: apiType }); } catch (err) { request.log.error({ err }, "Failed to insert metrics"); }
+        }
+      }
+      return reply;
+    } catch (err: unknown) {
+      const errMsg = err instanceof Error ? err.message : String(err);
+      const sentH = buildUpstreamHeaders(cliHdrs, apiKey, Buffer.byteLength(reqBodyStr));
+      const upstreamReq = JSON.stringify({ url: `${provider.base_url}${upstreamPath}`, headers: sentH, body: reqBodyStr });
+      insertRequestLog(db, { id: logId, api_type: apiType, model: clientModel, provider_id: provider.id, status_code: HTTP_BAD_GATEWAY, latency_ms: Date.now() - startTime, is_stream: isStream ? 1 : 0, error_message: errMsg || "Upstream connection failed", created_at: new Date().toISOString(), request_body: reqBodyStr, client_request: clientReq, upstream_request: upstreamReq, router_key_id: routerKeyId });
+
+      // --- Failover 检查（异常路径）---
+      if (isFailover && !reply.raw.headersSent) {
+        excludeTargets.push(resolved);
+        continue; // 尝试下一个 target
+      }
+
+      const e = errors.upstreamConnectionFailed();
+      return reply.status(e.statusCode).send(e.body);
+    }
   }
 }
 ```
 
-> 注意：这是一个复杂重构，实现时需要仔细处理。关键是确保：
-> 1. 非 failover 策略走原有路径（无循环）
-> 2. failover 仅在 headers 未发送时重试
-> 3. 每次重试使用新的 provider/model/apiKey
-> 4. 所有日志正常记录
-
-- [ ] **Step 3: 实现完整的 failover 循环**
-
-核心改动逻辑：
-- 将原有 `resolveMapping` → `proxy` → `log` → `return` 包裹在 `while(true)` 循环中
-- 每次循环开始时 `resolveMapping(db, clientModel, { now, excludeTargets })`
-- 在 `retryableCall` 返回后，检查是否需要 failover：
-  - 非 failover 策略：直接 break/return（与原逻辑相同）
-  - failover + 失败 + headers 未发送：将当前 target 加入 excludeTargets，continue
-  - failover + 成功 或 headers 已发送：break/return
+> **关键设计决策：**
+> - `group` 只在循环外查一次（不变）
+> - `startTime`、`logId`、`body` 在每次循环内重新初始化（每次 target 尝试独立）
+> - 白名单校验移到 `resolveMapping` 之前（首次循环外已处理，但后续 target 也需要检查——不过因为白名单校验的是 clientModel 而非 backend_model，所以只需校验一次）
+> - failover 检查条件：`isFailover && (statusCode >= 400 || exception) && !reply.raw.headersSent`
 
 - [ ] **Step 4: Run 全部 proxy 测试**
 
@@ -971,7 +1036,21 @@ interface FormData {
 }
 ```
 
-更新 `DEFAULT_FORM` 和 emits（增加 `addTarget`, `removeTarget`, `moveTargetUp`, `moveTargetDown`）。
+更新 `DEFAULT_FORM` 增加 `targets` 字段：
+
+```typescript
+const DEFAULT_FORM = {
+  client_model: '',
+  strategy: 'scheduled',
+  default: { backend_model: '', provider_id: '' },
+  windows: [] as RuleWindow[],
+  targets: [] as { backend_model: string; provider_id: string }[],
+}
+```
+
+更新 emits（增加 `addTarget`, `removeTarget`, `moveTargetUp`, `moveTargetDown`）。
+
+同时更新 `MappingGroupFormDialog.vue` 的 `props.form` 类型（加 `targets` 字段）。
 
 - [ ] **Step 4: 更新 ModelMappings.vue 中的展示逻辑**
 
@@ -992,6 +1071,94 @@ interface FormData {
     <span>{{ providerNameMap.get(t.provider_id) || t.provider_id }}</span>
   </div>
 </div>
+```
+
+- [ ] **Step 4b: 更新 ModelMappings.vue 中的事件监听和 handler**
+
+在 `<MappingGroupFormDialog>` 标签上添加新的事件监听：
+
+```html
+<MappingGroupFormDialog
+  v-model:open="dialogOpen"
+  :editing-id="editingId"
+  :form="form"
+  :providers="providersList"
+  :provider-models="providerModelsMap"
+  @save="handleSave"
+  @add-window="addWindow"
+  @remove-window="removeWindow"
+  @add-target="addTarget"
+  @remove-target="removeTarget"
+  @move-target-up="moveTargetUp"
+  @move-target-down="moveTargetDown"
+/>
+```
+
+添加对应的 handler 函数：
+
+```typescript
+function addTarget() {
+  const firstProviderId = providersList.value[0]?.id || ''
+  const firstModels = providerModelsMap.value.get(firstProviderId) || []
+  form.value.targets.push({ backend_model: firstModels[0] || '', provider_id: firstProviderId })
+}
+
+function removeTarget(idx: number) {
+  form.value.targets.splice(idx, 1)
+}
+
+function moveTargetUp(idx: number) {
+  if (idx <= 0) return
+  const targets = form.value.targets
+  ;[targets[idx - 1], targets[idx]] = [targets[idx], targets[idx - 1]]
+}
+
+function moveTargetDown(idx: number) {
+  const targets = form.value.targets
+  if (idx >= targets.length - 1) return
+  ;[targets[idx], targets[idx + 1]] = [targets[idx + 1], targets[idx]]
+}
+```
+
+- [ ] **Step 4c: 更新 openEdit 解析 targets 格式的 rule**
+
+修改 `ModelMappings.vue` 中的 `openEdit` 函数，支持解析 targets 格式的 rule：
+
+```typescript
+function openEdit(g: MappingGroup & { parsedRule?: Rule & { targets?: { backend_model: string; provider_id: string }[] } }) {
+  editingId.value = g.id
+  let rule: any = {}
+  try { rule = JSON.parse(g.rule) } catch { /* format error */ }
+
+  if (g.strategy === 'scheduled') {
+    form.value = {
+      ...DEFAULT_FORM,
+      client_model: g.client_model,
+      strategy: g.strategy,
+      default: {
+        backend_model: rule.default?.backend_model || '',
+        provider_id: rule.default?.provider_id || providersList.value[0]?.id || '',
+      },
+      windows: rule.windows ? JSON.parse(JSON.stringify(rule.windows)) : [],
+    }
+  } else {
+    // round-robin / random / failover
+    const firstProviderId = providersList.value[0]?.id || ''
+    const firstModels = providerModelsMap.value.get(firstProviderId) || []
+    form.value = {
+      ...DEFAULT_FORM,
+      client_model: g.client_model,
+      strategy: g.strategy,
+      targets: Array.isArray(rule.targets)
+        ? rule.targets.map((t: any) => ({
+            backend_model: t.backend_model || '',
+            provider_id: t.provider_id || firstProviderId,
+          }))
+        : [{ backend_model: firstModels[0] || '', provider_id: firstProviderId }],
+    }
+  }
+  dialogOpen.value = true
+}
 ```
 
 - [ ] **Step 5: 更新 handleSave 中的 rule 构造**

--- a/.superpowers/2026-04-16-model-mapping-strategy/spec-remaining-strategies.md
+++ b/.superpowers/2026-04-16-model-mapping-strategy/spec-remaining-strategies.md
@@ -1,0 +1,39 @@
+---
+date: 2026-04-17
+status: approved
+related_issue: "#8"
+---
+
+# 剩余负载策略设计：Round-Robin / Random / Failover
+
+## 背景
+
+Issue #8 定义了四种负载策略，scheduled（定时切换）已完成。本文档覆盖剩余三种：轮询、随机、故障转移。
+
+## 需求确认
+
+| 策略 | rule 结构 | 顺序 | 状态需求 | 行为 |
+|------|----------|------|---------|------|
+| round-robin | `{targets:[...]}` | 有序 | 内存 index | 轮流选择 |
+| random | `{targets:[...]}` | 无序 | 无 | 随机选择 |
+| failover | `{targets:[...]}` | 有序 | 无 | 主失败→备选重试 |
+
+- 健康检查不实现
+- 故障转移：单次请求内，复用 retry_rules 触发条件
+- 集成方式：exclude 模式（ResolveContext 增加 excludeTargets）
+
+## 策略层设计
+
+详见 [strategy-layer.md](strategy-layer.md)
+
+## proxy-core 集成设计
+
+详见 [failover-integration.md](failover-integration.md)
+
+## Admin API 设计
+
+详见 [admin-api-remaining.md](admin-api-remaining.md)
+
+## 前端 UI 设计
+
+详见 [frontend-remaining.md](frontend-remaining.md)

--- a/.superpowers/2026-04-16-model-mapping-strategy/strategy-layer.md
+++ b/.superpowers/2026-04-16-model-mapping-strategy/strategy-layer.md
@@ -31,22 +31,26 @@ interface TargetsRule {
 
 - 内存状态：`Map<string, number>`（clientModel → lastIndex）
 - `select(rule, context)`：
-  1. 从 targets 中过滤掉 excludeTargets
-  2. 取 (lastIndex + 1) % filteredTargets.length
-  3. 更新内存 index
+  1. 从 targets 中过滤掉 excludeTargets 得到 filteredTargets
+  2. 如果 filteredTargets 为空，返回 undefined
+  3. 取 (lastIndex + 1) % filteredTargets.length
+  4. 更新内存 index 为新位置
+  5. 返回 filteredTargets[index]
+- **index 语义**：lastIndex 基于 filteredTargets 数组的位置，每次 select 成功（返回非 undefined）才推进
 - 重启后 index 归零
 
 ## RandomStrategy
 
 - `select(rule, context)`：
   1. 从 targets 中过滤掉 excludeTargets
-  2. Math.random() 选一个
+  2. 如果为空，返回 undefined
+  3. Math.random() 选一个
 
 ## FailoverStrategy
 
 - `select(rule, context)`：
-  1. 返回第一个不在 excludeTargets 中的 target
-  2. 即 targets[0] → 失败 → exclude → targets[1] → ...
+  1. 遍历 targets，返回第一个不在 excludeTargets 中的 target
+  2. 无匹配时返回 undefined
 
 ## 注册
 

--- a/.superpowers/2026-04-16-model-mapping-strategy/strategy-layer.md
+++ b/.superpowers/2026-04-16-model-mapping-strategy/strategy-layer.md
@@ -1,0 +1,61 @@
+# 策略层设计
+
+## ResolveContext 扩展
+
+```typescript
+// src/proxy/strategy/types.ts
+export interface ResolveContext {
+  now: Date;
+  excludeTargets?: Target[];  // 已失败的 targets，策略选择时跳过
+}
+
+export const STRATEGY_NAMES = {
+  SCHEDULED: "scheduled",
+  ROUND_ROBIN: "round-robin",
+  RANDOM: "random",
+  FAILOVER: "failover",
+} as const;
+```
+
+## 共享类型
+
+三种新策略共享 rule 结构：
+
+```typescript
+interface TargetsRule {
+  targets: Target[];
+}
+```
+
+## RoundRobinStrategy
+
+- 内存状态：`Map<string, number>`（clientModel → lastIndex）
+- `select(rule, context)`：
+  1. 从 targets 中过滤掉 excludeTargets
+  2. 取 (lastIndex + 1) % filteredTargets.length
+  3. 更新内存 index
+- 重启后 index 归零
+
+## RandomStrategy
+
+- `select(rule, context)`：
+  1. 从 targets 中过滤掉 excludeTargets
+  2. Math.random() 选一个
+
+## FailoverStrategy
+
+- `select(rule, context)`：
+  1. 返回第一个不在 excludeTargets 中的 target
+  2. 即 targets[0] → 失败 → exclude → targets[1] → ...
+
+## 注册
+
+```typescript
+// src/proxy/mapping-resolver.ts
+const STRATEGIES = {
+  [STRATEGY_NAMES.SCHEDULED]: new ScheduledStrategy(),
+  [STRATEGY_NAMES.ROUND_ROBIN]: new RoundRobinStrategy(),
+  [STRATEGY_NAMES.RANDOM]: new RandomStrategy(),
+  [STRATEGY_NAMES.FAILOVER]: new FailoverStrategy(),
+};
+```

--- a/frontend/src/components/mappings/MappingGroupFormDialog.vue
+++ b/frontend/src/components/mappings/MappingGroupFormDialog.vue
@@ -18,66 +18,21 @@
               <SelectValue placeholder="选择策略" />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="scheduled">scheduled</SelectItem>
+              <SelectItem value="scheduled">定时切换 (scheduled)</SelectItem>
+              <SelectItem value="round-robin">轮询 (round-robin)</SelectItem>
+              <SelectItem value="random">随机 (random)</SelectItem>
+              <SelectItem value="failover">故障转移 (failover)</SelectItem>
             </SelectContent>
           </Select>
         </div>
 
-        <div class="border rounded-lg p-3 space-y-3">
-          <div class="text-sm font-medium text-foreground">默认目标</div>
-          <div class="flex gap-3">
-            <div class="flex-1">
-              <Label class="block text-xs text-muted-foreground mb-1">供应商</Label>
-              <Select :model-value="form.default.provider_id" @update:model-value="onDefaultProviderChange">
-                <SelectTrigger>
-                  <SelectValue placeholder="选择供应商" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem v-for="p in providers" :key="p.id" :value="p.id">{{ p.name }}</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-            <div class="flex-1">
-              <Label class="block text-xs text-muted-foreground mb-1">后端模型</Label>
-              <Select v-model="form.default.backend_model" :disabled="defaultModels.length === 0">
-                <SelectTrigger>
-                  <SelectValue :placeholder="defaultModels.length === 0 ? '暂无可用模型' : '选择后端模型'" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem v-for="m in defaultModels" :key="m" :value="m">{{ m }}</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-          </div>
-        </div>
-
-        <div class="border rounded-lg p-3 space-y-3">
-          <div class="flex items-center justify-between">
-            <div class="text-sm font-medium text-foreground">时间窗口</div>
-            <Button type="button" variant="outline" size="sm" @click="emit('addWindow')">添加窗口</Button>
-          </div>
-          <div
-            v-for="(w, idx) in form.windows"
-            :key="idx"
-            class="border rounded-md p-2 space-y-2"
-          >
-            <div class="flex items-end gap-2">
-              <div class="w-24">
-                <Label class="block text-xs text-muted-foreground mb-1">开始</Label>
-                <Input v-model="w.start" type="text" placeholder="HH:MM" required />
-              </div>
-              <span class="text-muted-foreground pb-1.5">-</span>
-              <div class="w-24">
-                <Label class="block text-xs text-muted-foreground mb-1">结束</Label>
-                <Input v-model="w.end" type="text" placeholder="HH:MM" required />
-              </div>
-              <div class="flex-1" />
-              <Button type="button" variant="ghost" size="sm" class="text-destructive shrink-0" @click="emit('removeWindow', idx)">删除</Button>
-            </div>
-            <div class="flex gap-2">
+        <template v-if="form.strategy === 'scheduled'">
+          <div class="border rounded-lg p-3 space-y-3">
+            <div class="text-sm font-medium text-foreground">默认目标</div>
+            <div class="flex gap-3">
               <div class="flex-1">
                 <Label class="block text-xs text-muted-foreground mb-1">供应商</Label>
-                <Select :model-value="w.target.provider_id" @update:model-value="onWindowProviderChange(idx, $event)">
+                <Select :model-value="form.default.provider_id" @update:model-value="onDefaultProviderChange">
                   <SelectTrigger>
                     <SelectValue placeholder="选择供应商" />
                   </SelectTrigger>
@@ -88,18 +43,107 @@
               </div>
               <div class="flex-1">
                 <Label class="block text-xs text-muted-foreground mb-1">后端模型</Label>
-                <Select v-model="w.target.backend_model" :disabled="getWindowModels(idx).length === 0">
+                <Select v-model="form.default.backend_model" :disabled="defaultModels.length === 0">
                   <SelectTrigger>
-                    <SelectValue :placeholder="getWindowModels(idx).length === 0 ? '暂无可用模型' : '选择后端模型'" />
+                    <SelectValue :placeholder="defaultModels.length === 0 ? '暂无可用模型' : '选择后端模型'" />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem v-for="m in getWindowModels(idx)" :key="m" :value="m">{{ m }}</SelectItem>
+                    <SelectItem v-for="m in defaultModels" :key="m" :value="m">{{ m }}</SelectItem>
                   </SelectContent>
                 </Select>
               </div>
             </div>
           </div>
-          <div v-if="form.windows.length === 0" class="text-sm text-muted-foreground">暂无窗口</div>
+
+          <div class="border rounded-lg p-3 space-y-3">
+            <div class="flex items-center justify-between">
+              <div class="text-sm font-medium text-foreground">时间窗口</div>
+              <Button type="button" variant="outline" size="sm" @click="emit('addWindow')">添加窗口</Button>
+            </div>
+            <div
+              v-for="(w, idx) in form.windows"
+              :key="idx"
+              class="border rounded-md p-2 space-y-2"
+            >
+              <div class="flex items-end gap-2">
+                <div class="w-24">
+                  <Label class="block text-xs text-muted-foreground mb-1">开始</Label>
+                  <Input v-model="w.start" type="text" placeholder="HH:MM" required />
+                </div>
+                <span class="text-muted-foreground pb-1.5">-</span>
+                <div class="w-24">
+                  <Label class="block text-xs text-muted-foreground mb-1">结束</Label>
+                  <Input v-model="w.end" type="text" placeholder="HH:MM" required />
+                </div>
+                <div class="flex-1" />
+                <Button type="button" variant="ghost" size="sm" class="text-destructive shrink-0" @click="emit('removeWindow', idx)">删除</Button>
+              </div>
+              <div class="flex gap-2">
+                <div class="flex-1">
+                  <Label class="block text-xs text-muted-foreground mb-1">供应商</Label>
+                  <Select :model-value="w.target.provider_id" @update:model-value="onWindowProviderChange(idx, $event)">
+                    <SelectTrigger>
+                      <SelectValue placeholder="选择供应商" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem v-for="p in providers" :key="p.id" :value="p.id">{{ p.name }}</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div class="flex-1">
+                  <Label class="block text-xs text-muted-foreground mb-1">后端模型</Label>
+                  <Select v-model="w.target.backend_model" :disabled="getWindowModels(idx).length === 0">
+                    <SelectTrigger>
+                      <SelectValue :placeholder="getWindowModels(idx).length === 0 ? '暂无可用模型' : '选择后端模型'" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem v-for="m in getWindowModels(idx)" :key="m" :value="m">{{ m }}</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+            </div>
+            <div v-if="form.windows.length === 0" class="text-sm text-muted-foreground">暂无窗口</div>
+          </div>
+        </template>
+
+        <div v-else class="border rounded-lg p-3 space-y-3">
+          <div class="flex items-center justify-between">
+            <div class="text-sm font-medium text-foreground">目标列表</div>
+            <Button type="button" variant="outline" size="sm" @click="emit('addTarget')">添加目标</Button>
+          </div>
+          <div v-for="(t, idx) in form.targets" :key="idx" class="border rounded-md p-2 space-y-2">
+            <div class="flex items-center gap-2">
+              <div class="flex-1">
+                <Label class="block text-xs text-muted-foreground mb-1">供应商</Label>
+                <Select :model-value="t.provider_id" @update:model-value="onTargetProviderChange(idx, $event)">
+                  <SelectTrigger>
+                    <SelectValue placeholder="选择供应商" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem v-for="p in providers" :key="p.id" :value="p.id">{{ p.name }}</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div class="flex-1">
+                <Label class="block text-xs text-muted-foreground mb-1">后端模型</Label>
+                <Select v-model="t.backend_model" :disabled="getTargetModels(idx).length === 0">
+                  <SelectTrigger>
+                    <SelectValue :placeholder="getTargetModels(idx).length === 0 ? '暂无可用模型' : '选择后端模型'" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem v-for="m in getTargetModels(idx)" :key="m" :value="m">{{ m }}</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div v-if="form.strategy === 'failover'" class="flex flex-col gap-1">
+                <Button type="button" variant="ghost" size="sm" :disabled="idx === 0" @click="emit('moveTargetUp', idx)">↑</Button>
+                <Button type="button" variant="ghost" size="sm" :disabled="idx === form.targets.length - 1" @click="emit('moveTargetDown', idx)">↓</Button>
+              </div>
+              <Button type="button" variant="ghost" size="sm" class="text-destructive shrink-0" @click="emit('removeTarget', idx)">删除</Button>
+            </div>
+          </div>
+          <div v-if="form.targets.length === 0" class="text-sm text-muted-foreground">暂无目标</div>
         </div>
 
         <DialogFooter>
@@ -139,6 +183,7 @@ interface FormData {
   strategy: string
   default: { backend_model: string; provider_id: string }
   windows: RuleWindow[]
+  targets: { backend_model: string; provider_id: string }[]
 }
 
 const props = defineProps<{
@@ -154,6 +199,10 @@ const emit = defineEmits<{
   (e: 'save'): void
   (e: 'addWindow'): void
   (e: 'removeWindow', idx: number): void
+  (e: 'addTarget'): void
+  (e: 'removeTarget', idx: number): void
+  (e: 'moveTargetUp', idx: number): void
+  (e: 'moveTargetDown', idx: number): void
 }>()
 
 const defaultModels = computed(() =>
@@ -182,6 +231,20 @@ function onWindowProviderChange(idx: number, value: AcceptableValue) {
   const models = props.providerModels.get(value) || []
   // eslint-disable-next-line vue/no-mutating-props
   props.form.windows[idx].target.backend_model = models[0] || ''
+}
+
+function getTargetModels(idx: number): string[] {
+  const providerId = props.form.targets[idx]?.provider_id
+  return providerId ? (props.providerModels.get(providerId) || []) : []
+}
+
+function onTargetProviderChange(idx: number, value: AcceptableValue) {
+  if (typeof value !== 'string') return
+  // eslint-disable-next-line vue/no-mutating-props
+  props.form.targets[idx].provider_id = value
+  const models = props.providerModels.get(value) || []
+  // eslint-disable-next-line vue/no-mutating-props
+  props.form.targets[idx].backend_model = models[0] || ''
 }
 
 function handleSave() {

--- a/frontend/src/views/ModelMappings.vue
+++ b/frontend/src/views/ModelMappings.vue
@@ -203,8 +203,11 @@ function openCreate() {
   const firstProviderId = providersList.value[0]?.id || ''
   const firstModels = providerModelsMap.value.get(firstProviderId) || []
   form.value = {
-    ...DEFAULT_FORM,
+    client_model: '',
+    strategy: 'scheduled',
     default: { backend_model: firstModels[0] || '', provider_id: firstProviderId },
+    windows: [],
+    targets: [],
   }
   dialogOpen.value = true
 }

--- a/frontend/src/views/ModelMappings.vue
+++ b/frontend/src/views/ModelMappings.vue
@@ -30,7 +30,7 @@
           </CardHeader>
           <CollapsibleContent>
             <CardContent>
-              <div class="space-y-3">
+              <div v-if="g.strategy === 'scheduled'" class="space-y-3">
                 <div class="flex items-center gap-2 text-sm">
                   <span class="text-muted-foreground">默认模型:</span>
                   <span class="font-mono">{{ g.parsedRule.default?.backend_model || '-' }}</span>
@@ -52,6 +52,15 @@
                 </div>
                 <div v-else class="text-sm text-muted-foreground">无时间窗口</div>
               </div>
+              <div v-else class="space-y-2">
+                <div v-for="(t, idx) in (g.parsedRule.targets || [])" :key="idx" class="flex items-center gap-2 text-sm">
+                  <span v-if="g.strategy === 'failover'" class="text-muted-foreground text-xs">{{ idx + 1 }}.</span>
+                  <span class="font-mono">{{ t.backend_model }}</span>
+                  <span class="text-muted-foreground">/</span>
+                  <span>{{ providerNameMap.get(t.provider_id) || t.provider_id }}</span>
+                </div>
+                <div v-if="!(g.parsedRule.targets || []).length" class="text-sm text-muted-foreground">无目标</div>
+              </div>
             </CardContent>
           </CollapsibleContent>
         </Collapsible>
@@ -71,6 +80,10 @@
       @save="handleSave"
       @add-window="addWindow"
       @remove-window="removeWindow"
+      @add-target="addTarget"
+      @remove-target="removeTarget"
+      @move-target-up="moveTargetUp"
+      @move-target-down="moveTargetDown"
     />
 
     <MappingGroupDeleteDialog
@@ -117,6 +130,7 @@ interface RuleWindow {
 interface Rule {
   default?: { backend_model: string; provider_id: string }
   windows?: RuleWindow[]
+  targets?: { backend_model: string; provider_id: string }[]
 }
 
 const DEFAULT_FORM = {
@@ -124,6 +138,7 @@ const DEFAULT_FORM = {
   strategy: 'scheduled',
   default: { backend_model: '', provider_id: '' },
   windows: [] as RuleWindow[],
+  targets: [] as { backend_model: string; provider_id: string }[],
 }
 
 const groups = ref<MappingGroup[]>([])
@@ -197,15 +212,33 @@ function openCreate() {
 function openEdit(g: MappingGroup & { parsedRule?: Rule }) {
   editingId.value = g.id
   let rule: Rule = {}
-  try { rule = JSON.parse(g.rule) as Rule } catch { /* eslint-disable-line taste/no-silent-catch -- 格式异常时使用空默认值 */ }
-  form.value = {
-    client_model: g.client_model,
-    strategy: g.strategy,
-    default: {
-      backend_model: rule.default?.backend_model || '',
-      provider_id: rule.default?.provider_id || providersList.value[0]?.id || '',
-    },
-    windows: rule.windows ? JSON.parse(JSON.stringify(rule.windows)) : [],
+  try { rule = JSON.parse(g.rule) } catch { /* eslint-disable-line taste/no-silent-catch -- 格式异常时使用空默认值 */ }
+
+  if (g.strategy === 'scheduled') {
+    form.value = {
+      ...DEFAULT_FORM,
+      client_model: g.client_model,
+      strategy: g.strategy,
+      default: {
+        backend_model: rule.default?.backend_model || '',
+        provider_id: rule.default?.provider_id || providersList.value[0]?.id || '',
+      },
+      windows: rule.windows ? JSON.parse(JSON.stringify(rule.windows)) : [],
+    }
+  } else {
+    const firstProviderId = providersList.value[0]?.id || ''
+    const firstModels = providerModelsMap.value.get(firstProviderId) || []
+    form.value = {
+      ...DEFAULT_FORM,
+      client_model: g.client_model,
+      strategy: g.strategy,
+      targets: Array.isArray(rule.targets)
+        ? rule.targets.map((t: { backend_model: string; provider_id: string }) => ({
+            backend_model: t.backend_model || '',
+            provider_id: t.provider_id || firstProviderId,
+          }))
+        : [{ backend_model: firstModels[0] || '', provider_id: firstProviderId }],
+    }
   }
   dialogOpen.value = true
 }
@@ -227,16 +260,46 @@ function removeWindow(idx: number) {
   form.value.windows.splice(idx, 1)
 }
 
+function addTarget() {
+  const firstProviderId = providersList.value[0]?.id || ''
+  const firstModels = providerModelsMap.value.get(firstProviderId) || []
+  form.value.targets.push({ backend_model: firstModels[0] || '', provider_id: firstProviderId })
+}
+
+function removeTarget(idx: number) {
+  form.value.targets.splice(idx, 1)
+}
+
+function moveTargetUp(idx: number) {
+  if (idx <= 0) return
+  const targets = form.value.targets
+  ;[targets[idx - 1], targets[idx]] = [targets[idx], targets[idx - 1]]
+}
+
+function moveTargetDown(idx: number) {
+  const targets = form.value.targets
+  if (idx >= targets.length - 1) return
+  ;[targets[idx], targets[idx + 1]] = [targets[idx + 1], targets[idx]]
+}
+
 async function handleSave() {
   try {
+    let ruleJson: string;
+    if (form.value.strategy === 'scheduled') {
+      ruleJson = JSON.stringify({
+        default: form.value.default,
+        windows: form.value.windows,
+      });
+    } else {
+      ruleJson = JSON.stringify({
+        targets: form.value.targets,
+      });
+    }
     const payload = {
       client_model: form.value.client_model,
       strategy: form.value.strategy,
-      rule: JSON.stringify({
-        default: form.value.default,
-        windows: form.value.windows,
-      }),
-    }
+      rule: ruleJson,
+    };
     if (editingId.value) {
       await api.updateMappingGroup(editingId.value, payload)
     } else {

--- a/src/admin/groups.ts
+++ b/src/admin/groups.ts
@@ -13,6 +13,8 @@ import {
 import { STRATEGY_NAMES } from "../proxy/strategy/types.js";
 import { HTTP_BAD_REQUEST, HTTP_CREATED, HTTP_CONFLICT } from "./constants.js";
 
+const MIN_FAILOVER_TARGETS = 2;
+
 const CreateGroupSchema = Type.Object({
   client_model: Type.String({ minLength: 1 }),
   strategy: Type.String({ minLength: 1 }),
@@ -29,7 +31,9 @@ interface GroupRoutesOptions {
   db: Database.Database;
 }
 
-interface ScheduledRuleDefault {
+type ScheduledRuleDefault = TargetInput;
+
+interface TargetInput {
   backend_model?: string;
   provider_id?: string;
 }
@@ -37,10 +41,7 @@ interface ScheduledRuleDefault {
 interface ScheduledRuleWindow {
   start: string;
   end: string;
-  target: {
-    backend_model: string;
-    provider_id: string;
-  };
+  target: TargetInput;
 }
 
 interface ScheduledRule {
@@ -97,12 +98,12 @@ async function validateRule(
     if (!Array.isArray(r.targets) || r.targets.length === 0) {
       return "rule.targets must be a non-empty array";
     }
-    const minTargets = strategy === STRATEGY_NAMES.FAILOVER ? 2 : 1;
+    const minTargets = strategy === STRATEGY_NAMES.FAILOVER ? MIN_FAILOVER_TARGETS : 1;
     if (r.targets.length < minTargets) {
       return `strategy '${strategy}' requires at least ${minTargets} target(s)`;
     }
     for (let i = 0; i < r.targets.length; i++) {
-      const t = r.targets[i] as any;
+      const t = r.targets[i] as TargetInput;
       if (!t.backend_model || !t.provider_id) {
         return `targets[${i}] missing backend_model or provider_id`;
       }

--- a/src/admin/groups.ts
+++ b/src/admin/groups.ts
@@ -53,6 +53,11 @@ async function validateRule(
   strategy: string,
   ruleJson: string
 ): Promise<string | undefined> {
+  const VALID_STRATEGIES = new Set(Object.values(STRATEGY_NAMES));
+  if (!VALID_STRATEGIES.has(strategy)) {
+    return `Unknown strategy '${strategy}'. Valid: ${[...VALID_STRATEGIES].join(", ")}`;
+  }
+
   let rule: unknown;
   try {
     rule = JSON.parse(ruleJson);
@@ -83,6 +88,27 @@ async function validateRule(
         if (!p) {
           return `window[${i}] provider_id '${w.target.provider_id}' not found`;
         }
+      }
+    }
+  }
+
+  if (strategy === STRATEGY_NAMES.ROUND_ROBIN || strategy === STRATEGY_NAMES.RANDOM || strategy === STRATEGY_NAMES.FAILOVER) {
+    const r = rule as { targets?: unknown[] };
+    if (!Array.isArray(r.targets) || r.targets.length === 0) {
+      return "rule.targets must be a non-empty array";
+    }
+    const minTargets = strategy === STRATEGY_NAMES.FAILOVER ? 2 : 1;
+    if (r.targets.length < minTargets) {
+      return `strategy '${strategy}' requires at least ${minTargets} target(s)`;
+    }
+    for (let i = 0; i < r.targets.length; i++) {
+      const t = r.targets[i] as any;
+      if (!t.backend_model || !t.provider_id) {
+        return `targets[${i}] missing backend_model or provider_id`;
+      }
+      const p = getProviderById(db, t.provider_id);
+      if (!p) {
+        return `targets[${i}] provider_id '${t.provider_id}' not found`;
       }
     }
   }

--- a/src/admin/groups.ts
+++ b/src/admin/groups.ts
@@ -54,7 +54,7 @@ async function validateRule(
   strategy: string,
   ruleJson: string
 ): Promise<string | undefined> {
-  const VALID_STRATEGIES = new Set(Object.values(STRATEGY_NAMES));
+  const VALID_STRATEGIES: Set<string> = new Set(Object.values(STRATEGY_NAMES));
   if (!VALID_STRATEGIES.has(strategy)) {
     return `Unknown strategy '${strategy}'. Valid: ${[...VALID_STRATEGIES].join(", ")}`;
   }

--- a/src/proxy/mapping-resolver.ts
+++ b/src/proxy/mapping-resolver.ts
@@ -2,6 +2,9 @@ import Database from "better-sqlite3";
 import type { Target, ResolveContext } from "./strategy/types.js";
 import { STRATEGY_NAMES } from "./strategy/types.js";
 import { ScheduledStrategy } from "./strategy/scheduled.js";
+import { RoundRobinStrategy } from "./strategy/round-robin.js";
+import { RandomStrategy } from "./strategy/random.js";
+import { FailoverStrategy } from "./strategy/failover.js";
 import { getMappingGroup } from "../db/index.js";
 
 // 策略注册表：key 为数据库中 mapping_groups.strategy 字段的值。
@@ -10,6 +13,9 @@ import { getMappingGroup } from "../db/index.js";
 // 2. 在此注册表中添加映射
 const STRATEGIES: Record<string, import("./strategy/types.js").MappingStrategy> = {
   [STRATEGY_NAMES.SCHEDULED]: new ScheduledStrategy(),
+  [STRATEGY_NAMES.ROUND_ROBIN]: new RoundRobinStrategy(),
+  [STRATEGY_NAMES.RANDOM]: new RandomStrategy(),
+  [STRATEGY_NAMES.FAILOVER]: new FailoverStrategy(),
 };
 
 export function resolveMapping(
@@ -26,5 +32,5 @@ export function resolveMapping(
   const strategy = STRATEGIES[group.strategy];
   if (!strategy) return null;
 
-  return strategy.select(rule, context) ?? null;
+  return strategy.select(rule, context, clientModel) ?? null;
 }

--- a/src/proxy/proxy-core.ts
+++ b/src/proxy/proxy-core.ts
@@ -11,9 +11,11 @@ import { getSetting } from "../db/settings.js";
 import { SSEMetricsTransform } from "../metrics/sse-metrics-transform.js";
 import { MetricsExtractor } from "../metrics/metrics-extractor.js";
 import type { MetricsResult } from "../metrics/metrics-extractor.js";
+import { getMappingGroup } from "../db/index.js";
 import { resolveMapping } from "./mapping-resolver.js";
 import { retryableCall, buildRetryConfig } from "./retry.js";
 import type { RetryRuleMatcher } from "./retry-rules.js";
+import type { Target } from "./strategy/types.js";
 
 // ---------- Types ----------
 
@@ -396,6 +398,9 @@ const HTTP_BAD_GATEWAY = 502;
 /**
  * 共享 POST handler，参数化 apiType/errorFormat/upstreamPath 等差异，
  * 消除 openai.ts / anthropic.ts 中约 120 行重复代码。
+ *
+ * 当分组策略为 failover 时，在 while 循环中依次尝试不同 target，
+ * 直到成功（或 headers 已发送）才返回。
  */
 export async function handleProxyPost(
   request: FastifyRequest,
@@ -411,150 +416,177 @@ export async function handleProxyPost(
   const { db, streamTimeoutMs, retryMaxAttempts, retryBaseDelayMs, matcher } = deps;
 
   request.raw.socket.on("error", (err) => request.log.debug({ err }, "client socket error"));
-  const startTime = Date.now();
-  const logId = randomUUID();
-  const routerKeyId = request.routerKey?.id ?? null;
-  const body = request.body as Record<string, unknown>;
-  const originalBody = JSON.parse(JSON.stringify(body));
-  const clientModel = (body.model as string) || "unknown";
-  const resolved = resolveMapping(db, clientModel, { now: new Date() });
-  if (!resolved) {
-    const e = errors.modelNotFound(clientModel);
-    return reply.status(e.statusCode).send(e.body);
-  }
+  const clientModel = ((request.body as Record<string, unknown>).model as string) || "unknown";
 
-  // 白名单校验
-  const allowedModels = request.routerKey?.allowed_models;
-  if (allowedModels) {
+  // 查询分组策略（只查一次）
+  const group = getMappingGroup(db, clientModel);
+  const isFailover = group?.strategy === "failover";
+  const excludeTargets: Target[] = [];
+
+  while (true) {
+    const startTime = Date.now();
+    const logId = randomUUID();
+    const routerKeyId = request.routerKey?.id ?? null;
+    const body = request.body as Record<string, unknown>;
+    const originalBody = JSON.parse(JSON.stringify(body));
+
+    const resolved = resolveMapping(db, clientModel, { now: new Date(), excludeTargets });
+    if (!resolved) {
+      if (isFailover && excludeTargets.length > 0) {
+        // 所有 failover target 都已尝试，reply 已在上一轮发送
+        return reply;
+      }
+      const e = errors.modelNotFound(clientModel);
+      return reply.status(e.statusCode).send(e.body);
+    }
+
+    // 白名单校验（只在首次循环检查，allowed_models 基于 clientModel 而非 backend_model）
+    if (excludeTargets.length === 0) {
+      const allowedModels = request.routerKey?.allowed_models;
+      if (allowedModels) {
+        try {
+          const models: string[] = JSON.parse(allowedModels);
+          if (models.length > 0 && !models.includes(resolved.backend_model)) {
+            const e = errors.modelNotAllowed(resolved.backend_model);
+            return reply.status(e.statusCode).send(e.body);
+          }
+        } catch { request.log.warn("Invalid allowed_models JSON, allowing all models"); }
+      }
+    }
+
+    const provider = getProviderById(db, resolved.provider_id);
+    if (!provider || !provider.is_active) {
+      const e = errors.providerUnavailable();
+      return reply.status(e.statusCode).send(e.body);
+    }
+    if (provider.api_type !== apiType) {
+      const e = errors.providerTypeMismatch();
+      return reply.status(e.statusCode).send(e.body);
+    }
+
+    body.model = resolved.backend_model;
+    const apiKey = decrypt(provider.api_key, getSetting(db, "encryption_key")!);
+    const isStream = body.stream === true;
+
+    // 允许调用方在发送代理请求前修改 body（如 openai 的 stream_options 注入）
+    options?.beforeSendProxy?.(body, isStream);
+
+    const reqBodyStr = JSON.stringify(body);
+    const cliHdrs: RawHeaders = request.headers as RawHeaders;
+    const clientReq = JSON.stringify({ headers: cliHdrs, body: originalBody });
+    const retryConfig = buildRetryConfig(retryMaxAttempts, retryBaseDelayMs, matcher);
+    const upstreamReqBase = JSON.stringify({ url: `${provider.base_url}${upstreamPath}`, headers: buildUpstreamHeaders(cliHdrs, apiKey, Buffer.byteLength(reqBodyStr)), body: reqBodyStr });
+
     try {
-      const models: string[] = JSON.parse(allowedModels);
-      if (models.length > 0 && !models.includes(resolved.backend_model)) {
-        const e = errors.modelNotAllowed(resolved.backend_model);
-        return reply.status(e.statusCode).send(e.body);
+      const { result: r, attempts } = isStream
+        ? await retryableCall(
+            () => {
+              const metricsTransform = new SSEMetricsTransform(apiType, startTime);
+              return proxyStream(provider, apiKey, body, cliHdrs, reply, streamTimeoutMs, upstreamPath, metricsTransform);
+            },
+            retryConfig,
+            reply,
+          )
+        : await retryableCall(
+            () => proxyNonStream(provider, apiKey, body, cliHdrs, upstreamPath),
+            retryConfig,
+            reply,
+          );
+
+      // 记录所有尝试的日志
+      let lastSuccessLogId = logId;
+      for (const attempt of attempts) {
+        const isOriginal = attempt.attemptIndex === 0;
+        const attemptLogId = isOriginal ? logId : randomUUID();
+
+        if (attempt.error) {
+          insertRequestLog(db, {
+            id: attemptLogId, api_type: apiType, model: clientModel, provider_id: provider.id,
+            status_code: HTTP_BAD_GATEWAY, latency_ms: attempt.latencyMs,
+            is_stream: isStream ? 1 : 0, error_message: attempt.error,
+            created_at: new Date().toISOString(), request_body: reqBodyStr,
+            client_request: clientReq, upstream_request: upstreamReqBase,
+            is_retry: isOriginal ? 0 : 1, original_request_id: isOriginal ? null : logId,
+            router_key_id: routerKeyId,
+          });
+        } else if (attempt.statusCode !== UPSTREAM_SUCCESS) {
+          insertRequestLog(db, {
+            id: attemptLogId, api_type: apiType, model: clientModel, provider_id: provider.id,
+            status_code: attempt.statusCode, latency_ms: attempt.latencyMs,
+            is_stream: isStream ? 1 : 0, error_message: null,
+            created_at: new Date().toISOString(), request_body: reqBodyStr,
+            response_body: attempt.responseBody, client_request: clientReq, upstream_request: upstreamReqBase,
+            upstream_response: JSON.stringify({ statusCode: attempt.statusCode, body: attempt.responseBody }),
+            client_response: JSON.stringify({ statusCode: attempt.statusCode, body: attempt.responseBody }),
+            is_retry: isOriginal ? 0 : 1, original_request_id: isOriginal ? null : logId,
+            router_key_id: routerKeyId,
+          });
+        } else {
+          const h = isStream
+            ? ((r as StreamProxyResult).upstreamResponseHeaders ?? {})
+            : ((r as ProxyResult).headers);
+          insertSuccessLog(db, apiType, attemptLogId, clientModel, provider, isStream, startTime,
+            reqBodyStr, clientReq, upstreamReqBase, r.statusCode, attempt.responseBody, h, h,
+            !isOriginal, isOriginal ? null : logId, routerKeyId);
+          lastSuccessLogId = attemptLogId;
+        }
       }
-    } catch { request.log.warn("Invalid allowed_models JSON, allowing all models"); }
-  }
 
-  const provider = getProviderById(db, resolved.provider_id);
-  if (!provider || !provider.is_active) {
-    const e = errors.providerUnavailable();
-    return reply.status(e.statusCode).send(e.body);
-  }
-  if (provider.api_type !== apiType) {
-    const e = errors.providerTypeMismatch();
-    return reply.status(e.statusCode).send(e.body);
-  }
-
-  body.model = resolved.backend_model;
-  const apiKey = decrypt(provider.api_key, getSetting(db, "encryption_key")!);
-  const isStream = body.stream === true;
-
-  // 允许调用方在发送代理请求前修改 body（如 openai 的 stream_options 注入）
-  options?.beforeSendProxy?.(body, isStream);
-
-  const reqBodyStr = JSON.stringify(body);
-  const cliHdrs: RawHeaders = request.headers as RawHeaders;
-  const clientReq = JSON.stringify({ headers: cliHdrs, body: originalBody });
-
-  const retryConfig = buildRetryConfig(retryMaxAttempts, retryBaseDelayMs, matcher);
-  const upstreamReqBase = JSON.stringify({ url: `${provider.base_url}${upstreamPath}`, headers: buildUpstreamHeaders(cliHdrs, apiKey, Buffer.byteLength(reqBodyStr)), body: reqBodyStr });
-
-  try {
-    const { result: r, attempts } = isStream
-      ? await retryableCall(
-          () => {
-            const metricsTransform = new SSEMetricsTransform(apiType, startTime);
-            return proxyStream(provider, apiKey, body, cliHdrs, reply, streamTimeoutMs, upstreamPath, metricsTransform);
-          },
-          retryConfig,
-          reply,
-        )
-      : await retryableCall(
-          () => proxyNonStream(provider, apiKey, body, cliHdrs, upstreamPath),
-          retryConfig,
-          reply,
-        );
-
-    // 记录所有尝试的日志
-    let lastSuccessLogId = logId;
-    for (const attempt of attempts) {
-      const isOriginal = attempt.attemptIndex === 0;
-      const attemptLogId = isOriginal ? logId : randomUUID();
-
-      if (attempt.error) {
-        insertRequestLog(db, {
-          id: attemptLogId, api_type: apiType, model: clientModel, provider_id: provider.id,
-          status_code: HTTP_BAD_GATEWAY, latency_ms: attempt.latencyMs,
-          is_stream: isStream ? 1 : 0, error_message: attempt.error,
-          created_at: new Date().toISOString(), request_body: reqBodyStr,
-          client_request: clientReq, upstream_request: upstreamReqBase,
-          is_retry: isOriginal ? 0 : 1, original_request_id: isOriginal ? null : logId,
-          router_key_id: routerKeyId,
-        });
-      } else if (attempt.statusCode !== UPSTREAM_SUCCESS) {
-        insertRequestLog(db, {
-          id: attemptLogId, api_type: apiType, model: clientModel, provider_id: provider.id,
-          status_code: attempt.statusCode, latency_ms: attempt.latencyMs,
-          is_stream: isStream ? 1 : 0, error_message: null,
-          created_at: new Date().toISOString(), request_body: reqBodyStr,
-          response_body: attempt.responseBody, client_request: clientReq, upstream_request: upstreamReqBase,
-          upstream_response: JSON.stringify({ statusCode: attempt.statusCode, body: attempt.responseBody }),
-          client_response: JSON.stringify({ statusCode: attempt.statusCode, body: attempt.responseBody }),
-          is_retry: isOriginal ? 0 : 1, original_request_id: isOriginal ? null : logId,
-          router_key_id: routerKeyId,
-        });
-      } else {
-        const h = isStream
-          ? ((r as StreamProxyResult).upstreamResponseHeaders ?? {})
-          : ((r as ProxyResult).headers);
-        insertSuccessLog(db, apiType, attemptLogId, clientModel, provider, isStream, startTime,
-          reqBodyStr, clientReq, upstreamReqBase, r.statusCode, attempt.responseBody, h, h,
-          !isOriginal, isOriginal ? null : logId, routerKeyId);
-        lastSuccessLogId = attemptLogId;
+      // --- Failover 检查 ---
+      if (isFailover && r.statusCode >= 400 && !reply.raw.headersSent) {
+        excludeTargets.push(resolved);
+        continue;
       }
-    }
 
-    // 将最终结果发送给客户端
-    if (isStream) {
-      if (r.statusCode !== UPSTREAM_SUCCESS) {
-        for (const [k, v] of Object.entries((r as StreamProxyResult).upstreamResponseHeaders ?? {})) reply.header(k, v);
-        reply.status(r.statusCode).send((r as StreamProxyResult).responseBody);
-      }
-    } else {
-      const pr = r as ProxyResult;
-      for (const [k, v] of Object.entries(pr.headers)) reply.header(k, v);
-      return reply.status(pr.statusCode).send(pr.body);
-    }
-
-    // 仅对最终成功请求采集 metrics
-    if (r.statusCode === UPSTREAM_SUCCESS) {
+      // 发送响应
       if (isStream) {
-        const streamResult = r as StreamProxyResult;
-        if (streamResult.metricsResult) {
-          try { insertMetrics(db, { ...streamResult.metricsResult, request_log_id: lastSuccessLogId, provider_id: provider.id, backend_model: resolved.backend_model, api_type: apiType }); }
-          catch (err) { request.log.error({ err }, "Failed to insert metrics"); }
+        if (r.statusCode !== UPSTREAM_SUCCESS) {
+          for (const [k, v] of Object.entries((r as StreamProxyResult).upstreamResponseHeaders ?? {})) reply.header(k, v);
+          reply.status(r.statusCode).send((r as StreamProxyResult).responseBody);
         }
       } else {
-        try {
-          const mr = MetricsExtractor.fromNonStreamResponse(apiType, (r as ProxyResult).body);
-          if (mr) insertMetrics(db, { ...mr, request_log_id: lastSuccessLogId, provider_id: provider.id, backend_model: resolved.backend_model, api_type: apiType });
-        } catch (err) { request.log.error({ err }, "Failed to insert metrics"); }
+        const pr = r as ProxyResult;
+        for (const [k, v] of Object.entries(pr.headers)) reply.header(k, v);
+        return reply.status(pr.statusCode).send(pr.body);
       }
+
+      // metrics 采集
+      if (r.statusCode === UPSTREAM_SUCCESS) {
+        if (isStream) {
+          const streamResult = r as StreamProxyResult;
+          if (streamResult.metricsResult) {
+            try { insertMetrics(db, { ...streamResult.metricsResult, request_log_id: lastSuccessLogId, provider_id: provider.id, backend_model: resolved.backend_model, api_type: apiType }); }
+            catch (err) { request.log.error({ err }, "Failed to insert metrics"); }
+          }
+        } else {
+          try {
+            const mr = MetricsExtractor.fromNonStreamResponse(apiType, (r as ProxyResult).body);
+            if (mr) insertMetrics(db, { ...mr, request_log_id: lastSuccessLogId, provider_id: provider.id, backend_model: resolved.backend_model, api_type: apiType });
+          } catch (err) { request.log.error({ err }, "Failed to insert metrics"); }
+        }
+      }
+      return reply;
+    } catch (err: unknown) {
+      const errMsg = err instanceof Error ? err.message : String(err);
+      const sentH = buildUpstreamHeaders(cliHdrs, apiKey, Buffer.byteLength(reqBodyStr));
+      const upstreamReq = JSON.stringify({ url: `${provider.base_url}${upstreamPath}`, headers: sentH, body: reqBodyStr });
+      insertRequestLog(db, {
+        id: logId, api_type: apiType, model: clientModel, provider_id: provider.id,
+        status_code: HTTP_BAD_GATEWAY, latency_ms: Date.now() - startTime,
+        is_stream: isStream ? 1 : 0, error_message: errMsg || "Upstream connection failed",
+        created_at: new Date().toISOString(), request_body: reqBodyStr,
+        client_request: clientReq, upstream_request: upstreamReq,
+        router_key_id: routerKeyId,
+      });
+
+      // --- Failover 检查（异常路径）---
+      if (isFailover && !reply.raw.headersSent) {
+        excludeTargets.push(resolved);
+        continue;
+      }
+
+      const e = errors.upstreamConnectionFailed();
+      return reply.status(e.statusCode).send(e.body);
     }
-    return reply;
-  } catch (err: unknown) {
-    const errMsg = err instanceof Error ? err.message : String(err);
-    const sentH = buildUpstreamHeaders(cliHdrs, apiKey, Buffer.byteLength(reqBodyStr));
-    const upstreamReq = JSON.stringify({ url: `${provider.base_url}${upstreamPath}`, headers: sentH, body: reqBodyStr });
-    insertRequestLog(db, {
-      id: logId, api_type: apiType, model: clientModel, provider_id: provider.id,
-      status_code: HTTP_BAD_GATEWAY, latency_ms: Date.now() - startTime,
-      is_stream: isStream ? 1 : 0, error_message: errMsg || "Upstream connection failed",
-      created_at: new Date().toISOString(), request_body: reqBodyStr,
-      client_request: clientReq, upstream_request: upstreamReq,
-      router_key_id: routerKeyId,
-    });
-    const e = errors.upstreamConnectionFailed();
-    return reply.status(e.statusCode).send(e.body);
   }
 }

--- a/src/proxy/proxy-core.ts
+++ b/src/proxy/proxy-core.ts
@@ -55,6 +55,8 @@ export interface GetProxyResult {
 // ---------- Constants ----------
 
 export const UPSTREAM_SUCCESS = 200;
+// failover 判断上游请求失败的 HTTP 状态码阈值
+const FAILOVER_FAIL_THRESHOLD = 400;
 const HTTPS_DEFAULT_PORT = 443;
 const HTTP_DEFAULT_PORT = 80;
 const UPSTREAM_BAD_GATEWAY = 502;
@@ -533,7 +535,7 @@ export async function handleProxyPost(
       }
 
       // --- Failover 检查 ---
-      if (isFailover && r.statusCode >= 400 && !reply.raw.headersSent) {
+      if (isFailover && r.statusCode >= FAILOVER_FAIL_THRESHOLD && !reply.raw.headersSent) {
         excludeTargets.push(resolved);
         continue;
       }

--- a/src/proxy/strategy/failover.ts
+++ b/src/proxy/strategy/failover.ts
@@ -1,0 +1,36 @@
+import type { MappingStrategy, ResolveContext, Target } from "./types.js";
+
+interface TargetsRule {
+  targets: Target[];
+}
+
+function isTarget(value: unknown): value is Target {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "backend_model" in value &&
+    typeof (value as Target).backend_model === "string" &&
+    "provider_id" in value &&
+    typeof (value as Target).provider_id === "string"
+  );
+}
+
+function isTargetsRule(value: unknown): value is TargetsRule {
+  if (typeof value !== "object" || value === null) return false;
+  const r = value as TargetsRule;
+  return Array.isArray(r.targets) && r.targets.every(isTarget);
+}
+
+export class FailoverStrategy implements MappingStrategy {
+  select(rule: unknown, context: ResolveContext): Target | undefined {
+    if (!isTargetsRule(rule)) return undefined;
+
+    for (const t of rule.targets) {
+      const excluded = context.excludeTargets?.some(
+        (e) => e.backend_model === t.backend_model && e.provider_id === t.provider_id
+      );
+      if (!excluded) return t;
+    }
+    return undefined;
+  }
+}

--- a/src/proxy/strategy/failover.ts
+++ b/src/proxy/strategy/failover.ts
@@ -1,25 +1,5 @@
 import type { MappingStrategy, ResolveContext, Target } from "./types.js";
-
-interface TargetsRule {
-  targets: Target[];
-}
-
-function isTarget(value: unknown): value is Target {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    "backend_model" in value &&
-    typeof (value as Target).backend_model === "string" &&
-    "provider_id" in value &&
-    typeof (value as Target).provider_id === "string"
-  );
-}
-
-function isTargetsRule(value: unknown): value is TargetsRule {
-  if (typeof value !== "object" || value === null) return false;
-  const r = value as TargetsRule;
-  return Array.isArray(r.targets) && r.targets.every(isTarget);
-}
+import { isTargetsRule } from "./targets-rule.js";
 
 export class FailoverStrategy implements MappingStrategy {
   select(rule: unknown, context: ResolveContext): Target | undefined {

--- a/src/proxy/strategy/random.ts
+++ b/src/proxy/strategy/random.ts
@@ -1,0 +1,37 @@
+import type { MappingStrategy, ResolveContext, Target } from "./types.js";
+
+interface TargetsRule {
+  targets: Target[];
+}
+
+function isTarget(value: unknown): value is Target {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "backend_model" in value &&
+    typeof (value as Target).backend_model === "string" &&
+    "provider_id" in value &&
+    typeof (value as Target).provider_id === "string"
+  );
+}
+
+function isTargetsRule(value: unknown): value is TargetsRule {
+  if (typeof value !== "object" || value === null) return false;
+  const r = value as TargetsRule;
+  return Array.isArray(r.targets) && r.targets.every(isTarget);
+}
+
+export class RandomStrategy implements MappingStrategy {
+  select(rule: unknown, context: ResolveContext): Target | undefined {
+    if (!isTargetsRule(rule)) return undefined;
+
+    const filtered = rule.targets.filter(
+      (t) => !context.excludeTargets?.some(
+        (e) => e.backend_model === t.backend_model && e.provider_id === t.provider_id
+      )
+    );
+    if (filtered.length === 0) return undefined;
+
+    return filtered[Math.floor(Math.random() * filtered.length)];
+  }
+}

--- a/src/proxy/strategy/random.ts
+++ b/src/proxy/strategy/random.ts
@@ -1,25 +1,5 @@
 import type { MappingStrategy, ResolveContext, Target } from "./types.js";
-
-interface TargetsRule {
-  targets: Target[];
-}
-
-function isTarget(value: unknown): value is Target {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    "backend_model" in value &&
-    typeof (value as Target).backend_model === "string" &&
-    "provider_id" in value &&
-    typeof (value as Target).provider_id === "string"
-  );
-}
-
-function isTargetsRule(value: unknown): value is TargetsRule {
-  if (typeof value !== "object" || value === null) return false;
-  const r = value as TargetsRule;
-  return Array.isArray(r.targets) && r.targets.every(isTarget);
-}
+import { isTargetsRule } from "./targets-rule.js";
 
 export class RandomStrategy implements MappingStrategy {
   select(rule: unknown, context: ResolveContext): Target | undefined {

--- a/src/proxy/strategy/round-robin.ts
+++ b/src/proxy/strategy/round-robin.ts
@@ -1,0 +1,44 @@
+import type { MappingStrategy, ResolveContext, Target } from "./types.js";
+
+interface TargetsRule {
+  targets: Target[];
+}
+
+function isTarget(value: unknown): value is Target {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "backend_model" in value &&
+    typeof (value as Target).backend_model === "string" &&
+    "provider_id" in value &&
+    typeof (value as Target).provider_id === "string"
+  );
+}
+
+function isTargetsRule(value: unknown): value is TargetsRule {
+  if (typeof value !== "object" || value === null) return false;
+  const r = value as TargetsRule;
+  return Array.isArray(r.targets) && r.targets.every(isTarget);
+}
+
+export class RoundRobinStrategy implements MappingStrategy {
+  private indexMap = new Map<string, number>();
+
+  select(rule: unknown, context: ResolveContext, clientModel?: string): Target | undefined {
+    if (!isTargetsRule(rule)) return undefined;
+
+    const key = clientModel ?? JSON.stringify(rule);
+    const filtered = rule.targets.filter(
+      (t) =>
+        !context.excludeTargets?.some(
+          (e) => e.backend_model === t.backend_model && e.provider_id === t.provider_id,
+        ),
+    );
+    if (filtered.length === 0) return undefined;
+
+    const lastIndex = this.indexMap.get(key) ?? -1;
+    const nextIndex = (lastIndex + 1) % filtered.length;
+    this.indexMap.set(key, nextIndex);
+    return filtered[nextIndex];
+  }
+}

--- a/src/proxy/strategy/round-robin.ts
+++ b/src/proxy/strategy/round-robin.ts
@@ -1,25 +1,5 @@
 import type { MappingStrategy, ResolveContext, Target } from "./types.js";
-
-interface TargetsRule {
-  targets: Target[];
-}
-
-function isTarget(value: unknown): value is Target {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    "backend_model" in value &&
-    typeof (value as Target).backend_model === "string" &&
-    "provider_id" in value &&
-    typeof (value as Target).provider_id === "string"
-  );
-}
-
-function isTargetsRule(value: unknown): value is TargetsRule {
-  if (typeof value !== "object" || value === null) return false;
-  const r = value as TargetsRule;
-  return Array.isArray(r.targets) && r.targets.every(isTarget);
-}
+import { isTargetsRule } from "./targets-rule.js";
 
 export class RoundRobinStrategy implements MappingStrategy {
   private indexMap = new Map<string, number>();

--- a/src/proxy/strategy/targets-rule.ts
+++ b/src/proxy/strategy/targets-rule.ts
@@ -1,0 +1,22 @@
+import type { Target } from "./types.js";
+
+interface TargetsRule {
+  targets: Target[];
+}
+
+export function isTarget(value: unknown): value is Target {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "backend_model" in value &&
+    typeof (value as Target).backend_model === "string" &&
+    "provider_id" in value &&
+    typeof (value as Target).provider_id === "string"
+  );
+}
+
+export function isTargetsRule(value: unknown): value is TargetsRule {
+  if (typeof value !== "object" || value === null) return false;
+  const r = value as TargetsRule;
+  return Array.isArray(r.targets) && r.targets.every(isTarget);
+}

--- a/src/proxy/strategy/types.ts
+++ b/src/proxy/strategy/types.ts
@@ -1,5 +1,8 @@
 export const STRATEGY_NAMES = {
   SCHEDULED: "scheduled",
+  ROUND_ROBIN: "round-robin",
+  RANDOM: "random",
+  FAILOVER: "failover",
 } as const;
 
 export interface Target {
@@ -9,8 +12,9 @@ export interface Target {
 
 export interface ResolveContext {
   now: Date;
+  excludeTargets?: Target[];
 }
 
 export interface MappingStrategy {
-  select(rule: unknown, context: ResolveContext): Target | undefined;
+  select(rule: unknown, context: ResolveContext, clientModel?: string): Target | undefined;
 }

--- a/tests/admin-groups.test.ts
+++ b/tests/admin-groups.test.ts
@@ -266,4 +266,106 @@ describe("Mapping Group CRUD", () => {
     });
     expect(res.statusCode).toBe(401);
   });
+
+  it("POST creates round-robin group", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/admin/api/mapping-groups",
+      headers: { cookie, "content-type": "application/json" },
+      payload: {
+        client_model: "gpt-4-rr",
+        strategy: "round-robin",
+        rule: JSON.stringify({
+          targets: [
+            { backend_model: "gpt-4-turbo", provider_id: providerId },
+            { backend_model: "gpt-4o", provider_id: providerId },
+          ],
+        }),
+      },
+    });
+    expect(res.statusCode).toBe(201);
+  });
+
+  it("POST creates random group", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/admin/api/mapping-groups",
+      headers: { cookie, "content-type": "application/json" },
+      payload: {
+        client_model: "gpt-4-rand",
+        strategy: "random",
+        rule: JSON.stringify({
+          targets: [
+            { backend_model: "gpt-4-turbo", provider_id: providerId },
+          ],
+        }),
+      },
+    });
+    expect(res.statusCode).toBe(201);
+  });
+
+  it("POST creates failover group", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/admin/api/mapping-groups",
+      headers: { cookie, "content-type": "application/json" },
+      payload: {
+        client_model: "gpt-4-fo",
+        strategy: "failover",
+        rule: JSON.stringify({
+          targets: [
+            { backend_model: "gpt-4-turbo", provider_id: providerId },
+            { backend_model: "gpt-4o", provider_id: providerId },
+          ],
+        }),
+      },
+    });
+    expect(res.statusCode).toBe(201);
+  });
+
+  it("POST failover with single target returns 400", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/admin/api/mapping-groups",
+      headers: { cookie, "content-type": "application/json" },
+      payload: {
+        client_model: "gpt-4-fo2",
+        strategy: "failover",
+        rule: JSON.stringify({
+          targets: [
+            { backend_model: "gpt-4-turbo", provider_id: providerId },
+          ],
+        }),
+      },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("POST round-robin with empty targets returns 400", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/admin/api/mapping-groups",
+      headers: { cookie, "content-type": "application/json" },
+      payload: {
+        client_model: "gpt-4-rr2",
+        strategy: "round-robin",
+        rule: JSON.stringify({ targets: [] }),
+      },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("POST with unknown strategy returns 400", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/admin/api/mapping-groups",
+      headers: { cookie, "content-type": "application/json" },
+      payload: {
+        client_model: "gpt-4-unk",
+        strategy: "unknown-strategy",
+        rule: JSON.stringify({ targets: [] }),
+      },
+    });
+    expect(res.statusCode).toBe(400);
+  });
 });

--- a/tests/failover-strategy.test.ts
+++ b/tests/failover-strategy.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { FailoverStrategy } from "../src/proxy/strategy/failover.js";
+import type { Target } from "../src/proxy/strategy/types.js";
+
+const t1: Target = { backend_model: "gpt-4", provider_id: "p1" };
+const t2: Target = { backend_model: "claude-3", provider_id: "p2" };
+const t3: Target = { backend_model: "gemini", provider_id: "p3" };
+
+function makeContext() {
+  return { now: new Date() };
+}
+
+describe("FailoverStrategy", () => {
+  it("returns first target by default", () => {
+    const strategy = new FailoverStrategy();
+    const rule = { targets: [t1, t2, t3] };
+    expect(strategy.select(rule, makeContext())).toEqual(t1);
+  });
+
+  it("returns second target when first is excluded", () => {
+    const strategy = new FailoverStrategy();
+    const rule = { targets: [t1, t2, t3] };
+    const result = strategy.select(rule, { ...makeContext(), excludeTargets: [t1] });
+    expect(result).toEqual(t2);
+  });
+
+  it("returns third target when first two are excluded", () => {
+    const strategy = new FailoverStrategy();
+    const rule = { targets: [t1, t2, t3] };
+    const result = strategy.select(rule, { ...makeContext(), excludeTargets: [t1, t2] });
+    expect(result).toEqual(t3);
+  });
+
+  it("returns undefined when all targets excluded", () => {
+    const strategy = new FailoverStrategy();
+    const rule = { targets: [t1, t2] };
+    const result = strategy.select(rule, { ...makeContext(), excludeTargets: [t1, t2] });
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined for invalid rule", () => {
+    const strategy = new FailoverStrategy();
+    expect(strategy.select(null, makeContext())).toBeUndefined();
+    expect(strategy.select({ targets: "not-array" }, makeContext())).toBeUndefined();
+    expect(strategy.select({ targets: [null] }, makeContext())).toBeUndefined();
+  });
+
+  it("returns undefined for empty targets", () => {
+    const strategy = new FailoverStrategy();
+    expect(strategy.select({ targets: [] }, makeContext())).toBeUndefined();
+  });
+});

--- a/tests/mapping-resolver.test.ts
+++ b/tests/mapping-resolver.test.ts
@@ -61,4 +61,64 @@ describe("resolveMapping", () => {
     const result = resolveMapping(db, "my-model", { now: new Date() });
     expect(result).toBeNull();
   });
+
+  it("resolves round-robin strategy", () => {
+    const rule = JSON.stringify({
+      targets: [
+        { backend_model: "gpt-4", provider_id: "p1" },
+        { backend_model: "claude-3", provider_id: "p2" },
+      ],
+    });
+    db.prepare("INSERT INTO mapping_groups (id, client_model, strategy, rule, created_at) VALUES (?, ?, ?, ?, ?)")
+      .run("g1", "my-model", "round-robin", rule, new Date().toISOString());
+
+    const result = resolveMapping(db, "my-model", { now: new Date() });
+    expect(result).toEqual({ backend_model: "gpt-4", provider_id: "p1" });
+  });
+
+  it("resolves random strategy", () => {
+    const rule = JSON.stringify({
+      targets: [
+        { backend_model: "gpt-4", provider_id: "p1" },
+        { backend_model: "claude-3", provider_id: "p2" },
+      ],
+    });
+    db.prepare("INSERT INTO mapping_groups (id, client_model, strategy, rule, created_at) VALUES (?, ?, ?, ?, ?)")
+      .run("g1", "my-model", "random", rule, new Date().toISOString());
+
+    const result = resolveMapping(db, "my-model", { now: new Date() });
+    expect(result?.backend_model).toBeDefined();
+    expect(result?.provider_id).toBeDefined();
+  });
+
+  it("resolves failover strategy", () => {
+    const rule = JSON.stringify({
+      targets: [
+        { backend_model: "gpt-4", provider_id: "p1" },
+        { backend_model: "claude-3", provider_id: "p2" },
+      ],
+    });
+    db.prepare("INSERT INTO mapping_groups (id, client_model, strategy, rule, created_at) VALUES (?, ?, ?, ?, ?)")
+      .run("g1", "my-model", "failover", rule, new Date().toISOString());
+
+    const result = resolveMapping(db, "my-model", { now: new Date() });
+    expect(result).toEqual({ backend_model: "gpt-4", provider_id: "p1" });
+  });
+
+  it("resolves failover with excludeTargets", () => {
+    const rule = JSON.stringify({
+      targets: [
+        { backend_model: "gpt-4", provider_id: "p1" },
+        { backend_model: "claude-3", provider_id: "p2" },
+      ],
+    });
+    db.prepare("INSERT INTO mapping_groups (id, client_model, strategy, rule, created_at) VALUES (?, ?, ?, ?, ?)")
+      .run("g1", "my-model", "failover", rule, new Date().toISOString());
+
+    const result = resolveMapping(db, "my-model", {
+      now: new Date(),
+      excludeTargets: [{ backend_model: "gpt-4", provider_id: "p1" }],
+    });
+    expect(result).toEqual({ backend_model: "claude-3", provider_id: "p2" });
+  });
 });

--- a/tests/random-strategy.test.ts
+++ b/tests/random-strategy.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { RandomStrategy } from "../src/proxy/strategy/random.js";
+import type { Target } from "../src/proxy/strategy/types.js";
+
+const t1: Target = { backend_model: "gpt-4", provider_id: "p1" };
+const t2: Target = { backend_model: "claude-3", provider_id: "p2" };
+const t3: Target = { backend_model: "gemini", provider_id: "p3" };
+
+function makeContext() {
+  return { now: new Date() };
+}
+
+describe("RandomStrategy", () => {
+  it("returns a target from the list", () => {
+    const strategy = new RandomStrategy();
+    const rule = { targets: [t1, t2, t3] };
+    const result = strategy.select(rule, makeContext());
+    expect([t1, t2, t3]).toContainEqual(result);
+  });
+
+  it("returns undefined for empty targets", () => {
+    const strategy = new RandomStrategy();
+    expect(strategy.select({ targets: [] }, makeContext())).toBeUndefined();
+  });
+
+  it("skips excluded targets", () => {
+    const strategy = new RandomStrategy();
+    const rule = { targets: [t1, t2] };
+    const result = strategy.select(rule, { ...makeContext(), excludeTargets: [t1] });
+    expect(result).toEqual(t2);
+  });
+
+  it("returns undefined when all excluded", () => {
+    const strategy = new RandomStrategy();
+    const rule = { targets: [t1, t2] };
+    const result = strategy.select(rule, { ...makeContext(), excludeTargets: [t1, t2] });
+    expect(result).toBeUndefined();
+  });
+
+  it("returns single target when only one remains after exclude", () => {
+    const strategy = new RandomStrategy();
+    const rule = { targets: [t1, t2, t3] };
+    const result = strategy.select(rule, { ...makeContext(), excludeTargets: [t1, t3] });
+    expect(result).toEqual(t2);
+  });
+
+  it("returns undefined for invalid rule", () => {
+    const strategy = new RandomStrategy();
+    expect(strategy.select(null, makeContext())).toBeUndefined();
+    expect(strategy.select({ targets: "not-array" }, makeContext())).toBeUndefined();
+    expect(strategy.select({ targets: [123] }, makeContext())).toBeUndefined();
+  });
+});

--- a/tests/round-robin-strategy.test.ts
+++ b/tests/round-robin-strategy.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { RoundRobinStrategy } from "../src/proxy/strategy/round-robin.js";
+import type { Target } from "../src/proxy/strategy/types.js";
+
+const t1: Target = { backend_model: "gpt-4", provider_id: "p1" };
+const t2: Target = { backend_model: "claude-3", provider_id: "p2" };
+const t3: Target = { backend_model: "gemini", provider_id: "p3" };
+
+function makeContext() {
+  return { now: new Date() };
+}
+
+describe("RoundRobinStrategy", () => {
+  it("cycles through targets in order", () => {
+    const strategy = new RoundRobinStrategy();
+    const rule = { targets: [t1, t2, t3] };
+    expect(strategy.select(rule, makeContext())).toEqual(t1);
+    expect(strategy.select(rule, makeContext())).toEqual(t2);
+    expect(strategy.select(rule, makeContext())).toEqual(t3);
+    expect(strategy.select(rule, makeContext())).toEqual(t1);
+  });
+
+  it("returns undefined for empty targets", () => {
+    const strategy = new RoundRobinStrategy();
+    expect(strategy.select({ targets: [] }, makeContext())).toBeUndefined();
+  });
+
+  it("skips excluded targets", () => {
+    const strategy = new RoundRobinStrategy();
+    const rule = { targets: [t1, t2, t3] };
+    strategy.select(rule, makeContext()); // t1
+    strategy.select(rule, makeContext()); // t2
+    const result = strategy.select(rule, { ...makeContext(), excludeTargets: [t3] });
+    expect(result).toEqual(t1);
+  });
+
+  it("returns undefined when all targets excluded", () => {
+    const strategy = new RoundRobinStrategy();
+    const rule = { targets: [t1, t2] };
+    const result = strategy.select(rule, { ...makeContext(), excludeTargets: [t1, t2] });
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined for invalid rule", () => {
+    const strategy = new RoundRobinStrategy();
+    expect(strategy.select(null, makeContext())).toBeUndefined();
+    expect(strategy.select({ targets: "not-array" }, makeContext())).toBeUndefined();
+    expect(strategy.select({ targets: [null] }, makeContext())).toBeUndefined();
+  });
+
+  it("maintains independent state per client model", () => {
+    const strategy = new RoundRobinStrategy();
+    const ruleA = { targets: [t1, t2] };
+    const ruleB = { targets: [t3, t1] };
+    expect(strategy.select(ruleA, makeContext(), "model-a")).toEqual(t1);
+    expect(strategy.select(ruleB, makeContext(), "model-b")).toEqual(t3);
+    expect(strategy.select(ruleA, makeContext(), "model-a")).toEqual(t2);
+    expect(strategy.select(ruleB, makeContext(), "model-b")).toEqual(t1);
+  });
+});


### PR DESCRIPTION
## Summary

- Implement 3 new model mapping strategies: **round-robin**, **random**, **failover** (scheduled was already done)
- Strategy layer: `MappingStrategy` interface with shared `TargetsRule` structure, per-strategy selection logic
- Proxy-core failover loop: excludes failed targets and retries with next provider/model
- Admin API validation: strategy whitelist, targets array validation, minimum target counts
- Frontend UI: strategy dropdown, conditional forms (scheduled=default+windows, others=targets list), failover ordering arrows
- Code quality: extracted shared `targets-rule.ts`, eliminated `as any`, named magic constants

## Test plan

- [x] Unit tests for all 3 strategies (18 new tests)
- [x] Admin API validation tests (6 new tests)
- [x] Mapping resolver integration tests (4 new tests)
- [x] All 219 tests pass
- [x] ESLint 0 errors 0 warnings
- [ ] Manual: create round-robin mapping group via admin UI, verify rotation
- [ ] Manual: create failover group, verify fallback on provider error

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)