### PR TITLE
fix: 前端 UX 改进 — 复制按钮、模型输入、预设配置

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,7 +105,7 @@ vite.config.ts.timestamp-*
 .vite/
 
 # Project specific
-data/
+/data/
 *.db
 __pycache__/
 .DS_Store
@@ -117,3 +117,6 @@ __pycache__/
 
 # Build output
 frontend-dist/
+
+# Personal scripts
+.scripts/

--- a/frontend/src/components/log-viewer/JsonCopyBlock.vue
+++ b/frontend/src/components/log-viewer/JsonCopyBlock.vue
@@ -14,17 +14,14 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
+import { useClipboard } from '@/composables/useClipboard'
 import { Button } from '@/components/ui/button'
 
 const props = defineProps<{ content: string; hideCopyButton?: boolean }>()
-const COPIED_FEEDBACK_MS = 1500
 
-const copied = ref(false)
+const { copied, copy } = useClipboard()
 
 async function handleCopy() {
-  await navigator.clipboard.writeText(props.content)
-  copied.value = true
-  setTimeout(() => { copied.value = false }, COPIED_FEEDBACK_MS)
+  await copy(props.content)
 }
 </script>

--- a/frontend/src/components/log-viewer/LogRequestViewer.vue
+++ b/frontend/src/components/log-viewer/LogRequestViewer.vue
@@ -152,6 +152,7 @@
 
 <script setup lang="ts">
 import { computed, reactive, ref } from 'vue'
+import { useClipboard } from '@/composables/useClipboard'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { Card, CardContent, CardHeader } from '@/components/ui/card'
@@ -176,7 +177,7 @@ const props = defineProps<{
 const headersOpen = ref(false)
 const expanded = reactive<Record<string, boolean>>({})
 const toolsExpanded = ref(false)
-const copied = ref(false)
+const { copied, copy: clipboardCopy } = useClipboard()
 
 const parsed = computed<Record<string, unknown>>(() => {
   try {
@@ -196,11 +197,7 @@ const parseError = computed(() => {
 })
 
 async function copyRaw() {
-  try {
-    await navigator.clipboard.writeText(props.raw)
-    copied.value = true
-    setTimeout(() => { copied.value = false }, 2000) // eslint-disable-line no-magic-numbers
-  } catch { copied.value = false }
+  await clipboardCopy(props.raw)
 }
 
 const headerEntries = computed(() => {

--- a/frontend/src/components/log-viewer/LogResponseViewer.vue
+++ b/frontend/src/components/log-viewer/LogResponseViewer.vue
@@ -278,6 +278,7 @@
 
 <script setup lang="ts">
 import { computed, reactive, ref } from 'vue'
+import { useClipboard } from '@/composables/useClipboard'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { Card, CardContent, CardHeader } from '@/components/ui/card'
@@ -385,13 +386,9 @@ const {
 
 const expandedBlock = reactive<Record<number, boolean>>({})
 const streamTab = ref<'assembled' | 'raw-events'>('assembled')
-const copied = ref(false)
+const { copied, copy: clipboardCopy } = useClipboard()
 
 async function copyRaw() {
-  try {
-    await navigator.clipboard.writeText(props.raw)
-    copied.value = true
-    setTimeout(() => { copied.value = false }, 2000) // eslint-disable-line no-magic-numbers
-  } catch { copied.value = false }
+  await clipboardCopy(props.raw)
 }
 </script>

--- a/frontend/src/composables/useClipboard.ts
+++ b/frontend/src/composables/useClipboard.ts
@@ -1,0 +1,47 @@
+import { ref } from 'vue'
+
+const FEEDBACK_MS = 2000
+
+/**
+ * 可靠的剪贴板复制 composable。
+ * 优先使用 navigator.clipboard.writeText，失败时降级为 textarea + execCommand。
+ */
+export function useClipboard() {
+  const copied = ref(false)
+
+  async function copy(text: string): Promise<boolean> {
+    try {
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(text)
+      } else {
+        fallbackCopy(text)
+      }
+      copied.value = true
+      setTimeout(() => { copied.value = false }, FEEDBACK_MS)
+      return true
+    } catch {
+      try {
+        fallbackCopy(text)
+        copied.value = true
+        setTimeout(() => { copied.value = false }, FEEDBACK_MS)
+        return true
+      } catch {
+        return false
+      }
+    }
+  }
+
+  return { copied, copy }
+}
+
+function fallbackCopy(text: string) {
+  const ta = document.createElement('textarea')
+  ta.value = text
+  ta.style.cssText = 'position:fixed;left:-9999px;opacity:0'
+  document.body.appendChild(ta)
+  ta.select()
+  if (!document.execCommand('copy')) {
+    throw new Error('execCommand copy failed')
+  }
+  document.body.removeChild(ta)
+}

--- a/frontend/src/data/provider-presets.ts
+++ b/frontend/src/data/provider-presets.ts
@@ -16,7 +16,7 @@ export interface ProviderGroup {
  *
  * base_url 约定：router 拼接 {base_url}/v1/chat/completions (OpenAI) 或
  * {base_url}/v1/messages (Anthropic)。
- * 对于使用非标准版本路径的供应商（如 /v3/、/v4/），保留完整路径前缀。
+ * Coding Plan 端点通常只兼容 Anthropic 协议，apiType 需设为 'anthropic'。
  */
 export const PROVIDER_PRESETS: ProviderGroup[] = [
   {
@@ -32,8 +32,8 @@ export const PROVIDER_PRESETS: ProviderGroup[] = [
       {
         plan: 'Coding Plan',
         presetName: '智谱 Coding Plan',
-        apiType: 'openai',
-        baseUrl: 'https://open.bigmodel.cn/api/coding/paas/v4',
+        apiType: 'anthropic',
+        baseUrl: 'https://open.bigmodel.cn/api/anthropic',
         models: ['glm-5.1', 'glm-5-turbo', 'glm-4.7', 'glm-4.5-air'],
       },
     ],
@@ -48,6 +48,13 @@ export const PROVIDER_PRESETS: ProviderGroup[] = [
         baseUrl: 'https://api.moonshot.cn',
         models: ['kimi-k2.5', 'kimi-k2-0905-preview', 'kimi-k2-turbo-preview', 'kimi-k2-thinking', 'kimi-k2-thinking-turbo', 'moonshot-v1-128k'],
       },
+      {
+        plan: 'Coding Plan',
+        presetName: 'KIMI Coding Plan',
+        apiType: 'anthropic',
+        baseUrl: 'https://api.kimi.com/coding',
+        models: ['kimi-for-coding', 'kimi-k2.5'],
+      },
     ],
   },
   {
@@ -59,6 +66,13 @@ export const PROVIDER_PRESETS: ProviderGroup[] = [
         apiType: 'openai',
         baseUrl: 'https://api.minimax.chat',
         models: ['MiniMax-M2.7', 'MiniMax-M2.7-highspeed', 'MiniMax-M2.5', 'MiniMax-M2.5-highspeed', 'MiniMax-M2.1', 'MiniMax-M2'],
+      },
+      {
+        plan: 'Token Plan',
+        presetName: 'Minimax Token Plan',
+        apiType: 'anthropic',
+        baseUrl: 'https://api.minimaxi.com/anthropic',
+        models: ['MiniMax-M2.7'],
       },
     ],
   },
@@ -75,9 +89,9 @@ export const PROVIDER_PRESETS: ProviderGroup[] = [
       {
         plan: 'Coding Plan',
         presetName: '火山引擎 Coding Plan',
-        apiType: 'openai',
-        baseUrl: 'https://ark.cn-beijing.volces.com/api/coding/v3',
-        models: ['ark-code-latest', 'doubao-seed-code', 'doubao-seed-2.0-code', 'kimi-k2.5', 'glm-4.7'],
+        apiType: 'anthropic',
+        baseUrl: 'https://ark.cn-beijing.volces.com/api/compatible',
+        models: ['ark-code-latest', 'doubao-seed-2.0-code', 'kimi-k2.5', 'glm-4.7', 'deepseek-v3.2'],
       },
     ],
   },
@@ -94,8 +108,8 @@ export const PROVIDER_PRESETS: ProviderGroup[] = [
       {
         plan: 'Coding Plan',
         presetName: '阿里云 Coding Plan',
-        apiType: 'openai',
-        baseUrl: 'https://coding.dashscope.aliyuncs.com',
+        apiType: 'anthropic',
+        baseUrl: 'https://coding.dashscope.aliyuncs.com/apps/anthropic',
         models: ['qwen3.6-plus', 'qwen3-coder-next', 'qwen3-coder-plus', 'kimi-k2.5', 'glm-5', 'MiniMax-M2.5'],
       },
     ],
@@ -113,8 +127,8 @@ export const PROVIDER_PRESETS: ProviderGroup[] = [
       {
         plan: 'Coding Plan',
         presetName: '腾讯云 Coding Plan',
-        apiType: 'openai',
-        baseUrl: 'https://api.lkeap.cloud.tencent.com/coding/v3',
+        apiType: 'anthropic',
+        baseUrl: 'https://api.lkeap.cloud.tencent.com/coding/anthropic',
         models: ['tc-code-latest', 'hunyuan-2.0-instruct', 'hunyuan-2.0-thinking', 'hunyuan-turbos', 'hunyuan-t1', 'glm-5', 'kimi-k2.5'],
       },
     ],
@@ -132,9 +146,9 @@ export const PROVIDER_PRESETS: ProviderGroup[] = [
       {
         plan: 'Step Plan',
         presetName: '阶跃星辰 Step Plan',
-        apiType: 'openai',
+        apiType: 'anthropic',
         baseUrl: 'https://api.stepfun.com/step_plan',
-        models: ['step-3.5-flash', 'step-3.5-flash-2603'],
+        models: ['step-3.5-flash-2603', 'step-3.5-flash'],
       },
     ],
   },

--- a/frontend/src/data/provider-presets.ts
+++ b/frontend/src/data/provider-presets.ts
@@ -1,0 +1,141 @@
+export interface ProviderPreset {
+  plan: string
+  presetName: string
+  apiType: 'openai' | 'anthropic'
+  baseUrl: string
+  models: string[]
+}
+
+export interface ProviderGroup {
+  group: string
+  presets: ProviderPreset[]
+}
+
+/**
+ * 国内 LLM 供应商预设配置。
+ *
+ * base_url 约定：router 拼接 {base_url}/v1/chat/completions (OpenAI) 或
+ * {base_url}/v1/messages (Anthropic)。
+ * 对于使用非标准版本路径的供应商（如 /v3/、/v4/），保留完整路径前缀。
+ */
+export const PROVIDER_PRESETS: ProviderGroup[] = [
+  {
+    group: '智谱',
+    presets: [
+      {
+        plan: '标准',
+        presetName: '智谱',
+        apiType: 'openai',
+        baseUrl: 'https://open.bigmodel.cn/api/paas/v4',
+        models: ['glm-5.1', 'glm-5', 'glm-5-turbo', 'glm-4.7', 'glm-4.7-flash', 'glm-4.6'],
+      },
+      {
+        plan: 'Coding Plan',
+        presetName: '智谱 Coding Plan',
+        apiType: 'openai',
+        baseUrl: 'https://open.bigmodel.cn/api/coding/paas/v4',
+        models: ['glm-5.1', 'glm-5-turbo', 'glm-4.7', 'glm-4.5-air'],
+      },
+    ],
+  },
+  {
+    group: 'KIMI',
+    presets: [
+      {
+        plan: '标准',
+        presetName: 'KIMI',
+        apiType: 'openai',
+        baseUrl: 'https://api.moonshot.cn',
+        models: ['kimi-k2.5', 'kimi-k2-0905-preview', 'kimi-k2-turbo-preview', 'kimi-k2-thinking', 'kimi-k2-thinking-turbo', 'moonshot-v1-128k'],
+      },
+    ],
+  },
+  {
+    group: 'Minimax',
+    presets: [
+      {
+        plan: '标准',
+        presetName: 'Minimax',
+        apiType: 'openai',
+        baseUrl: 'https://api.minimax.chat',
+        models: ['MiniMax-M2.7', 'MiniMax-M2.7-highspeed', 'MiniMax-M2.5', 'MiniMax-M2.5-highspeed', 'MiniMax-M2.1', 'MiniMax-M2'],
+      },
+    ],
+  },
+  {
+    group: '火山引擎',
+    presets: [
+      {
+        plan: '标准',
+        presetName: '火山引擎',
+        apiType: 'openai',
+        baseUrl: 'https://ark.cn-beijing.volces.com/api/v3',
+        models: ['doubao-seed-2-0-pro-260215', 'doubao-seed-1-8-251228', 'doubao-seed-code-preview-251028'],
+      },
+      {
+        plan: 'Coding Plan',
+        presetName: '火山引擎 Coding Plan',
+        apiType: 'openai',
+        baseUrl: 'https://ark.cn-beijing.volces.com/api/coding/v3',
+        models: ['ark-code-latest', 'doubao-seed-code', 'doubao-seed-2.0-code', 'kimi-k2.5', 'glm-4.7'],
+      },
+    ],
+  },
+  {
+    group: '阿里云',
+    presets: [
+      {
+        plan: '标准',
+        presetName: '阿里云百炼',
+        apiType: 'openai',
+        baseUrl: 'https://dashscope.aliyuncs.com/compatible-mode',
+        models: ['qwen3.6-plus', 'qwen3.5-plus', 'qwen3-max', 'qwen3.5-flash', 'qwen3-coder-plus', 'qwen3-coder-next'],
+      },
+      {
+        plan: 'Coding Plan',
+        presetName: '阿里云 Coding Plan',
+        apiType: 'openai',
+        baseUrl: 'https://coding.dashscope.aliyuncs.com',
+        models: ['qwen3.6-plus', 'qwen3-coder-next', 'qwen3-coder-plus', 'kimi-k2.5', 'glm-5', 'MiniMax-M2.5'],
+      },
+    ],
+  },
+  {
+    group: '腾讯云',
+    presets: [
+      {
+        plan: '标准',
+        presetName: '腾讯云混元',
+        apiType: 'openai',
+        baseUrl: 'https://api.hunyuan.cloud.tencent.com',
+        models: ['hunyuan-2.0-thinking', 'hunyuan-2.0-instruct', 'hunyuan-t1-latest', 'hunyuan-a13b', 'hunyuan-turbos-latest'],
+      },
+      {
+        plan: 'Coding Plan',
+        presetName: '腾讯云 Coding Plan',
+        apiType: 'openai',
+        baseUrl: 'https://api.lkeap.cloud.tencent.com/coding/v3',
+        models: ['tc-code-latest', 'hunyuan-2.0-instruct', 'hunyuan-2.0-thinking', 'hunyuan-turbos', 'hunyuan-t1', 'glm-5', 'kimi-k2.5'],
+      },
+    ],
+  },
+  {
+    group: '阶跃星辰',
+    presets: [
+      {
+        plan: '标准',
+        presetName: '阶跃星辰',
+        apiType: 'openai',
+        baseUrl: 'https://api.stepfun.com',
+        models: ['step-3.5-flash', 'step-3', 'step-2-mini', 'step-2-16k', 'step-1-8k', 'step-1-32k'],
+      },
+      {
+        plan: 'Step Plan',
+        presetName: '阶跃星辰 Step Plan',
+        apiType: 'openai',
+        baseUrl: 'https://api.stepfun.com/step_plan',
+        models: ['step-3.5-flash', 'step-3.5-flash-2603'],
+      },
+    ],
+  },
+]

--- a/frontend/src/views/Logs.vue
+++ b/frontend/src/views/Logs.vue
@@ -263,6 +263,7 @@
 import { ref, reactive, onMounted } from 'vue'
 import { toast } from 'vue-sonner'
 import { api } from '@/api/client'
+import { useClipboard } from '@/composables/useClipboard'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -324,6 +325,7 @@ const sectionModes = reactive<Record<SectionKey, 'structured' | 'raw'>>({
   client_response: 'structured',
 })
 const copiedSection = ref<SectionKey | null>(null)
+const { copy: clipboardCopy } = useClipboard()
 
 function getSectionRaw(key: SectionKey): string {
   if (!detailData.value) return '{}'
@@ -337,11 +339,11 @@ function getSectionRaw(key: SectionKey): string {
 }
 
 async function copySection(key: SectionKey) {
-  try {
-    await navigator.clipboard.writeText(getSectionRaw(key))
+  const ok = await clipboardCopy(getSectionRaw(key))
+  if (ok) {
     copiedSection.value = key
     setTimeout(() => { copiedSection.value = null }, 2000) // eslint-disable-line no-magic-numbers
-  } catch {
+  } else {
     toast.error('复制失败')
   }
 }

--- a/frontend/src/views/Providers.vue
+++ b/frontend/src/views/Providers.vue
@@ -58,6 +58,29 @@
           <DialogTitle>{{ editingId ? '编辑供应商' : '添加供应商' }}</DialogTitle>
         </DialogHeader>
         <form @submit.prevent="handleSave" class="space-y-3">
+          <!-- 快速配置 -->
+          <div class="rounded-md border bg-muted/40 p-3 space-y-2">
+            <div class="text-xs font-medium text-muted-foreground">快速配置</div>
+            <div class="flex gap-2">
+              <Select v-model="presetGroup" @update:model-value="onGroupChange">
+                <SelectTrigger class="flex-1">
+                  <SelectValue placeholder="选择供应商" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem v-for="g in PROVIDER_PRESETS" :key="g.group" :value="g.group">{{ g.group }}</SelectItem>
+                </SelectContent>
+              </Select>
+              <Select v-model="presetPlan" @update:model-value="onPresetChange" :disabled="!presetGroup">
+                <SelectTrigger class="flex-1">
+                  <SelectValue placeholder="选择套餐" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem v-for="p in availablePlans" :key="p.plan" :value="p.plan">{{ p.plan }}</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+
           <div>
             <Label class="block text-sm font-medium text-foreground mb-1">名称</Label>
             <Input v-model="form.name" type="text" required />
@@ -124,9 +147,10 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import { toast } from 'vue-sonner'
 import { api } from '@/api/client'
+import { PROVIDER_PRESETS } from '@/data/provider-presets'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -155,6 +179,28 @@ const dialogOpen = ref(false)
 const editingId = ref<string | null>(null)
 const deleteTarget = ref<Provider | null>(null)
 const form = ref({ ...DEFAULT_FORM })
+
+// 预设级联状态
+const presetGroup = ref('')
+const presetPlan = ref('')
+
+const availablePlans = computed(() => {
+  if (!presetGroup.value) return []
+  return PROVIDER_PRESETS.find(g => g.group === presetGroup.value)?.presets ?? []
+})
+
+function onGroupChange() {
+  presetPlan.value = ''
+}
+
+function onPresetChange() {
+  const preset = availablePlans.value.find(p => p.plan === presetPlan.value)
+  if (!preset) return
+  form.value.name = preset.presetName
+  form.value.api_type = preset.apiType
+  form.value.base_url = preset.baseUrl
+  form.value.models = [...preset.models]
+}
 
 async function loadProviders() {
   try {
@@ -186,6 +232,8 @@ function openCreate() {
   editingId.value = null
   form.value = { name: '', api_type: 'openai', base_url: '', api_key: '', models: [], is_active: true }
   modelInput.value = ''
+  presetGroup.value = ''
+  presetPlan.value = ''
   dialogOpen.value = true
 }
 
@@ -193,6 +241,8 @@ function openEdit(p: Provider) {
   editingId.value = p.id
   form.value = { name: p.name, api_type: p.api_type, base_url: p.base_url, api_key: '', models: [...(p.models || [])], is_active: !!p.is_active }
   modelInput.value = ''
+  presetGroup.value = ''
+  presetPlan.value = ''
   dialogOpen.value = true
 }
 

--- a/frontend/src/views/Providers.vue
+++ b/frontend/src/views/Providers.vue
@@ -90,7 +90,10 @@
                 <Button type="button" variant="ghost" size="icon" class="h-4 w-4 rounded-full hover:bg-muted p-0 text-xs leading-none" @click="removeModel(i)">&times;</Button>
               </Badge>
             </div>
-            <Input v-model="modelInput" placeholder="输入模型名称，按 Enter 添加" @keydown.enter.prevent="addModel" />
+            <div class="flex gap-2">
+              <Input v-model="modelInput" placeholder="输入模型名称，多个用逗号分隔" @keydown.enter.prevent="addModel" class="flex-1" />
+              <Button type="button" variant="outline" size="sm" @click="addModel" :disabled="!modelInput.trim()">添加</Button>
+            </div>
           </div>
           <div class="flex items-center gap-2">
             <Checkbox v-model="form.is_active" id="svc-active" />
@@ -164,9 +167,13 @@ async function loadProviders() {
 }
 
 function addModel() {
-  const name = modelInput.value.trim()
-  if (name && !form.value.models.includes(name)) {
-    form.value.models.push(name)
+  const input = modelInput.value.trim()
+  if (!input) return
+  const names = input.split(/[,，]/).map(s => s.trim()).filter(Boolean)
+  for (const name of names) {
+    if (!form.value.models.includes(name)) {
+      form.value.models.push(name)
+    }
   }
   modelInput.value = ''
 }

--- a/frontend/src/views/RouterKeys.vue
+++ b/frontend/src/views/RouterKeys.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/multi-word-component-names -->
 <template>
   <div class="p-6">
     <div class="flex items-center justify-between mb-4">
@@ -26,8 +27,8 @@
             <TableCell>
               <div class="flex items-center gap-1">
                 <span class="font-mono text-xs text-muted-foreground">{{ k.key }}</span>
-                <Button variant="ghost" size="sm" class="h-6 w-6 p-0" @click="copyKeyOf(k.id, k.key)">
-                  <svg v-if="copiedId !== k.id" class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <Button variant="ghost" size="sm" class="h-6 w-6 p-0" @click="tableCopy(k.key)">
+                  <svg v-if="!tableCopied" class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"/>
                   </svg>
                   <svg v-else class="w-3.5 h-3.5 text-success" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -118,7 +119,7 @@
         <div class="space-y-3">
           <p class="text-sm text-muted-foreground">请立即保存此密钥，关闭后将无法再次查看完整密钥。</p>
           <div class="bg-muted rounded-md p-3 font-mono text-sm break-all select-all">{{ createdKey }}</div>
-          <Button variant="outline" size="sm" @click="copyKey">{{ copied ? '已复制' : '复制密钥' }}</Button>
+          <Button variant="outline" size="sm" @click="dialogCopy(createdKey)">{{ dialogCopied ? '已复制' : '复制密钥' }}</Button>
         </div>
         <DialogFooter>
           <Button @click="showKeyDialog = false">我已保存密钥</Button>
@@ -146,6 +147,7 @@
 import { ref, onMounted } from 'vue'
 import { toast } from 'vue-sonner'
 import { api } from '@/api/client'
+import { useClipboard } from '@/composables/useClipboard'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -166,7 +168,6 @@ interface RouterKey {
 }
 
 const DEFAULT_FORM = { name: '', allowed_models: [] as string[], is_active: true }
-const COPY_FEEDBACK_MS = 2000
 
 const keys = ref<RouterKey[]>([])
 const availableModels = ref<string[]>([])
@@ -177,8 +178,8 @@ const form = ref({ ...DEFAULT_FORM, allowed_models: [] as string[] })
 
 const showKeyDialog = ref(false)
 const createdKey = ref('')
-const copied = ref(false)
-const copiedId = ref('')
+const { copied: dialogCopied, copy: dialogCopy } = useClipboard()
+const { copied: tableCopied, copy: tableCopy } = useClipboard()
 
 function formatDate(dateStr: string): string {
   return new Date(dateStr).toLocaleString('zh-CN')
@@ -267,28 +268,6 @@ async function handleDelete() {
   } catch (e) {
     console.error('Failed to delete router key:', e)
     toast.error('删除密钥失败')
-  }
-}
-
-async function copyKey() {
-  try {
-    await navigator.clipboard.writeText(createdKey.value)
-    copied.value = true
-    setTimeout(() => { copied.value = false }, COPY_FEEDBACK_MS)
-  } catch (e) {
-    console.error('Failed to copy key:', e)
-    toast.error('复制失败')
-  }
-}
-
-async function copyKeyOf(id: string, key: string) {
-  try {
-    await navigator.clipboard.writeText(key)
-    copiedId.value = id
-    setTimeout(() => { copiedId.value = '' }, COPY_FEEDBACK_MS)
-  } catch (e) {
-    console.error('Failed to copy key:', e)
-    toast.error('复制失败')
   }
 }
 

--- a/frontend/src/views/Setup.vue
+++ b/frontend/src/views/Setup.vue
@@ -77,7 +77,7 @@ async function handleSetup() {
   loading.value = true
   try {
     await api.initializeSetup(password.value)
-    router.push('/login')
+    router.push('/admin/dashboard')
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } catch (e: any) {
     error.value = e.response?.data?.error?.message || '设置失败'

--- a/src/admin/setup.ts
+++ b/src/admin/setup.ts
@@ -1,6 +1,7 @@
 import { FastifyPluginCallback } from "fastify";
 import Database from "better-sqlite3";
 import { randomBytes } from "node:crypto";
+import jwt from "jsonwebtoken";
 import { getSetting, setSetting, isInitialized } from "../db/settings.js";
 import { hashPassword } from "../utils/password.js";
 
@@ -36,6 +37,18 @@ export const adminSetupRoutes: FastifyPluginCallback<SetupOptions> = (app, optio
     if (alreadyInitialized) {
       return reply.code(409).send({ error: { message: "Already initialized" } });
     }
+
+    // 自动登录：签发 JWT
+    const TOKEN_EXPIRY_SECONDS = 172800; // 48 hours，与 admin-auth 保持一致
+    const secret = getSetting(db, "jwt_secret");
+    const token = jwt.sign({ role: "admin" }, secret!, { expiresIn: TOKEN_EXPIRY_SECONDS });
+    reply.setCookie("admin_token", token, {
+      path: "/admin",
+      httpOnly: true,
+      secure: process.env.NODE_ENV === "production",
+      sameSite: "lax",
+      maxAge: TOKEN_EXPIRY_SECONDS,
+    });
 
     return { success: true };
   });

--- a/src/middleware/admin-auth.ts
+++ b/src/middleware/admin-auth.ts
@@ -54,7 +54,7 @@ const adminAuthRaw: FastifyPluginCallback<AdminAuthOptions> = (app, options, don
 export const adminAuthPlugin = fp(adminAuthRaw, { name: "admin-auth" });
 
 export const adminLoginRoutes: FastifyPluginCallback<AdminAuthOptions> = (app, options, done) => {
-  const TOKEN_EXPIRY_SECONDS = 86400;
+  const TOKEN_EXPIRY_SECONDS = 172800; // 48 hours
 
   app.post("/admin/api/login", async (request, reply) => {
     const { password } = request.body as { password?: string };


### PR DESCRIPTION
## Summary

- 修复 API 密钥页、日志详情页、JSON 复制块的复制按钮失效问题（创建 useClipboard composable，增加 execCommand fallback）
- 优化供应商模型输入交互：添加可见"添加"按钮 + 逗号分隔批量输入
- Setup 完成后自动登录（JWT 签发），token 有效期从 24h 延长至 48h
- 添加 7 家国内 LLM 供应商预设配置（智谱、KIMI、Minimax、火山引擎、阿里云、腾讯云、阶跃星辰）
- 供应商对话框增加级联快速配置下拉框（供应商 → 套餐）
- Coding Plan 预设全部使用 Anthropic 协议端点，新增 KIMI Coding Plan 和 Minimax Token Plan

## Test plan

- [ ] 在 HTTP 环境下测试所有复制按钮是否正常工作
- [ ] 测试供应商添加对话框的级联下拉框选择后字段可自由修改
- [ ] 测试模型输入：Enter 触发 + 点击添加按钮 + 逗号分隔批量添加
- [ ] 首次 Setup 后验证自动跳转到 Dashboard（无需再次登录）
- [ ] 验证 48h 后 token 过期

🤖 Generated with [Claude Code](https://claude.com/claude-code)