### PR TITLE
feat: dynamic model switching for Claude Code

### DIFF
--- a/.superpowers/2026-04-18-proxy-enhancement-tabs/plan-task1-db-migration.md
+++ b/.superpowers/2026-04-18-proxy-enhancement-tabs/plan-task1-db-migration.md
@@ -1,0 +1,349 @@
+# Task 1: 数据库迁移 + CRUD
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:test-driven-development. Write failing test first, then implement.
+
+**Goal:** 创建 `session_model_states` 和 `session_model_history` 两张表，以及对应的 CRUD 模块。
+
+**Depends on:** 无（首个任务）
+
+---
+
+## Step 1: 写失败测试
+
+> 前置：确认迁移计数为 15，新迁移后应为 16。
+
+- [ ] 在 `tests/db.test.ts` 末尾追加新的 `describe("session states", ...)` 块。
+
+**文件:** `tests/db.test.ts`
+
+在现有最后一个 `});` 之后追加：
+
+```ts
+describe("session states", () => {
+  let db: Database.Database;
+
+  afterEach(() => {
+    if (db) db.close();
+  });
+
+  function setupDb(): Database.Database {
+    db = initDatabase(":memory:");
+    const now = new Date().toISOString();
+    db.prepare(
+      `INSERT INTO providers (id, name, api_type, base_url, api_key, is_active, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+    ).run("prov-1", "Test", "openai", "https://api.openai.com", "key", 1, now, now);
+    db.prepare(
+      `INSERT INTO router_keys (id, name, key_hash, key_prefix, key_encrypted, is_active, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+    ).run("rk-1", "Test Key", "hash1", "sk-", "enc", 1, now, now);
+    return db;
+  }
+
+  it("should create session state and query it back", () => {
+    const database = setupDb();
+    const id = upsertSessionState(database, {
+      router_key_id: "rk-1",
+      session_id: "sess-001",
+      current_model: "claude-sonnet-4-20250514",
+      original_model: "claude-sonnet-4-20250514",
+    });
+
+    const states = getSessionStates(database);
+    expect(states).toHaveLength(1);
+    expect(states[0].session_id).toBe("sess-001");
+    expect(states[0].current_model).toBe("claude-sonnet-4-20250514");
+    expect(states[0].router_key_name).toBe("Test Key");
+  });
+
+  it("should upsert update existing state", () => {
+    const database = setupDb();
+    upsertSessionState(database, {
+      router_key_id: "rk-1",
+      session_id: "sess-001",
+      current_model: "claude-sonnet-4-20250514",
+      original_model: "claude-sonnet-4-20250514",
+    });
+
+    const id2 = upsertSessionState(database, {
+      router_key_id: "rk-1",
+      session_id: "sess-001",
+      current_model: "claude-opus-4-20250514",
+      original_model: "claude-sonnet-4-20250514",
+    });
+
+    const states = getSessionStates(database);
+    expect(states).toHaveLength(1);
+    expect(states[0].current_model).toBe("claude-opus-4-20250514");
+  });
+
+  it("should insert and query history", () => {
+    const database = setupDb();
+    insertSessionHistory(database, {
+      router_key_id: "rk-1",
+      session_id: "sess-001",
+      old_model: "claude-sonnet-4-20250514",
+      new_model: "claude-opus-4-20250514",
+      trigger_type: "directive",
+    });
+
+    const history = getSessionHistory(database, "rk-1", "sess-001");
+    expect(history).toHaveLength(1);
+    expect(history[0].old_model).toBe("claude-sonnet-4-20250514");
+    expect(history[0].new_model).toBe("claude-opus-4-20250514");
+    expect(history[0].trigger_type).toBe("directive");
+  });
+
+  it("should delete session state", () => {
+    const database = setupDb();
+    upsertSessionState(database, {
+      router_key_id: "rk-1",
+      session_id: "sess-001",
+      current_model: "claude-sonnet-4-20250514",
+      original_model: "claude-sonnet-4-20250514",
+    });
+
+    deleteSessionState(database, "rk-1", "sess-001");
+    const states = getSessionStates(database);
+    expect(states).toHaveLength(0);
+  });
+});
+```
+
+同时在测试文件顶部 import 中追加：
+
+```ts
+import {
+  getSessionStates,
+  getSessionHistory,
+  upsertSessionState,
+  insertSessionHistory,
+  deleteSessionState,
+} from "../src/db/index.js";
+```
+
+- [ ] 运行测试，确认失败（import 找不到）：
+
+```bash
+npx vitest run tests/db.test.ts
+```
+
+---
+
+## Step 2: 创建迁移文件
+
+- [ ] 创建 `src/db/migrations/016_create_session_model_tables.sql`
+
+**文件:** `src/db/migrations/016_create_session_model_tables.sql`
+
+```sql
+CREATE TABLE IF NOT EXISTS session_model_states (
+  id TEXT PRIMARY KEY,
+  router_key_id TEXT NOT NULL,
+  session_id TEXT NOT NULL,
+  current_model TEXT NOT NULL,
+  original_model TEXT,
+  last_active_at TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  UNIQUE(router_key_id, session_id),
+  FOREIGN KEY (router_key_id) REFERENCES router_keys(id)
+);
+CREATE INDEX idx_sms_router_key ON session_model_states(router_key_id);
+
+CREATE TABLE IF NOT EXISTS session_model_history (
+  id TEXT PRIMARY KEY,
+  router_key_id TEXT NOT NULL,
+  session_id TEXT NOT NULL,
+  old_model TEXT,
+  new_model TEXT NOT NULL,
+  trigger_type TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  FOREIGN KEY (router_key_id) REFERENCES router_keys(id)
+);
+CREATE INDEX idx_smh_session ON session_model_history(router_key_id, session_id);
+```
+
+---
+
+## Step 3: 实现 CRUD 模块
+
+- [ ] 创建 `src/db/session-states.ts`
+
+**文件:** `src/db/session-states.ts`
+
+```ts
+import Database from "better-sqlite3";
+import { randomUUID } from "crypto";
+
+// --- Types ---
+
+export interface SessionModelState {
+  id: string;
+  router_key_id: string;
+  router_key_name?: string;
+  session_id: string;
+  current_model: string;
+  original_model: string | null;
+  last_active_at: string;
+  created_at: string;
+}
+
+export interface SessionModelHistory {
+  id: string;
+  router_key_id: string;
+  session_id: string;
+  old_model: string | null;
+  new_model: string;
+  trigger_type: string;
+  created_at: string;
+}
+
+export interface UpsertSessionStateInput {
+  id?: string;
+  router_key_id: string;
+  session_id: string;
+  current_model: string;
+  original_model?: string | null;
+}
+
+export interface InsertSessionHistoryInput {
+  router_key_id: string;
+  session_id: string;
+  old_model?: string | null;
+  new_model: string;
+  trigger_type: string;
+}
+
+// --- CRUD ---
+
+export function getSessionStates(db: Database.Database): SessionModelState[] {
+  return db.prepare(
+    `SELECT sms.*, rk.name AS router_key_name
+     FROM session_model_states sms
+     JOIN router_keys rk ON rk.id = sms.router_key_id
+     ORDER BY sms.last_active_at DESC`
+  ).all() as SessionModelState[];
+}
+
+export function getSessionHistory(
+  db: Database.Database,
+  routerKeyId: string,
+  sessionId: string,
+): SessionModelHistory[] {
+  return db.prepare(
+    `SELECT * FROM session_model_history
+     WHERE router_key_id = ? AND session_id = ?
+     ORDER BY created_at DESC`
+  ).all(routerKeyId, sessionId) as SessionModelHistory[];
+}
+
+export function upsertSessionState(
+  db: Database.Database,
+  input: UpsertSessionStateInput,
+): string {
+  const now = new Date().toISOString();
+  const id = input.id ?? randomUUID();
+
+  db.prepare(
+    `INSERT INTO session_model_states (id, router_key_id, session_id, current_model, original_model, last_active_at, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT(router_key_id, session_id) DO UPDATE SET
+       current_model = excluded.current_model,
+       original_model = excluded.original_model,
+       last_active_at = excluded.last_active_at`
+  ).run(
+    id,
+    input.router_key_id,
+    input.session_id,
+    input.current_model,
+    input.original_model ?? null,
+    now,
+    now,
+  );
+
+  return id;
+}
+
+export function insertSessionHistory(
+  db: Database.Database,
+  input: InsertSessionHistoryInput,
+): string {
+  const id = randomUUID();
+  const now = new Date().toISOString();
+
+  db.prepare(
+    `INSERT INTO session_model_history (id, router_key_id, session_id, old_model, new_model, trigger_type, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`
+  ).run(
+    id,
+    input.router_key_id,
+    input.session_id,
+    input.old_model ?? null,
+    input.new_model,
+    input.trigger_type,
+    now,
+  );
+
+  return id;
+}
+
+export function deleteSessionState(
+  db: Database.Database,
+  routerKeyId: string,
+  sessionId: string,
+): void {
+  db.prepare(
+    `DELETE FROM session_model_states WHERE router_key_id = ? AND session_id = ?`
+  ).run(routerKeyId, sessionId);
+}
+
+export function getSessionState(
+  db: Database.Database,
+  routerKeyId: string,
+  sessionId: string,
+): SessionModelState | undefined {
+  return db.prepare(
+    `SELECT * FROM session_model_states WHERE router_key_id = ? AND session_id = ?`
+  ).get(routerKeyId, sessionId) as SessionModelState | undefined;
+}
+```
+
+---
+
+## Step 4: 更新 re-export
+
+- [ ] 在 `src/db/index.ts` 追加 re-export
+
+**文件:** `src/db/index.ts`
+
+在文件末尾（`export { getSetting, setSetting, isInitialized } from "./settings.js";` 之后）追加：
+
+```ts
+export {
+  getSessionStates,
+  getSessionState,
+  getSessionHistory,
+  upsertSessionState,
+  insertSessionHistory,
+  deleteSessionState,
+} from "./session-states.js";
+export type { SessionModelState, SessionModelHistory, UpsertSessionStateInput, InsertSessionHistoryInput } from "./session-states.js";
+```
+
+---
+
+## Step 5: 更新迁移计数断言
+
+- [ ] 在 `tests/db.test.ts` 的 "should record migration in migrations table" 测试中，将 `expect(rows.length).toBe(15)` 改为 `expect(rows.length).toBe(16)`。
+
+---
+
+## Step 6: 运行测试确认通过
+
+- [ ] 执行：
+
+```bash
+npx vitest run tests/db.test.ts
+```
+
+所有测试应通过，包括新增的 4 个 session states 测试和更新后的迁移计数断言。

--- a/.superpowers/2026-04-18-proxy-enhancement-tabs/plan-task2-model-state.md
+++ b/.superpowers/2026-04-18-proxy-enhancement-tabs/plan-task2-model-state.md
@@ -1,0 +1,389 @@
+# Task 2: ModelStateManager 改造 + Enhancement Handler + Proxy Core
+
+> 依赖：Task 1（DB 迁移 + `src/db/session-states.ts` CRUD 模块）已完成
+> 本 Task 拥有 `model-state.ts`、`enhancement-handler.ts`、`proxy-core.ts`、`src/index.ts` 的修改权
+
+## 总览
+
+将 `ModelStateManager` 从纯内存 Map 改为「内存优先 + DB 持久化」双写架构。同时更新所有调用链：proxy-core → enhancement-handler → model-state。
+
+---
+
+## Step 1: 写测试 — 新增 session-scoped 测试用例
+
+文件：`tests/model-state.test.ts`
+
+在现有测试之后新增一个 `describe("session-scoped", ...)` 块。需要一个 mock DB 对象来验证双写行为。
+
+```ts
+function createMockDb() {
+  return {
+    transaction: vi.fn((fn) => (...args: unknown[]) => fn(...args)),
+    prepare: vi.fn(() => ({
+      run: vi.fn(),
+      get: vi.fn(),
+      all: vi.fn(),
+    })),
+  };
+}
+```
+
+测试骨架（8 个用例）：
+
+```ts
+describe("session-scoped", () => {
+  let mgr: ModelStateManager;
+  let mockDb: ReturnType<typeof createMockDb>;
+
+  beforeEach(() => {
+    mockDb = createMockDb();
+    mgr = new ModelStateManager(mockDb as unknown as Database.Database);
+    vi.useFakeTimers();
+  });
+
+  it("set with sessionId 写入内存", () => {
+    mgr.set("key-1", "glm-5.1", "sess-1");
+    expect(mgr.get("key-1", "sess-1")).toBe("glm-5.1");
+  });
+
+  it("set with sessionId 调用 DB transaction", () => {
+    mgr.set("key-1", "glm-5.1", "sess-1");
+    expect(mockDb.transaction).toHaveBeenCalled();
+  });
+
+  it("get 内存命中时不查 DB", () => {
+    mgr.set("key-1", "glm-5.1", "sess-1");
+    const result = mgr.get("key-1", "sess-1");
+    expect(result).toBe("glm-5.1");
+    // prepare 不应被调用（无 DB 读取）
+    expect(mockDb.prepare).not.toHaveBeenCalled();
+  });
+
+  it("get 内存 miss 时查 DB 并回填", () => {
+    // 模拟 DB 返回
+    const mockGet = vi.fn().mockReturnValue({
+      current_model: "deepseek-v3",
+      last_active_at: new Date().toISOString(),
+    });
+    mockDb.prepare.mockReturnValue({ get: mockGet, run: vi.fn(), all: vi.fn() });
+
+    const result = mgr.get("key-1", "sess-1");
+    expect(result).toBe("deepseek-v3");
+    expect(mockGet).toHaveBeenCalled();
+    // 验证内存回填
+    expect(mgr.get("key-1", "sess-1")).toBe("deepseek-v3");
+  });
+
+  it("get 内存 miss + DB miss 返回 null", () => {
+    mockDb.prepare.mockReturnValue({ get: vi.fn().mockReturnValue(undefined), run: vi.fn(), all: vi.fn() });
+    expect(mgr.get("key-1", "sess-1")).toBeNull();
+  });
+
+  it("delete 清理内存 + DB", () => {
+    mgr.set("key-1", "glm-5.1", "sess-1");
+    mgr.delete("key-1", "sess-1");
+    expect(mgr.get("key-1", "sess-1")).toBeNull();
+    expect(mockDb.transaction).toHaveBeenCalled();
+  });
+
+  it("set default with sessionId 删除内存 + DB", () => {
+    mgr.set("key-1", "glm-5.1", "sess-1");
+    mgr.set("key-1", "default", "sess-1");
+    expect(mgr.get("key-1", "sess-1")).toBeNull();
+  });
+
+  it("无 sessionId 保持原有行为", () => {
+    mgr.set("key-1", "glm-5.1");
+    expect(mgr.get("key-1")).toBe("glm-5.1");
+  });
+
+  it("不同 sessionId 之间隔离", () => {
+    mgr.set("key-1", "glm-5.1", "sess-1");
+    mgr.set("key-1", "deepseek-v3", "sess-2");
+    expect(mgr.get("key-1", "sess-1")).toBe("glm-5.1");
+    expect(mgr.get("key-1", "sess-2")).toBe("deepseek-v3");
+  });
+});
+```
+
+**验证命令：** `npx vitest run tests/model-state.test.ts`（预期失败）
+
+- [ ] Step 1 完成
+
+---
+
+## Step 2: 改造 ModelStateManager
+
+文件：`src/proxy/model-state.ts`
+
+完整替换为：
+
+```ts
+import type Database from "better-sqlite3";
+import { randomUUID } from "crypto";
+import {
+  upsertSessionState,
+  getSessionState,
+  deleteSessionState,
+  insertSessionHistory,
+} from "../db/session-states.js";
+
+const HOUR_MS = 3600_000;
+const TTL_HOURS = 24;
+const TTL_MS = TTL_HOURS * HOUR_MS;
+
+interface StateEntry {
+  model: string;
+  updatedAt: number;
+}
+
+export class ModelStateManager {
+  private store = new Map<string, StateEntry>();
+  private db?: Database.Database;
+
+  constructor(db?: Database.Database) {
+    this.db = db;
+  }
+
+  /** 运行时注入数据库实例（用于 singleton 场景） */
+  init(db: Database.Database): void {
+    this.db = db;
+  }
+
+  private buildKey(routerKeyId: string | null, sessionId?: string): string {
+    const base = routerKeyId ?? "null";
+    return sessionId ? `${base}:${sessionId}` : base;
+  }
+
+  set(
+    routerKeyId: string | null,
+    model: string,
+    sessionId?: string,
+    originalModel?: string,
+    triggerType?: "directive" | "command",
+  ): void {
+    const key = this.buildKey(routerKeyId, sessionId);
+
+    if (model === "default") {
+      this.store.delete(key);
+      if (sessionId && this.db && routerKeyId) {
+        this.deleteFromDb(routerKeyId, sessionId);
+      }
+      return;
+    }
+
+    this.store.set(key, { model, updatedAt: Date.now() });
+
+    if (sessionId && this.db && routerKeyId) {
+      this.writeToDb(routerKeyId, sessionId, model, originalModel, triggerType ?? "command");
+    }
+  }
+
+  get(routerKeyId: string | null, sessionId?: string): string | null {
+    const key = this.buildKey(routerKeyId, sessionId);
+    const entry = this.store.get(key);
+
+    if (entry) {
+      if (Date.now() - entry.updatedAt > TTL_MS) {
+        this.store.delete(key);
+        return null;
+      }
+      return entry.model;
+    }
+
+    // 内存 miss → 尝试 DB 回填
+    if (sessionId && this.db && routerKeyId) {
+      return this.loadFromDb(routerKeyId, sessionId);
+    }
+
+    return null;
+  }
+
+  delete(routerKeyId: string, sessionId: string): void {
+    const key = this.buildKey(routerKeyId, sessionId);
+    this.store.delete(key);
+
+    if (this.db) {
+      this.deleteFromDb(routerKeyId, sessionId);
+    }
+  }
+
+  private writeToDb(
+    routerKeyId: string,
+    sessionId: string,
+    model: string,
+    originalModel: string | undefined,
+    triggerType: "directive" | "command",
+  ): void {
+    try {
+      this.db!.transaction(() => {
+        upsertSessionState(this.db!, {
+          router_key_id: routerKeyId,
+          session_id: sessionId,
+          current_model: model,
+          original_model: originalModel ?? null,
+        });
+        insertSessionHistory(this.db!, {
+          router_key_id: routerKeyId,
+          session_id: sessionId,
+          old_model: originalModel,
+          new_model: model,
+          trigger_type: triggerType,
+        });
+      })();
+    } catch (err) {
+      // DB 写入失败不影响内存状态
+      console.error("Failed to persist session state:", err);
+    }
+  }
+
+  private loadFromDb(routerKeyId: string, sessionId: string): string | null {
+    try {
+      const row = getSessionState(this.db!, routerKeyId, sessionId);
+      if (!row) return null;
+      const key = this.buildKey(routerKeyId, sessionId);
+      this.store.set(key, { model: row.current_model, updatedAt: Date.now() });
+      return row.current_model;
+    } catch {
+      return null;
+    }
+  }
+
+  private deleteFromDb(routerKeyId: string, sessionId: string): void {
+    try {
+      this.db!.transaction(() => {
+        deleteSessionState(this.db!, routerKeyId, sessionId);
+        insertSessionHistory(this.db!, {
+          router_key_id: routerKeyId,
+          session_id: sessionId,
+          new_model: "default",
+          trigger_type: "manual_clear",
+        });
+      })();
+    } catch (err) {
+      console.error("Failed to delete session state:", err);
+    }
+  }
+}
+
+// singleton
+export const modelState = new ModelStateManager();
+```
+
+**关键点：**
+- `writeToDb` 在 `db.transaction()` 中同时调用 `upsertSessionState` + `insertSessionHistory`
+- `deleteFromDb` 在 `db.transaction()` 中同时调用 `deleteSessionState` + `insertSessionHistory(manual_clear)`
+- DB 函数参数使用 snake_case（与 `session-states.ts` 的接口一致）
+
+**验证命令：** `npx vitest run tests/model-state.test.ts`
+
+- [ ] Step 2 完成
+
+---
+
+## Step 3: 更新 enhancement-handler.ts — 透传 sessionId + triggerType
+
+文件：`src/proxy/enhancement-handler.ts`
+
+### 3.1 函数签名变更
+
+```ts
+export function applyEnhancement(
+  db: Database.Database,
+  request: FastifyRequest,
+  clientModel: string,
+  sessionId?: string,
+): EnhancementResult {
+```
+
+### 3.2 select-model 命令分支（~L65）
+
+```ts
+// 原来：modelState.set(routerKeyId, arg);
+modelState.set(routerKeyId, arg, sessionId, clientModel, "command");
+```
+
+### 3.3 内联指令分支（~L92）
+
+```ts
+// 原来：modelState.set(request.routerKey?.id ?? null, directive.modelName);
+modelState.set(request.routerKey?.id ?? null, directive.modelName, sessionId, clientModel, "directive");
+```
+
+### 3.4 会话记忆查询分支（~L101）
+
+```ts
+// 原来：const remembered = modelState.get(request.routerKey?.id ?? null);
+const remembered = modelState.get(request.routerKey?.id ?? null, sessionId);
+```
+
+**验证命令：** `npx vitest run tests/directive-parser.test.ts`
+
+- [ ] Step 3 完成
+
+---
+
+## Step 4: 更新 proxy-core.ts — 提取 sessionId header + init modelState
+
+### 4.1 proxy-core.ts：提取 header
+
+文件：`src/proxy/proxy-core.ts`
+
+在 `handleProxyPost` 中，`applyEnhancement` 调用之前添加 header 提取：
+
+```ts
+// 原来（L137）：
+// const { effectiveModel, originalModel, interceptResponse } = applyEnhancement(db, request, clientModel);
+
+// 改为：
+const sessionId = (request.headers as RawHeaders)["x-claude-code-session-id"] as string | undefined;
+const { effectiveModel, originalModel, interceptResponse } = applyEnhancement(db, request, clientModel, sessionId);
+```
+
+### 4.2 src/index.ts：init modelState
+
+在 `buildApp()` 中 db 初始化后，调用 `modelState.init(db)`：
+
+```ts
+import { modelState } from "./proxy/model-state.js";
+// ... 在 initDatabase(dbPath) 之后：
+modelState.init(db);
+```
+
+**验证命令：** `npm test`
+
+- [ ] Step 4 完成
+
+---
+
+## Step 5: 全量测试验证
+
+```bash
+# 1. model-state 单元测试
+npx vitest run tests/model-state.test.ts
+
+# 2. directive-parser 测试（确认无破坏）
+npx vitest run tests/directive-parser.test.ts
+
+# 3. 全量测试
+npm test
+
+# 4. TypeScript 编译检查
+npx tsc --noEmit
+```
+
+- [ ] Step 5 完成
+
+---
+
+## 检查清单
+
+| 检查项 | 标准 |
+|--------|------|
+| 无 sessionId 时行为不变 | 所有原有测试通过 |
+| 有 sessionId 时双写 | 内存 + DB states + history 均写入 |
+| get DB 回填 | 内存 miss 时从 DB 恢复 |
+| delete 双清 + history | 内存 + DB states 删除 + manual_clear history |
+| DB 失败降级 | 内存操作不受影响 |
+| triggerType 正确 | directive / command 区分 |
+| TypeScript 编译 | `npx tsc --noEmit` 无错误 |

--- a/.superpowers/2026-04-18-proxy-enhancement-tabs/plan-task3-admin-api.md
+++ b/.superpowers/2026-04-18-proxy-enhancement-tabs/plan-task3-admin-api.md
@@ -1,0 +1,236 @@
+# Task 3: 后端 Session API
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:test-driven-development. Write failing test first, then implement.
+
+**Goal:** 在 proxy-enhancement admin 路由中新增 3 个 session API 端点。
+
+**Depends on:** Task 1（session-states.ts 已存在）、Task 2（ModelStateManager 已支持复合键 + DB 双写 + modelState.delete 已实现）
+
+**注意：** `proxy-core.ts`、`enhancement-handler.ts`、`frontend/src/api/client.ts` 的修改分别在 Task 2 和 Task 4 中完成，本 Task 只负责 admin API 端点。
+
+---
+
+## Step 1: 写失败测试 — Session API 端点
+
+- [ ] 创建 `tests/admin-session-states.test.ts`
+
+**文件:** `tests/admin-session-states.test.ts`
+
+```ts
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { FastifyInstance } from "fastify";
+import { buildApp } from "../src/index.js";
+import { initDatabase } from "../src/db/index.js";
+import { setSetting } from "../src/db/settings.js";
+import { hashPassword } from "../src/utils/password.js";
+import {
+  upsertSessionState,
+  insertSessionHistory,
+} from "../src/db/session-states.js";
+
+const TEST_ENCRYPTION_KEY =
+  "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+function makeConfig() {
+  return {
+    PORT: 9981,
+    DB_PATH: ":memory:",
+    LOG_LEVEL: "silent",
+    TZ: "Asia/Shanghai",
+    STREAM_TIMEOUT_MS: 5000,
+    RETRY_MAX_ATTEMPTS: 0,
+    RETRY_BASE_DELAY_MS: 0,
+  };
+}
+
+async function login(app: FastifyInstance): Promise<string> {
+  const res = await app.inject({
+    method: "POST",
+    url: "/admin/api/login",
+    payload: { password: "test-admin-pass" },
+  });
+  const match = (res.headers["set-cookie"] as string).match(
+    /admin_token=([^;]+)/,
+  );
+  return `admin_token=${match![1]}`;
+}
+
+function seedSettings(db: ReturnType<typeof initDatabase>) {
+  setSetting(db, "encryption_key", TEST_ENCRYPTION_KEY);
+  setSetting(db, "jwt_secret", "test-jwt-secret-for-testing");
+  setSetting(db, "admin_password_hash", hashPassword("test-admin-pass"));
+  setSetting(db, "initialized", "true");
+}
+
+describe("Session States API", () => {
+  let app: FastifyInstance;
+  let db: ReturnType<typeof initDatabase>;
+  let close: () => Promise<void>;
+  let cookie: string;
+
+  beforeEach(async () => {
+    db = initDatabase(":memory:");
+    seedSettings(db);
+    const result = await buildApp({ config: makeConfig() as any, db });
+    app = result.app;
+    close = result.close;
+    cookie = await login(app);
+
+    // Seed: provider + router_key + session state + history
+    const now = new Date().toISOString();
+    db.prepare(
+      `INSERT INTO providers (id, name, api_type, base_url, api_key, is_active, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run("prov-1", "Test", "openai", "https://api.openai.com", "key", 1, now, now);
+    db.prepare(
+      `INSERT INTO router_keys (id, name, key_hash, key_prefix, key_encrypted, is_active, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run("rk-1", "Test Key", "hash1", "sk-", "enc", 1, now, now);
+
+    upsertSessionState(db, {
+      router_key_id: "rk-1",
+      session_id: "sess-001",
+      current_model: "claude-opus-4-20250514",
+      original_model: "claude-sonnet-4-20250514",
+    });
+    insertSessionHistory(db, {
+      router_key_id: "rk-1",
+      session_id: "sess-001",
+      old_model: "claude-sonnet-4-20250514",
+      new_model: "claude-opus-4-20250514",
+      trigger_type: "directive",
+    });
+  });
+
+  afterEach(async () => {
+    await close();
+  });
+
+  it("GET /admin/api/session-states returns list with router_key_name", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: "/admin/api/session-states",
+      headers: { cookie },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body).toHaveLength(1);
+    expect(body[0].session_id).toBe("sess-001");
+    expect(body[0].current_model).toBe("claude-opus-4-20250514");
+    expect(body[0].router_key_name).toBe("Test Key");
+  });
+
+  it("GET /admin/api/session-states/:keyId/:sessionId/history returns history", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: "/admin/api/session-states/rk-1/sess-001/history",
+      headers: { cookie },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body).toHaveLength(1);
+    expect(body[0].old_model).toBe("claude-sonnet-4-20250514");
+    expect(body[0].new_model).toBe("claude-opus-4-20250514");
+    expect(body[0].trigger_type).toBe("directive");
+  });
+
+  it("DELETE /admin/api/session-states/:keyId/:sessionId deletes state", async () => {
+    const delRes = await app.inject({
+      method: "DELETE",
+      url: "/admin/api/session-states/rk-1/sess-001",
+      headers: { cookie },
+    });
+    expect(delRes.statusCode).toBe(200);
+    expect(delRes.json()).toEqual({ success: true });
+
+    // Verify state is gone
+    const getRes = await app.inject({
+      method: "GET",
+      url: "/admin/api/session-states",
+      headers: { cookie },
+    });
+    expect(getRes.json()).toHaveLength(0);
+  });
+
+  it("unauthenticated access returns 401", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: "/admin/api/session-states",
+    });
+    expect(res.statusCode).toBe(401);
+  });
+});
+```
+
+- [ ] 运行测试，确认失败（路由不存在返回 404）：
+
+```bash
+npx vitest run tests/admin-session-states.test.ts
+```
+
+---
+
+## Step 2: 添加 3 个 Session API 路由
+
+- [ ] 修改 `src/admin/proxy-enhancement.ts`，追加 import 和 3 个路由。
+
+**文件:** `src/admin/proxy-enhancement.ts`
+
+在现有 import 追加：
+
+```ts
+import {
+  getSessionStates,
+  getSessionHistory,
+} from "../db/session-states.js";
+import { modelState } from "../proxy/model-state.js";
+```
+
+在 `app.put("/admin/api/proxy-enhancement", ...)` 之后、`done()` 之前追加 3 个路由：
+
+```ts
+app.get("/admin/api/session-states", async (_req, reply) => {
+  const states = getSessionStates(db);
+  return reply.send(states);
+});
+
+app.get<{ Params: { keyId: string; sessionId: string } }>(
+  "/admin/api/session-states/:keyId/:sessionId/history",
+  async (req, reply) => {
+    const { keyId, sessionId } = req.params;
+    const history = getSessionHistory(db, keyId, sessionId);
+    return reply.send(history);
+  },
+);
+
+app.delete<{ Params: { keyId: string; sessionId: string } }>(
+  "/admin/api/session-states/:keyId/:sessionId",
+  async (req, reply) => {
+    const { keyId, sessionId } = req.params;
+    modelState.delete(keyId, sessionId);
+    return reply.send({ success: true });
+  },
+);
+```
+
+> `modelState.delete` 已在 Task 2 中实现双写（内存 + DB + history），此处无需再调 `deleteSessionState`。
+
+---
+
+## Step 3: 运行测试确认通过
+
+- [ ] 执行：
+
+```bash
+npx vitest run tests/admin-session-states.test.ts
+```
+
+所有 4 个测试应通过。
+
+- [ ] 回归测试：
+
+```bash
+npm test
+```
+
+确认所有现有测试不受影响。

--- a/.superpowers/2026-04-18-proxy-enhancement-tabs/plan-task4-frontend.md
+++ b/.superpowers/2026-04-18-proxy-enhancement-tabs/plan-task4-frontend.md
@@ -1,0 +1,335 @@
+# Task 4: 前端改造 — Tabs + SessionTable
+
+> 前置：Task 1-3 完成后执行。后端 session API 已就绪。
+> 本 Task 拥有 `frontend/src/api/client.ts`、`ProxyEnhancement.vue`、`SessionTable.vue` 的修改权。
+
+---
+
+## Step 1: 更新前端 API 客户端
+
+- [ ] 修改 `frontend/src/api/client.ts`
+
+**1) 在 `API` 常量中 `PROXY_ENHANCEMENT` 行后追加：**
+
+```ts
+SESSION_STATES: '/session-states',
+```
+
+**2) 在 `RetryRulePayload` 接口之后追加类型定义（导出）：**
+
+```ts
+export interface SessionState {
+  id: string
+  router_key_id: string
+  router_key_name: string
+  session_id: string
+  current_model: string
+  original_model: string | null
+  last_active_at: string
+  created_at: string
+}
+
+export interface SessionHistoryEntry {
+  id: string
+  old_model: string | null
+  new_model: string
+  trigger_type: 'directive' | 'command' | 'manual_clear'
+  created_at: string
+}
+```
+
+**3) 在 `api` 对象的 `updateProxyEnhancement` 方法后追加 3 个方法：**
+
+```ts
+getSessionStates: () => request<SessionState[]>('get', API.SESSION_STATES),
+getSessionHistory: (keyId: string, sessionId: string) =>
+  request<SessionHistoryEntry[]>('get', `${API.SESSION_STATES}/${keyId}/${encodeURIComponent(sessionId)}/history`),
+deleteSessionState: (keyId: string, sessionId: string) =>
+  request<{ success: boolean }>('delete', `${API.SESSION_STATES}/${keyId}/${encodeURIComponent(sessionId)}`),
+```
+
+- [ ] Step 1 完成
+
+---
+
+## Step 2: 创建 SessionTable 子组件
+
+- [ ] 创建目录和文件
+
+```bash
+mkdir -p frontend/src/components/proxy-enhancement
+```
+
+**文件:** `frontend/src/components/proxy-enhancement/SessionTable.vue`
+
+```vue
+<template>
+  <div v-if="loading" class="text-center py-8 text-muted-foreground">加载中...</div>
+  <div v-else-if="sessions.length === 0" class="text-center py-8 text-muted-foreground">暂无活跃 Session</div>
+  <Table v-else>
+    <TableHeader>
+      <TableRow>
+        <TableHead>密钥名称</TableHead>
+        <TableHead>Session ID</TableHead>
+        <TableHead>当前模型</TableHead>
+        <TableHead>原始模型</TableHead>
+        <TableHead>最后活跃</TableHead>
+        <TableHead class="text-right">操作</TableHead>
+      </TableRow>
+    </TableHeader>
+    <TableBody>
+      <template v-for="session in sessions" :key="session.id">
+        <TableRow>
+          <TableCell class="font-medium">{{ session.router_key_name }}</TableCell>
+          <TableCell>
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger as-child>
+                  <span class="font-mono text-xs cursor-default">{{ shortId(session.session_id) }}</span>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p class="font-mono text-xs">{{ session.session_id }}</p>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          </TableCell>
+          <TableCell>{{ session.current_model }}</TableCell>
+          <TableCell class="text-muted-foreground">{{ session.original_model ?? '-' }}</TableCell>
+          <TableCell class="text-muted-foreground text-xs">{{ relativeTime(session.last_active_at) }}</TableCell>
+          <TableCell class="text-right space-x-1">
+            <Button variant="ghost" size="sm" @click="emit('viewHistory', session)">
+              {{ historyMap[session.session_id] ? '收起' : '历史' }}
+            </Button>
+            <Button variant="ghost" size="sm" class="text-destructive" @click="clearingSession = session">
+              清除
+            </Button>
+          </TableCell>
+        </TableRow>
+        <!-- 历史展开区域 -->
+        <TableRow v-if="historyMap[session.session_id]">
+          <TableCell colspan="6" class="bg-muted/50 px-8 py-3">
+            <div class="space-y-1 text-xs">
+              <div v-for="h in historyMap[session.session_id]" :key="h.id" class="flex items-center gap-2">
+                <span class="text-muted-foreground w-36">{{ formatTime(h.created_at) }}</span>
+                <span>{{ h.old_model ?? '(无)' }}</span>
+                <span class="text-muted-foreground">-></span>
+                <span>{{ h.new_model }}</span>
+                <Badge variant="outline" class="text-[10px] px-1 py-0">{{ h.trigger_type }}</Badge>
+              </div>
+            </div>
+          </TableCell>
+        </TableRow>
+      </template>
+    </TableBody>
+  </Table>
+
+  <!-- 清除确认弹窗 -->
+  <AlertDialog :open="!!clearingSession" @update:open="(v) => { if (!v) clearingSession = null }">
+    <AlertDialogContent>
+      <AlertDialogHeader>
+        <AlertDialogTitle>清除 Session</AlertDialogTitle>
+        <AlertDialogDescription>
+          确定要清除 session {{ clearingSession ? shortId(clearingSession.session_id) : '' }} 的模型配置吗？它将恢复使用默认模型。
+        </AlertDialogDescription>
+      </AlertDialogHeader>
+      <AlertDialogFooter>
+        <AlertDialogCancel>取消</AlertDialogCancel>
+        <AlertDialogAction @click="emit('clear', clearingSession!); clearingSession = null">确认</AlertDialogAction>
+      </AlertDialogFooter>
+    </AlertDialogContent>
+  </AlertDialog>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import type { SessionState, SessionHistoryEntry } from '@/api/client'
+import { Table, TableHeader, TableBody, TableRow, TableHead, TableCell } from '@/components/ui/table'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { TooltipProvider, Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
+import {
+  AlertDialog, AlertDialogContent, AlertDialogHeader, AlertDialogTitle,
+  AlertDialogDescription, AlertDialogFooter, AlertDialogCancel, AlertDialogAction,
+} from '@/components/ui/alert-dialog'
+
+const props = defineProps<{
+  sessions: SessionState[]
+  loading: boolean
+  historyMap: Record<string, SessionHistoryEntry[]>
+}>()
+
+const emit = defineEmits<{
+  clear: [session: SessionState]
+  viewHistory: [session: SessionState]
+}>()
+
+const clearingSession = ref<SessionState | null>(null)
+
+function shortId(id: string): string {
+  return id.slice(0, 8) + '...'
+}
+
+function relativeTime(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime()
+  const mins = Math.floor(diff / 60000)
+  if (mins < 1) return '刚刚'
+  if (mins < 60) return `${mins} 分钟前`
+  const hours = Math.floor(mins / 60)
+  if (hours < 24) return `${hours} 小时前`
+  return `${Math.floor(hours / 24)} 天前`
+}
+
+function formatTime(iso: string): string {
+  return new Date(iso).toLocaleString('zh-CN', {
+    month: '2-digit', day: '2-digit',
+    hour: '2-digit', minute: '2-digit', second: '2-digit',
+  })
+}
+</script>
+```
+
+- [ ] Step 2 完成
+
+---
+
+## Step 3: 修改 ProxyEnhancement.vue
+
+- [ ] 改造页面结构为 Tabs 布局 + 新增 Session 管理
+
+**文件:** `frontend/src/views/ProxyEnhancement.vue`
+
+**新增 import：**
+
+```ts
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
+import SessionTable from '@/components/proxy-enhancement/SessionTable.vue'
+import type { SessionState, SessionHistoryEntry } from '@/api/client'
+```
+
+**新增状态：**
+
+```ts
+const sessions = ref<SessionState[]>([])
+const sessionsLoading = ref(false)
+const sessionHistoryMap = ref<Record<string, SessionHistoryEntry[]>>({})
+```
+
+**新增函数：**
+
+```ts
+async function loadSessions() {
+  sessionsLoading.value = true
+  try {
+    sessions.value = await api.getSessionStates()
+  } catch (e) {
+    console.error('Failed to load sessions:', e)
+    toast.error('加载 Session 列表失败')
+  } finally {
+    sessionsLoading.value = false
+  }
+}
+
+async function handleClearSession(session: SessionState) {
+  try {
+    await api.deleteSessionState(session.router_key_id, session.session_id)
+    toast.success('Session 已清除')
+    loadSessions()
+  } catch (e) {
+    console.error('Failed to clear session:', e)
+    toast.error('清除 Session 失败')
+  }
+}
+
+async function handleViewHistory(session: SessionState) {
+  const key = session.session_id
+  if (sessionHistoryMap.value[key]) {
+    delete sessionHistoryMap.value[key]
+    return
+  }
+  try {
+    const history = await api.getSessionHistory(session.router_key_id, session.session_id)
+    sessionHistoryMap.value[key] = history
+  } catch (e) {
+    console.error('Failed to load history:', e)
+    toast.error('加载历史记录失败')
+  }
+}
+```
+
+**修改 onMounted：**
+
+```ts
+onMounted(() => {
+  loadConfig()
+  loadSessions()
+})
+```
+
+**Template 改造：** 在 `<div class="p-6">` 内部，用 Tabs 包裹：
+
+```
+Tabs default-value="claude-code"
+├── TabsList
+│   ├── TabsTrigger "claude-code" → "Claude Code"
+│   └── TabsTrigger "opencode" → "OpenCode"
+├── TabsContent "claude-code"
+│   ├── 保存按钮 header（从页面顶部移入）
+│   ├── Card 开关（不变）
+│   ├── Collapsible 使用说明（不变）
+│   └── Card "活跃 Session"（新增）
+│       ├── CardHeader: 标题 + 刷新 Button
+│       └── CardContent: <SessionTable
+│             :sessions="sessions"
+│             :loading="sessionsLoading"
+│             :history-map="sessionHistoryMap"
+│             @clear="handleClearSession"
+│             @view-history="handleViewHistory" />
+└── TabsContent "opencode"
+    └── 居中提示 "暂未支持 OpenCode 增强"（py-16 text-muted-foreground）
+```
+
+- [ ] Step 3 完成
+
+---
+
+## Step 4: 启动前端开发服务器验证
+
+```bash
+cd frontend && npm run dev
+```
+
+验证项：
+- 页面默认显示 Claude Code Tab，开关和使用说明正常
+- 点击 OpenCode Tab 显示占位提示
+- Session 卡片显示（可能为空列表，因为后端可能无数据）
+- 刷新按钮可点击
+- 如果有 session 数据，验证 Tooltip、历史展开、清除确认弹窗
+
+- [ ] Step 4 完成
+
+---
+
+## Step 5: 提交
+
+```bash
+git add frontend/src/components/proxy-enhancement/SessionTable.vue \
+        frontend/src/views/ProxyEnhancement.vue \
+        frontend/src/api/client.ts
+git commit -m "feat: add session management tab and SessionTable component
+
+- Wrap ProxyEnhancement in Tabs (Claude Code / OpenCode)
+- Add SessionTable with history view and clear confirmation
+- Add session API methods to client"
+```
+
+- [ ] Step 5 完成
+
+---
+
+## 注意事项
+
+- **不新增前端测试**：项目未配置 Vue 组件测试环境
+- **shadcn-vue 组件**：所有已安装（tabs、table、alert-dialog、tooltip、badge），无需额外安装
+- **类型来源**：`SessionState` 和 `SessionHistoryEntry` 从 `@/api/client` 导入
+- **historyMap 由父组件管理**：SessionTable 通过 props 接收 historyMap，通过 emit 通知父组件加载/切换
+- **encodeURIComponent**：sessionId 是 UUID，包含 `-` 字符，虽无安全风险但为一致性保留编码

--- a/.superpowers/2026-04-18-proxy-enhancement-tabs/plan.md
+++ b/.superpowers/2026-04-18-proxy-enhancement-tabs/plan.md
@@ -1,0 +1,43 @@
+# 代理增强页面改造 + Session 管理 实施计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 在代理增强页面添加 Tab 切换和 Session 管理，持久化 session-model 映射到数据库。
+
+**Architecture:** 双写策略（内存 Map + SQLite），session 以 `(routerKeyId, sessionId)` 复合键标识。前端单页面 Tabs 布局。
+
+**Tech Stack:** Fastify + better-sqlite3 + Vue 3 + shadcn-vue
+
+**Spec:** [session-management-design.md](./session-management-design.md)
+
+---
+
+## File Structure & Ownership
+
+| Action | File | Owner Task |
+|--------|------|-----------|
+| Create | `src/db/migrations/016_create_session_model_tables.sql` | Task 1 |
+| Create | `src/db/session-states.ts` | Task 1 |
+| Modify | `src/db/index.ts` | Task 1 |
+| Modify | `tests/db.test.ts` | Task 1 |
+| Modify | `src/proxy/model-state.ts` | Task 2 |
+| Modify | `src/proxy/enhancement-handler.ts` | Task 2 |
+| Modify | `src/proxy/proxy-core.ts` | Task 2 |
+| Modify | `src/index.ts` | Task 2 |
+| Modify | `tests/model-state.test.ts` | Task 2 |
+| Modify | `src/admin/proxy-enhancement.ts` | Task 3 |
+| Create | `tests/admin-session-states.test.ts` | Task 3 |
+| Modify | `frontend/src/api/client.ts` | Task 4 |
+| Modify | `frontend/src/views/ProxyEnhancement.vue` | Task 4 |
+| Create | `frontend/src/components/proxy-enhancement/SessionTable.vue` | Task 4 |
+
+---
+
+## Tasks
+
+按顺序执行，每个 Task 依赖前一个的产出：
+
+1. [Task 1: 数据库迁移 + CRUD](./plan-task1-db-migration.md)
+2. [Task 2: ModelStateManager + Enhancement Handler + Proxy Core](./plan-task2-model-state.md)
+3. [Task 3: 后端 Session API](./plan-task3-admin-api.md)
+4. [Task 4: 前端改造](./plan-task4-frontend.md)

--- a/.superpowers/2026-04-18-proxy-enhancement-tabs/session-management-design.md
+++ b/.superpowers/2026-04-18-proxy-enhancement-tabs/session-management-design.md
@@ -1,0 +1,105 @@
+# 代理增强页面改造 + Session 管理
+
+## 背景
+
+当前代理增强页面只有 Claude Code 的开关和使用说明。需要：
+1. 支持多工具 Tab 切换（Claude Code / OpenCode）
+2. 在 Claude Code Tab 下新增 Session 管理，查看每个 session 的模型配置
+3. Session 数据持久化到数据库
+
+## 方案
+
+单页面方案（方案 A）。在 `ProxyEnhancement.vue` 内用 Tabs 切换工具，Claude Code Tab 内包含现有开关 + 新增 Session 管理卡片。
+
+## 数据库设计
+
+### session_model_states 表
+
+存储每个 session 当前的模型配置状态。
+
+```sql
+CREATE TABLE IF NOT EXISTS session_model_states (
+  id TEXT PRIMARY KEY,
+  router_key_id TEXT NOT NULL,
+  session_id TEXT NOT NULL,
+  current_model TEXT NOT NULL,
+  original_model TEXT,
+  last_active_at TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  UNIQUE(router_key_id, session_id),
+  FOREIGN KEY (router_key_id) REFERENCES router_keys(id)
+);
+CREATE INDEX idx_sms_router_key ON session_model_states(router_key_id);
+```
+
+### session_model_history 表
+
+记录每次模型切换的审计日志。
+
+```sql
+CREATE TABLE IF NOT EXISTS session_model_history (
+  id TEXT PRIMARY KEY,
+  router_key_id TEXT NOT NULL,
+  session_id TEXT NOT NULL,
+  old_model TEXT,
+  new_model TEXT NOT NULL,
+  trigger_type TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  FOREIGN KEY (router_key_id) REFERENCES router_keys(id)
+);
+CREATE INDEX idx_smh_session ON session_model_history(router_key_id, session_id);
+```
+
+`trigger_type` 取值：`directive`（内联指令）、`command`（交互命令）、`manual_clear`（手动清除）。
+
+## 后端设计
+
+### ModelStateManager 改造
+
+- **复合键**：从 `routerKeyId` 改为 `(routerKeyId, sessionId)` 元组
+- **双写策略**：`set()` 同时写入内存 Map 和数据库（UPSERT states + INSERT history）
+- **冷启动 fallback**：`get()` miss 时从数据库读取
+- **清除**：`delete()` 同时清理内存和数据库，并写入 `manual_clear` 历史记录
+
+### session-id 提取
+
+在 `applyEnhancement()` 中从 request headers 提取 `x-claude-code-session-id`，传递给 `ModelStateManager`。
+
+### API 端点
+
+| 方法 | 路径 | 说明 |
+|------|------|------|
+| GET | `/admin/api/session-states` | 所有活跃 session 列表，关联 router_keys 表 |
+| GET | `/admin/api/session-states/:keyId/:sessionId/history` | 某个 session 的切换历史 |
+| DELETE | `/admin/api/session-states/:keyId/:sessionId` | 清除 session 模型配置 |
+
+## 前端设计
+
+### 页面结构
+
+```
+代理增强页面
+├── Tabs（Claude Code / OpenCode）
+│   ├── TabsContent "claude-code"
+│   │   ├── 现有开关 + 使用说明（不变）
+│   │   └── Card "活跃 Session"
+│   │       ├── 卡片头：标题 + 刷新按钮
+│   │       └── SessionTable 子组件
+│   └── TabsContent "opencode"
+│       └── 居中提示 "暂未支持 OpenCode 增强"
+```
+
+### SessionTable 子组件
+
+- 列：密钥名称 | Session ID（前 8 位 + Tooltip）| 当前模型 | 原始模型 | 最后活跃 | 操作
+- 操作：查看历史（展开行）/ 清除配置（AlertDialog 确认）
+- 历史展开后按时间倒序显示切换时间线
+
+### 新增文件
+
+- `frontend/src/components/proxy-enhancement/SessionTable.vue`
+- `frontend/src/api/client.ts` 新增 3 个 API 方法
+
+### 组件
+
+使用项目已有的 shadcn-vue 组件：Tabs、Table、AlertDialog、Tooltip、Card。

--- a/.superpowers/2026-04-18-proxy-enhancement-tabs/session-management-design.md
+++ b/.superpowers/2026-04-18-proxy-enhancement-tabs/session-management-design.md
@@ -13,9 +13,11 @@
 
 ## 数据库设计
 
+迁移文件：`src/db/migrations/016_create_session_model_tables.sql`
+
 ### session_model_states 表
 
-存储每个 session 当前的模型配置状态。
+存储每个 session 当前的模型配置状态。`id` 使用 `randomUUID()` 生成。
 
 ```sql
 CREATE TABLE IF NOT EXISTS session_model_states (
@@ -34,7 +36,7 @@ CREATE INDEX idx_sms_router_key ON session_model_states(router_key_id);
 
 ### session_model_history 表
 
-记录每次模型切换的审计日志。
+记录每次模型切换的审计日志。`id` 使用 `randomUUID()` 生成。
 
 ```sql
 CREATE TABLE IF NOT EXISTS session_model_history (
@@ -52,34 +54,94 @@ CREATE INDEX idx_smh_session ON session_model_history(router_key_id, session_id)
 
 `trigger_type` 取值：`directive`（内联指令）、`command`（交互命令）、`manual_clear`（手动清除）。
 
+### 关于 null 处理
+
+`router_key_id` 和 `session_id` 均为 `NOT NULL`。当请求未携带 `x-claude-code-session-id` header 时，不写入数据库，仅使用内存 Map（key 为 `routerKeyId`），保持与当前行为一致。只有携带 session header 的请求才走持久化路径。
+
 ## 后端设计
+
+### session-id 提取链路
+
+1. `proxy-core.ts` 的 `handleProxyPost()` 从 `request.headers` 提取 `x-claude-code-session-id`
+2. 作为新参数传递给 `applyEnhancement(db, request, clientModel, sessionId)`
+3. `applyEnhancement()` 将 `sessionId` 透传给 `modelState.set(routerKeyId, model, sessionId)`
+
+调用点更新：
+- `src/proxy/proxy-core.ts` — 提取 header，传递 sessionId
+- `src/proxy/enhancement-handler.ts` — 函数签名增加 sessionId 参数
+- `src/proxy/model-state.ts` — 接口改为接受 sessionId
 
 ### ModelStateManager 改造
 
-- **复合键**：从 `routerKeyId` 改为 `(routerKeyId, sessionId)` 元组
-- **双写策略**：`set()` 同时写入内存 Map 和数据库（UPSERT states + INSERT history）
-- **冷启动 fallback**：`get()` miss 时从数据库读取
-- **清除**：`delete()` 同时清理内存和数据库，并写入 `manual_clear` 历史记录
+内存 Map 的 key 格式：`routerKeyId` 或 `routerKeyId:sessionId`（sessionId 存在时）。
 
-### session-id 提取
-
-在 `applyEnhancement()` 中从 request headers 提取 `x-claude-code-session-id`，传递给 `ModelStateManager`。
+- **set(routerKeyId, model, sessionId?)**:
+  - 内存：key 为 `sessionId ? `${routerKeyId}:${sessionId}` : routerKeyId`
+  - 数据库：仅当 sessionId 存在时执行 `db.transaction()` 包裹的 UPSERT states + INSERT history
+  - DB 失败时不回滚内存（better-sqlite3 同步操作极少失败，且内存状态优先保证请求正常响应）
+- **get(routerKeyId, sessionId?)**:
+  - 内存 key 同上
+  - 内存 miss 时，若 sessionId 存在则查数据库，命中后回填内存
+- **delete(routerKeyId, sessionId)**:
+  - 同时清理内存和数据库（DELETE states + INSERT manual_clear history），包裹在 `db.transaction()` 中
 
 ### API 端点
 
 | 方法 | 路径 | 说明 |
 |------|------|------|
-| GET | `/admin/api/session-states` | 所有活跃 session 列表，关联 router_keys 表 |
+| GET | `/admin/api/session-states` | 所有活跃 session 列表 |
 | GET | `/admin/api/session-states/:keyId/:sessionId/history` | 某个 session 的切换历史 |
 | DELETE | `/admin/api/session-states/:keyId/:sessionId` | 清除 session 模型配置 |
 
+### API 响应结构
+
+**GET /admin/api/session-states**
+
+```ts
+interface SessionState {
+  id: string;
+  router_key_id: string;
+  router_key_name: string;        // 关联 router_keys.name
+  session_id: string;
+  current_model: string;
+  original_model: string | null;
+  last_active_at: string;
+  created_at: string;
+}
+// 响应: SessionState[]
+```
+
+**GET .../history**
+
+```ts
+interface SessionHistoryEntry {
+  id: string;
+  old_model: string | null;
+  new_model: string;
+  trigger_type: 'directive' | 'command' | 'manual_clear';
+  created_at: string;
+}
+// 响应: SessionHistoryEntry[]，按 created_at DESC 排序，不分页
+```
+
+**DELETE ...**
+
+```ts
+// 响应: { success: boolean }
+```
+
 ## 前端设计
+
+### Tab 值定义
+
+- `"claude-code"` — Claude Code Tab（默认激活）
+- `"opencode"` — OpenCode Tab
 
 ### 页面结构
 
 ```
 代理增强页面
-├── Tabs（Claude Code / OpenCode）
+├── Tabs default="claude-code"
 │   ├── TabsContent "claude-code"
 │   │   ├── 现有开关 + 使用说明（不变）
 │   │   └── Card "活跃 Session"
@@ -94,6 +156,12 @@ CREATE INDEX idx_smh_session ON session_model_history(router_key_id, session_id)
 - 列：密钥名称 | Session ID（前 8 位 + Tooltip）| 当前模型 | 原始模型 | 最后活跃 | 操作
 - 操作：查看历史（展开行）/ 清除配置（AlertDialog 确认）
 - 历史展开后按时间倒序显示切换时间线
+
+### 数据刷新策略
+
+- 页面加载时获取一次
+- 手动点击刷新按钮重新获取
+- 清除 session 后自动刷新列表
 
 ### 新增文件
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -36,6 +36,7 @@ const API = {
   ROUTER_KEYS: '/router-keys',
   MODELS_AVAILABLE: '/models/available',
   PROXY_ENHANCEMENT: '/proxy-enhancement',
+  SESSION_STATES: '/session-states',
 } as const
 
 // --- Payload types ---
@@ -78,6 +79,25 @@ interface RetryRulePayload {
   status_code: number
   body_pattern: string
   is_active?: number
+}
+
+export interface SessionState {
+  id: string
+  router_key_id: string
+  router_key_name: string
+  session_id: string
+  current_model: string
+  original_model: string | null
+  last_active_at: string
+  created_at: string
+}
+
+export interface SessionHistoryEntry {
+  id: string
+  old_model: string | null
+  new_model: string
+  trigger_type: 'directive' | 'command' | 'manual_clear'
+  created_at: string
 }
 
 // --- Typed request helper ---
@@ -151,4 +171,10 @@ export const api = {
     request<{ claude_code_enabled: boolean }>('get', API.PROXY_ENHANCEMENT),
   updateProxyEnhancement: (data: { claude_code_enabled: boolean }) =>
     request<{ success: boolean }>('put', API.PROXY_ENHANCEMENT, data),
+
+  getSessionStates: () => request<SessionState[]>('get', API.SESSION_STATES),
+  getSessionHistory: (keyId: string, sessionId: string) =>
+    request<SessionHistoryEntry[]>('get', `${API.SESSION_STATES}/${keyId}/${encodeURIComponent(sessionId)}/history`),
+  deleteSessionState: (keyId: string, sessionId: string) =>
+    request<{ success: boolean }>('delete', `${API.SESSION_STATES}/${keyId}/${encodeURIComponent(sessionId)}`),
 }

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -35,6 +35,7 @@ const API = {
   METRICS_TIMESERIES: '/metrics/timeseries',
   ROUTER_KEYS: '/router-keys',
   MODELS_AVAILABLE: '/models/available',
+  PROXY_ENHANCEMENT: '/proxy-enhancement',
 } as const
 
 // --- Payload types ---
@@ -145,4 +146,9 @@ export const api = {
   updateRetryRule: (id: string, data: RetryRulePayload) =>
     client.put(`${API.RETRY_RULES}/${id}`, data),
   deleteRetryRule: (id: string) => client.delete(`${API.RETRY_RULES}/${id}`),
+
+  getProxyEnhancement: () =>
+    request<{ claude_code_enabled: boolean }>('get', API.PROXY_ENHANCEMENT),
+  updateProxyEnhancement: (data: { claude_code_enabled: boolean }) =>
+    request<{ success: boolean }>('put', API.PROXY_ENHANCEMENT, data),
 }

--- a/frontend/src/components/layout/Sidebar.vue
+++ b/frontend/src/components/layout/Sidebar.vue
@@ -45,6 +45,7 @@ import {
   ArrowLeftRight,
   KeyRound,
   RefreshCcw,
+  Sparkles,
   FileText,
   LogOut,
 } from 'lucide-vue-next'
@@ -64,6 +65,7 @@ const navItems: NavItem[] = [
   { path: '/mappings', label: '模型映射', icon: ArrowLeftRight },
   { path: '/router-keys', label: 'API 密钥', icon: KeyRound },
   { path: '/retry-rules', label: '重试规则', icon: RefreshCcw },
+  { path: '/proxy-enhancement', label: '代理增强', icon: Sparkles },
   { path: '/logs', label: '请求日志', icon: FileText },
 ]
 

--- a/frontend/src/components/log-viewer/LogRequestViewer.vue
+++ b/frontend/src/components/log-viewer/LogRequestViewer.vue
@@ -163,6 +163,7 @@ import JsonCopyBlock from './JsonCopyBlock.vue'
 import StatPill from './StatPill.vue'
 import TagPill from './TagPill.vue'
 import { roleClass, tagClass } from './logColors'
+import InfoBanner from './InfoBanner.vue'
 import { extractBlocks } from './requestBlockParser'
 import type { MsgBlock } from './requestBlockParser'
 

--- a/frontend/src/components/log-viewer/LogResponseViewer.vue
+++ b/frontend/src/components/log-viewer/LogResponseViewer.vue
@@ -112,8 +112,11 @@
             </div>
             <div v-if="anthropicContentBlocks.length" class="space-y-2">
               <div class="text-xs font-medium text-muted-foreground">Content</div>
-              <div class="flex flex-wrap gap-2">
-                <Badge v-for="(block, idx) in anthropicContentBlocks" :key="idx" :class="blockClass(block.type)">{{ block.type }}</Badge>
+              <div v-for="(block, idx) in anthropicContentBlocks" :key="idx" class="rounded-md border p-3">
+                <div class="flex items-center gap-2 mb-2">
+                  <Badge :class="blockClass(block.type)">{{ block.type }}</Badge>
+                  <span v-if="block.text" class="text-sm">{{ block.text }}</span>
+                </div>
               </div>
             </div>
             <div v-if="anthropicUsage" class="grid grid-cols-2 sm:grid-cols-4 gap-2">

--- a/frontend/src/components/proxy-enhancement/SessionTable.vue
+++ b/frontend/src/components/proxy-enhancement/SessionTable.vue
@@ -1,0 +1,149 @@
+<template>
+  <div v-if="loading" class="py-8 text-center text-muted-foreground">加载中...</div>
+  <div v-else-if="sessions.length === 0" class="py-8 text-center text-muted-foreground">暂无活跃 Session</div>
+  <Table v-else>
+    <TableHeader>
+      <TableRow>
+        <TableHead>密钥名称</TableHead>
+        <TableHead>Session ID</TableHead>
+        <TableHead>当前模型</TableHead>
+        <TableHead>原始模型</TableHead>
+        <TableHead>最后活跃</TableHead>
+        <TableHead>操作</TableHead>
+      </TableRow>
+    </TableHeader>
+    <TableBody>
+      <template v-for="session in sessions" :key="session.id">
+        <TableRow>
+          <TableCell class="font-medium">{{ session.router_key_name }}</TableCell>
+          <TableCell>
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger as-child>
+                  <span class="cursor-default font-mono text-xs">{{ shortId(session.session_id) }}</span>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p class="font-mono text-xs">{{ session.session_id }}</p>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          </TableCell>
+          <TableCell>
+            <Badge variant="secondary">{{ session.current_model }}</Badge>
+          </TableCell>
+          <TableCell>
+            <span v-if="session.original_model" class="text-muted-foreground">{{ session.original_model }}</span>
+            <span v-else class="text-muted-foreground">-</span>
+          </TableCell>
+          <TableCell class="text-muted-foreground text-sm">{{ relativeTime(session.last_active_at) }}</TableCell>
+          <TableCell>
+            <div class="flex items-center gap-2">
+              <Button variant="ghost" size="sm" @click="$emit('viewHistory', session)">
+                {{ historyMap[session.session_id] ? '收起' : '历史' }}
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                class="text-destructive hover:text-destructive"
+                @click="clearingSession = session"
+              >
+                清除
+              </Button>
+            </div>
+          </TableCell>
+        </TableRow>
+        <TableRow v-if="historyMap[session.session_id]">
+          <TableCell colspan="6" class="bg-muted/50 px-6 py-3">
+            <div class="space-y-2">
+              <p class="text-sm font-medium text-foreground">切换历史</p>
+              <div
+                v-for="entry in historyMap[session.session_id]"
+                :key="entry.id"
+                class="flex items-center gap-3 text-sm"
+              >
+                <span class="text-muted-foreground whitespace-nowrap">{{ formatTime(entry.created_at) }}</span>
+                <Badge variant="outline" class="text-xs">{{ entry.trigger_type }}</Badge>
+                <span>
+                  <span class="text-muted-foreground">{{ entry.old_model || '默认' }}</span>
+                  <span class="mx-1">&rarr;</span>
+                  <span class="font-medium">{{ entry.new_model }}</span>
+                </span>
+              </div>
+            </div>
+          </TableCell>
+        </TableRow>
+      </template>
+    </TableBody>
+  </Table>
+
+  <AlertDialog :open="!!clearingSession" @update:open="clearingSession = null">
+    <AlertDialogContent>
+      <AlertDialogHeader>
+        <AlertDialogTitle>确认清除 Session</AlertDialogTitle>
+        <AlertDialogDescription>
+          清除后，该 Session 将恢复使用默认模型映射。此操作不可撤销。
+        </AlertDialogDescription>
+      </AlertDialogHeader>
+      <AlertDialogFooter>
+        <AlertDialogCancel @click="clearingSession = null">取消</AlertDialogCancel>
+        <AlertDialogAction @click="handleClear">确认清除</AlertDialogAction>
+      </AlertDialogFooter>
+    </AlertDialogContent>
+  </AlertDialog>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import type { SessionState, SessionHistoryEntry } from '@/api/client'
+import { Table, TableHeader, TableBody, TableRow, TableHead, TableCell } from '@/components/ui/table'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { TooltipProvider, Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
+import {
+  AlertDialog, AlertDialogContent, AlertDialogHeader, AlertDialogTitle,
+  AlertDialogDescription, AlertDialogFooter, AlertDialogCancel, AlertDialogAction,
+} from '@/components/ui/alert-dialog'
+
+defineProps<{
+  sessions: SessionState[]
+  loading: boolean
+  historyMap: Record<string, SessionHistoryEntry[]>
+}>()
+
+const emit = defineEmits<{
+  clear: [session: SessionState]
+  viewHistory: [session: SessionState]
+}>()
+
+const clearingSession = ref<SessionState | null>(null)
+
+function handleClear() {
+  if (clearingSession.value) {
+    emit('clear', clearingSession.value)
+    clearingSession.value = null
+  }
+}
+
+const SHORT_ID_LENGTH = 8
+const MS_PER_MINUTE = 60_000
+const MINUTES_PER_HOUR = 60
+const HOURS_PER_DAY = 24
+
+function shortId(id: string): string {
+  return id.slice(0, SHORT_ID_LENGTH) + '...'
+}
+
+function relativeTime(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime()
+  const minutes = Math.floor(diff / MS_PER_MINUTE)
+  if (minutes < 1) return '刚刚'
+  if (minutes < MINUTES_PER_HOUR) return `${minutes} 分钟前`
+  const hours = Math.floor(minutes / MINUTES_PER_HOUR)
+  if (hours < HOURS_PER_DAY) return `${hours} 小时前`
+  return `${Math.floor(hours / HOURS_PER_DAY)} 天前`
+}
+
+function formatTime(iso: string): string {
+  return new Date(iso).toLocaleString()
+}
+</script>

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -44,6 +44,12 @@ const router = createRouter({
       meta: { requiresAuth: true },
     },
     {
+      path: '/proxy-enhancement',
+      name: 'proxy-enhancement',
+      component: () => import('@/views/ProxyEnhancement.vue'),
+      meta: { requiresAuth: true },
+    },
+    {
       path: '/logs',
       name: 'logs',
       component: () => import('@/views/Logs.vue'),

--- a/frontend/src/views/Logs.vue
+++ b/frontend/src/views/Logs.vue
@@ -64,7 +64,10 @@
               <Badge v-if="log.original_model" variant="secondary" class="ml-1 text-xs">已替换</Badge>
             </TableCell>
             <TableCell class="text-xs">
-              <template v-if="log.backend_model || log.provider_name">
+              <template v-if="log.provider_id === 'router'">
+                <Badge variant="secondary" class="text-[10px] px-1 py-0">代理增强：{{ enhancementLabel(log.upstream_request) }}</Badge>
+              </template>
+              <template v-else-if="log.backend_model || log.provider_name">
                 <span class="font-mono">{{ log.backend_model || '-' }}</span>
                 <span class="text-muted-foreground"> @ </span>
                 <Badge variant="outline" class="text-[10px] px-1 py-0">{{ log.provider_name || log.provider_id || '-' }}</Badge>
@@ -106,6 +109,7 @@
       <DialogScrollContent class="max-w-4xl max-h-[85vh]">
         <DialogHeader>
           <DialogTitle class="flex items-center gap-2">请求详情 <span v-if="detailData" class="font-mono text-xs text-muted-foreground font-normal select-all">{{ detailData.id }}</span></DialogTitle>
+          <DialogDescription class="sr-only">请求日志详情</DialogDescription>
         </DialogHeader>
         <!-- 骨架屏加载状态 -->
         <template v-if="detailLoading">
@@ -157,13 +161,13 @@
                 </Button>
               </div>
               <div class="p-4">
-                <LogRequestViewer :raw="detailData.client_request || detailData.request_body || '{}'" :api-type="asApiType(detailData.api_type)" :mode="sectionModes.client_request" />
+                <LogRequestViewer :raw="getClientRequestRaw(detailData)" :api-type="asApiType(detailData.api_type)" :mode="sectionModes.client_request" />
               </div>
             </CollapsibleContent>
           </Collapsible>
 
           <!-- Router→LLM API 请求 -->
-          <Collapsible v-if="detailData.upstream_request" v-model:open="upstreamRequestOpen" class="border rounded-md">
+          <Collapsible v-if="detailData.upstream_request && !isIntercepted(detailData)" v-model:open="upstreamRequestOpen" class="border rounded-md">
             <CollapsibleTrigger as-child>
               <Button variant="ghost" class="w-full px-4 py-3 text-left text-sm font-medium text-foreground bg-muted/50 hover:bg-muted rounded-none rounded-t-md flex items-center gap-2">
                 <span class="text-xs transition-transform" :class="upstreamRequestOpen ? 'rotate-0' : '-rotate-90'">&#9660;</span>
@@ -186,8 +190,8 @@
             </CollapsibleContent>
           </Collapsible>
 
-          <!-- LLM API 返回的原始响应 -->
-          <Collapsible v-model:open="responseOpen" class="border rounded-md">
+          <!-- LLM API 返回的原始响应（拦截请求无上游调用，隐藏此栏） -->
+          <Collapsible v-if="!isIntercepted(detailData)" v-model:open="responseOpen" class="border rounded-md">
             <CollapsibleTrigger as-child>
               <Button variant="ghost" class="w-full px-4 py-3 text-left text-sm font-medium text-foreground bg-muted/50 hover:bg-muted rounded-none rounded-t-md flex items-center gap-2">
                 <span class="text-xs transition-transform" :class="responseOpen ? 'rotate-0' : '-rotate-90'">&#9660;</span>
@@ -211,7 +215,7 @@
           </Collapsible>
 
           <!-- Router→客户端响应 -->
-          <Collapsible v-if="detailData.client_response" v-model:open="clientResponseOpen" class="border rounded-md">
+          <Collapsible v-if="getClientResponseRaw(detailData)" v-model:open="clientResponseOpen" class="border rounded-md">
             <CollapsibleTrigger as-child>
               <Button variant="ghost" class="w-full px-4 py-3 text-left text-sm font-medium text-foreground bg-muted/50 hover:bg-muted rounded-none rounded-t-md flex items-center gap-2">
                 <span class="text-xs transition-transform" :class="clientResponseOpen ? 'rotate-0' : '-rotate-90'">&#9660;</span>
@@ -229,7 +233,7 @@
                 </Button>
               </div>
               <div class="p-4">
-                <LogResponseViewer :raw="detailData.client_response" :api-type="asApiType(detailData.api_type)" :is-stream="!!detailData.is_stream" :mode="sectionModes.client_response" />
+                <LogResponseViewer :raw="getClientResponseRaw(detailData)" :api-type="asApiType(detailData.api_type)" :is-stream="!!detailData.is_stream" :mode="sectionModes.client_response" />
               </div>
             </CollapsibleContent>
           </Collapsible>
@@ -275,7 +279,7 @@ import { Badge } from '@/components/ui/badge'
 import { Card, CardContent } from '@/components/ui/card'
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@/components/ui/select'
 import { Table, TableHeader, TableBody, TableRow, TableHead, TableCell } from '@/components/ui/table'
-import { Dialog, DialogContent, DialogScrollContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog'
+import { Dialog, DialogContent, DialogScrollContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from '@/components/ui/dialog'
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
 import { Skeleton } from '@/components/ui/skeleton'
 import LogRequestViewer from '@/components/log-viewer/LogRequestViewer.vue'
@@ -335,10 +339,10 @@ const { copy: clipboardCopy } = useClipboard()
 function getSectionRaw(key: SectionKey): string {
   if (!detailData.value) return '{}'
   const map: Record<SectionKey, string> = {
-    client_request: detailData.value.client_request || detailData.value.request_body || '{}',
+    client_request: getClientRequestRaw(detailData.value),
     upstream_request: detailData.value.upstream_request || '{}',
     upstream_response: detailData.value.upstream_response || detailData.value.response_body || '{}',
-    client_response: detailData.value.client_response || '{}',
+    client_response: getClientResponseRaw(detailData.value),
   }
   return map[key]
 }
@@ -355,6 +359,44 @@ async function copySection(key: SectionKey) {
 
 function asApiType(t: string): 'openai' | 'anthropic' {
   return t === 'openai' ? 'openai' : 'anthropic'
+}
+
+function enhancementLabel(raw: string | null): string {
+  if (!raw) return '未知'
+  try {
+    const meta = JSON.parse(raw)
+    if (meta.action) {
+      return meta.detail ? `${meta.action}: ${meta.detail}` : meta.action
+    }
+  } catch { /* ignore */ }
+  return '未知'
+}
+
+function isIntercepted(log: LogEntry): boolean {
+  return log.provider_id === 'router'
+}
+
+/** 组装客户端请求数据：当 client_request 缺少 body 时从 request_body 补充 */
+function getClientRequestRaw(detail: LogEntry): string {
+  if (!detail.client_request) return detail.request_body || '{}'
+  try {
+    const cr = JSON.parse(detail.client_request)
+    if (cr.body != null) return detail.client_request
+    if (detail.request_body) {
+      try { cr.body = JSON.parse(detail.request_body) } catch { cr.body = detail.request_body }
+      return JSON.stringify(cr)
+    }
+  } catch { /* 解析失败则原样返回 */ }
+  return detail.client_request
+}
+
+/** 组装客户端响应数据：client_response 为空时从 response_body 构造 */
+function getClientResponseRaw(detail: LogEntry): string {
+  if (detail.client_response) return detail.client_response
+  if (detail.response_body) {
+    return JSON.stringify({ statusCode: detail.status_code, body: detail.response_body })
+  }
+  return ''
 }
 
 async function openDetail(id: string) {

--- a/frontend/src/views/Logs.vue
+++ b/frontend/src/views/Logs.vue
@@ -59,7 +59,10 @@
             <TableCell>
               <Badge :variant="log.api_type === 'openai' ? 'default' : 'secondary'">{{ log.api_type }}</Badge>
             </TableCell>
-            <TableCell class="font-mono text-xs">{{ log.model || '-' }}</TableCell>
+            <TableCell class="font-mono text-xs">
+              {{ log.model || '-' }}
+              <Badge v-if="log.original_model" variant="secondary" class="ml-1 text-xs">已替换</Badge>
+            </TableCell>
             <TableCell class="text-xs">
               <template v-if="log.backend_model || log.provider_name">
                 <span class="font-mono">{{ log.backend_model || '-' }}</span>
@@ -128,6 +131,7 @@
           <div class="bg-muted/50 rounded-md p-3 text-sm grid grid-cols-3 gap-2">
             <div><span class="text-muted-foreground">类型:</span> <Badge :variant="detailData.api_type === 'openai' ? 'default' : 'secondary'" class="text-xs">{{ detailData.api_type }}</Badge></div>
             <div><span class="text-muted-foreground">模型:</span> <span class="font-medium font-mono">{{ detailData.model || '-' }}</span></div>
+            <div v-if="detailData.original_model" class="col-span-3"><span class="text-muted-foreground">模型替换:</span> <span class="font-mono text-xs">{{ detailData.original_model }} → {{ detailData.backend_model || detailData.model }}</span></div>
             <div><span class="text-muted-foreground">状态码:</span> <Badge :variant="(detailData.status_code ?? 0) < 400 ? 'default' : 'destructive'" class="text-xs">{{ detailData.status_code || '-' }}</Badge></div>
             <div><span class="text-muted-foreground">延迟:</span> <span class="font-medium">{{ detailData.latency_ms ? detailData.latency_ms + 'ms' : '-' }}</span></div>
             <div><span class="text-muted-foreground">流式:</span> <span class="font-medium">{{ detailData.is_stream ? 'Yes' : 'No' }}</span></div>
@@ -295,6 +299,7 @@ interface LogEntry {
   client_response: string | null
   is_retry: number
   original_request_id: string | null
+  original_model: string | null
   backend_model: string | null
   provider_name: string | null
 }

--- a/frontend/src/views/Providers.vue
+++ b/frontend/src/views/Providers.vue
@@ -259,8 +259,14 @@ function buildPayload(): { name: string; api_type: string; base_url: string; api
 }
 
 async function handleSave() {
+  const name = form.value.name.trim()
+  if (!/^[a-zA-Z0-9_-]+$/.test(name)) {
+    toast.error('名称仅允许英文大小写字母、数字、横线和下划线')
+    return
+  }
   try {
     const payload = buildPayload()
+    payload.name = name
     if (editingId.value) {
       await api.updateProvider(editingId.value, payload)
     } else {

--- a/frontend/src/views/Providers.vue
+++ b/frontend/src/views/Providers.vue
@@ -102,8 +102,8 @@
             <Input v-model="form.base_url" type="url" required />
           </div>
           <div>
-            <Label class="block text-sm font-medium text-foreground mb-1">API Key {{ editingId ? '(留空不修改)' : '' }}</Label>
-            <Input v-model="form.api_key" :type="editingId ? 'password' : 'text'" :required="!editingId" />
+            <Label class="block text-sm font-medium text-foreground mb-1">API Key</Label>
+            <Input v-model="form.api_key" type="text" required />
           </div>
           <div>
             <Label class="block text-sm font-medium text-foreground mb-1">可用模型</Label>
@@ -239,7 +239,7 @@ function openCreate() {
 
 function openEdit(p: Provider) {
   editingId.value = p.id
-  form.value = { name: p.name, api_type: p.api_type, base_url: p.base_url, api_key: '', models: [...(p.models || [])], is_active: !!p.is_active }
+  form.value = { name: p.name, api_type: p.api_type, base_url: p.base_url, api_key: p.api_key, models: [...(p.models || [])], is_active: !!p.is_active }
   modelInput.value = ''
   presetGroup.value = ''
   presetPlan.value = ''

--- a/frontend/src/views/ProxyEnhancement.vue
+++ b/frontend/src/views/ProxyEnhancement.vue
@@ -22,14 +22,10 @@
         </CardDescription>
       </CardHeader>
       <CardContent>
-        <div class="flex items-center gap-3">
-          <Switch
-            id="claude-code-toggle"
-            :checked="claudeCodeEnabled"
-            @update:checked="claudeCodeEnabled = $event"
-          />
+        <div class="flex items-center gap-2">
+          <Checkbox v-model="claudeCodeEnabled" id="claude-code-toggle" :disabled="loading" />
           <Label for="claude-code-toggle">
-            {{ claudeCodeEnabled ? '已启用' : '已禁用' }}
+            {{ loading ? '加载中...' : (claudeCodeEnabled ? '已启用' : '已禁用') }}
           </Label>
         </div>
       </CardContent>
@@ -91,22 +87,26 @@ import { ref, onMounted } from 'vue'
 import { toast } from 'vue-sonner'
 import { api } from '@/api/client'
 import { Button } from '@/components/ui/button'
-import { Switch } from '@/components/ui/switch'
+import { Checkbox } from '@/components/ui/checkbox'
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card'
 import { Label } from '@/components/ui/label'
 import { Collapsible, CollapsibleTrigger, CollapsibleContent } from '@/components/ui/collapsible'
 
 const claudeCodeEnabled = ref(false)
 const saving = ref(false)
+const loading = ref(true)
 const instructionsOpen = ref(false)
 
 async function loadConfig() {
+  loading.value = true
   try {
     const data = await api.getProxyEnhancement()
     claudeCodeEnabled.value = data.claude_code_enabled
   } catch (e) {
     console.error('Failed to load proxy enhancement config:', e)
     toast.error('加载配置失败')
+  } finally {
+    loading.value = false
   }
 }
 

--- a/frontend/src/views/ProxyEnhancement.vue
+++ b/frontend/src/views/ProxyEnhancement.vue
@@ -1,0 +1,127 @@
+<template>
+  <div class="p-6">
+    <div class="flex items-center justify-between mb-4">
+      <h2 class="text-lg font-semibold text-foreground">代理增强</h2>
+      <Button :disabled="saving" @click="handleSave">
+        <span v-if="saving" class="flex items-center gap-1">
+          <svg class="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
+            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
+            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+          </svg>
+          保存中...
+        </span>
+        <span v-else>保存</span>
+      </Button>
+    </div>
+
+    <Card>
+      <CardHeader>
+        <CardTitle>Claude Code 动态模型切换</CardTitle>
+        <CardDescription>
+          启用后，Claude Code 客户端可在对话中通过指令动态切换后端模型，无需修改路由配置。
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div class="flex items-center gap-3">
+          <Switch
+            id="claude-code-toggle"
+            :checked="claudeCodeEnabled"
+            @update:checked="claudeCodeEnabled = $event"
+          />
+          <Label for="claude-code-toggle">
+            {{ claudeCodeEnabled ? '已启用' : '已禁用' }}
+          </Label>
+        </div>
+      </CardContent>
+    </Card>
+
+    <!-- 使用说明 -->
+    <Collapsible v-model:open="instructionsOpen" class="mt-4">
+      <CollapsibleTrigger as-child>
+        <Button variant="ghost" class="w-full justify-between">
+          <span>使用说明</span>
+          <svg
+            class="w-4 h-4 transition-transform"
+            :class="{ 'rotate-180': instructionsOpen }"
+            fill="none" stroke="currentColor" viewBox="0 0 24 24"
+          >
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+          </svg>
+        </Button>
+      </CollapsibleTrigger>
+      <CollapsibleContent class="mt-2">
+        <Card>
+          <CardContent class="pt-6 space-y-4 text-sm">
+            <div>
+              <p class="font-medium text-foreground mb-1">内联指令切换模型</p>
+              <p class="text-muted-foreground">
+                在消息开头添加指令，单次切换使用的模型：
+              </p>
+              <code class="block mt-1 px-3 py-2 bg-muted rounded text-xs font-mono">
+                $SELECT-MODEL=claude-sonnet-4-20250514 你的问题内容
+              </code>
+            </div>
+            <div>
+              <p class="font-medium text-foreground mb-1">交互式选择模型</p>
+              <p class="text-muted-foreground">
+                发送命令进入交互式模型选择：
+              </p>
+              <code class="block mt-1 px-3 py-2 bg-muted rounded text-xs font-mono">
+                /select-model
+              </code>
+            </div>
+            <div>
+              <p class="font-medium text-foreground mb-1">恢复默认模型</p>
+              <p class="text-muted-foreground">
+                切回路由默认映射的模型：
+              </p>
+              <code class="block mt-1 px-3 py-2 bg-muted rounded text-xs font-mono">
+                $SELECT-MODEL=default
+              </code>
+            </div>
+          </CardContent>
+        </Card>
+      </CollapsibleContent>
+    </Collapsible>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { toast } from 'vue-sonner'
+import { api } from '@/api/client'
+import { Button } from '@/components/ui/button'
+import { Switch } from '@/components/ui/switch'
+import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card'
+import { Label } from '@/components/ui/label'
+import { Collapsible, CollapsibleTrigger, CollapsibleContent } from '@/components/ui/collapsible'
+
+const claudeCodeEnabled = ref(false)
+const saving = ref(false)
+const instructionsOpen = ref(false)
+
+async function loadConfig() {
+  try {
+    const data = await api.getProxyEnhancement()
+    claudeCodeEnabled.value = data.claude_code_enabled
+  } catch (e) {
+    console.error('Failed to load proxy enhancement config:', e)
+    toast.error('加载配置失败')
+  }
+}
+
+async function handleSave() {
+  saving.value = true
+  try {
+    await api.updateProxyEnhancement({ claude_code_enabled: claudeCodeEnabled.value })
+    toast.success('保存成功')
+  } catch (e) {
+    console.error('Failed to save proxy enhancement config:', e)
+    toast.error('保存失败')
+  } finally {
+    saving.value = false
+  }
+}
+
+onMounted(loadConfig)
+</script>

--- a/frontend/src/views/ProxyEnhancement.vue
+++ b/frontend/src/views/ProxyEnhancement.vue
@@ -1,84 +1,119 @@
 <template>
   <div class="p-6">
-    <div class="flex items-center justify-between mb-4">
-      <h2 class="text-lg font-semibold text-foreground">代理增强</h2>
-      <Button :disabled="saving" @click="handleSave">
-        <span v-if="saving" class="flex items-center gap-1">
-          <svg class="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
-            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
-            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
-          </svg>
-          保存中...
-        </span>
-        <span v-else>保存</span>
-      </Button>
-    </div>
-
-    <Card>
-      <CardHeader>
-        <CardTitle>Claude Code 动态模型切换</CardTitle>
-        <CardDescription>
-          启用后，Claude Code 客户端可在对话中通过指令动态切换后端模型，无需修改路由配置。
-        </CardDescription>
-      </CardHeader>
-      <CardContent>
-        <div class="flex items-center gap-2">
-          <Checkbox v-model="claudeCodeEnabled" id="claude-code-toggle" :disabled="loading" />
-          <Label for="claude-code-toggle">
-            {{ loading ? '加载中...' : (claudeCodeEnabled ? '已启用' : '已禁用') }}
-          </Label>
+    <Tabs default-value="claude-code">
+      <TabsList>
+        <TabsTrigger value="claude-code">Claude Code</TabsTrigger>
+        <TabsTrigger value="opencode">OpenCode</TabsTrigger>
+      </TabsList>
+      <TabsContent value="claude-code">
+        <div class="flex items-center justify-between mb-4">
+          <h2 class="text-lg font-semibold text-foreground">代理增强</h2>
+          <Button :disabled="saving" @click="handleSave">
+            <span v-if="saving" class="flex items-center gap-1">
+              <svg class="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
+                <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
+                <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+              </svg>
+              保存中...
+            </span>
+            <span v-else>保存</span>
+          </Button>
         </div>
-      </CardContent>
-    </Card>
 
-    <!-- 使用说明 -->
-    <Collapsible v-model:open="instructionsOpen" class="mt-4">
-      <CollapsibleTrigger as-child>
-        <Button variant="ghost" class="w-full justify-between">
-          <span>使用说明</span>
-          <svg
-            class="w-4 h-4 transition-transform"
-            :class="{ 'rotate-180': instructionsOpen }"
-            fill="none" stroke="currentColor" viewBox="0 0 24 24"
-          >
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
-          </svg>
-        </Button>
-      </CollapsibleTrigger>
-      <CollapsibleContent class="mt-2">
         <Card>
-          <CardContent class="pt-6 space-y-4 text-sm">
-            <div>
-              <p class="font-medium text-foreground mb-1">内联指令切换模型</p>
-              <p class="text-muted-foreground">
-                在消息开头添加指令，单次切换使用的模型：
-              </p>
-              <code class="block mt-1 px-3 py-2 bg-muted rounded text-xs font-mono">
-                $SELECT-MODEL=claude-sonnet-4-20250514 你的问题内容
-              </code>
-            </div>
-            <div>
-              <p class="font-medium text-foreground mb-1">交互式选择模型</p>
-              <p class="text-muted-foreground">
-                发送命令进入交互式模型选择：
-              </p>
-              <code class="block mt-1 px-3 py-2 bg-muted rounded text-xs font-mono">
-                /select-model
-              </code>
-            </div>
-            <div>
-              <p class="font-medium text-foreground mb-1">恢复默认模型</p>
-              <p class="text-muted-foreground">
-                切回路由默认映射的模型：
-              </p>
-              <code class="block mt-1 px-3 py-2 bg-muted rounded text-xs font-mono">
-                $SELECT-MODEL=default
-              </code>
+          <CardHeader>
+            <CardTitle>Claude Code 动态模型切换</CardTitle>
+            <CardDescription>
+              启用后，Claude Code 客户端可在对话中通过指令动态切换后端模型，无需修改路由配置。
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div class="flex items-center gap-2">
+              <Checkbox v-model="claudeCodeEnabled" id="claude-code-toggle" :disabled="loading" />
+              <Label for="claude-code-toggle">
+                {{ loading ? '加载中...' : (claudeCodeEnabled ? '已启用' : '已禁用') }}
+              </Label>
             </div>
           </CardContent>
         </Card>
-      </CollapsibleContent>
-    </Collapsible>
+
+        <!-- 使用说明 -->
+        <Collapsible v-model:open="instructionsOpen" class="mt-4">
+          <CollapsibleTrigger as-child>
+            <Button variant="ghost" class="w-full justify-between">
+              <span>使用说明</span>
+              <svg
+                class="w-4 h-4 transition-transform"
+                :class="{ 'rotate-180': instructionsOpen }"
+                fill="none" stroke="currentColor" viewBox="0 0 24 24"
+              >
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+              </svg>
+            </Button>
+          </CollapsibleTrigger>
+          <CollapsibleContent class="mt-2">
+            <Card>
+              <CardContent class="pt-6 space-y-4 text-sm">
+                <div>
+                  <p class="font-medium text-foreground mb-1">内联指令切换模型</p>
+                  <p class="text-muted-foreground">
+                    在消息开头添加指令，单次切换使用的模型：
+                  </p>
+                  <code class="block mt-1 px-3 py-2 bg-muted rounded text-xs font-mono">
+                    $SELECT-MODEL=claude-sonnet-4-20250514 你的问题内容
+                  </code>
+                </div>
+                <div>
+                  <p class="font-medium text-foreground mb-1">交互式选择模型</p>
+                  <p class="text-muted-foreground">
+                    发送命令进入交互式模型选择：
+                  </p>
+                  <code class="block mt-1 px-3 py-2 bg-muted rounded text-xs font-mono">
+                    /select-model
+                  </code>
+                </div>
+                <div>
+                  <p class="font-medium text-foreground mb-1">恢复默认模型</p>
+                  <p class="text-muted-foreground">
+                    切回路由默认映射的模型：
+                  </p>
+                  <code class="block mt-1 px-3 py-2 bg-muted rounded text-xs font-mono">
+                    $SELECT-MODEL=default
+                  </code>
+                </div>
+              </CardContent>
+            </Card>
+          </CollapsibleContent>
+        </Collapsible>
+
+        <!-- 活跃 Session -->
+        <Card class="mt-4">
+          <CardHeader>
+            <div class="flex items-center justify-between">
+              <div>
+                <CardTitle>活跃 Session</CardTitle>
+                <CardDescription>查看和管理当前已配置模型的 session</CardDescription>
+              </div>
+              <Button variant="outline" size="sm" @click="loadSessions" :disabled="sessionsLoading">刷新</Button>
+            </div>
+          </CardHeader>
+          <CardContent>
+            <SessionTable
+              :sessions="sessions"
+              :loading="sessionsLoading"
+              :history-map="sessionHistoryMap"
+              @clear="handleClearSession"
+              @view-history="handleViewHistory"
+            />
+          </CardContent>
+        </Card>
+      </TabsContent>
+      <TabsContent value="opencode">
+        <div class="flex flex-col items-center justify-center py-16 text-muted-foreground">
+          <p class="text-lg">暂未支持 OpenCode 增强</p>
+        </div>
+      </TabsContent>
+    </Tabs>
   </div>
 </template>
 
@@ -86,16 +121,23 @@
 import { ref, onMounted } from 'vue'
 import { toast } from 'vue-sonner'
 import { api } from '@/api/client'
+import type { SessionState, SessionHistoryEntry } from '@/api/client'
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card'
 import { Label } from '@/components/ui/label'
 import { Collapsible, CollapsibleTrigger, CollapsibleContent } from '@/components/ui/collapsible'
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
+import SessionTable from '@/components/proxy-enhancement/SessionTable.vue'
 
 const claudeCodeEnabled = ref(false)
 const saving = ref(false)
 const loading = ref(true)
 const instructionsOpen = ref(false)
+
+const sessions = ref<SessionState[]>([])
+const sessionsLoading = ref(false)
+const sessionHistoryMap = ref<Record<string, SessionHistoryEntry[]>>({})
 
 async function loadConfig() {
   loading.value = true
@@ -123,5 +165,46 @@ async function handleSave() {
   }
 }
 
-onMounted(loadConfig)
+async function loadSessions() {
+  sessionsLoading.value = true
+  try {
+    sessions.value = await api.getSessionStates()
+  } catch (e) {
+    console.error('Failed to load sessions:', e)
+    toast.error('加载 Session 列表失败')
+  } finally {
+    sessionsLoading.value = false
+  }
+}
+
+async function handleClearSession(session: SessionState) {
+  try {
+    await api.deleteSessionState(session.router_key_id, session.session_id)
+    toast.success('Session 已清除')
+    loadSessions()
+  } catch (e) {
+    console.error('Failed to clear session:', e)
+    toast.error('清除 Session 失败')
+  }
+}
+
+async function handleViewHistory(session: SessionState) {
+  const key = session.session_id
+  if (sessionHistoryMap.value[key]) {
+    delete sessionHistoryMap.value[key]
+    return
+  }
+  try {
+    const history = await api.getSessionHistory(session.router_key_id, session.session_id)
+    sessionHistoryMap.value[key] = history
+  } catch (e) {
+    console.error('Failed to load history:', e)
+    toast.error('加载历史记录失败')
+  }
+}
+
+onMounted(() => {
+  loadConfig()
+  loadSessions()
+})
 </script>

--- a/src/admin/providers.ts
+++ b/src/admin/providers.ts
@@ -7,6 +7,10 @@ import { encrypt, decrypt } from "../utils/crypto.js";
 import { getSetting } from "../db/settings.js";
 import { HTTP_CREATED, HTTP_NOT_FOUND, HTTP_CONFLICT } from "./constants.js";
 
+const API_KEY_PREVIEW_MIN_LEN = 8;
+const API_KEY_PREVIEW_PREFIX_LEN = 4;
+const PROVIDER_NAME_RE = /^[a-zA-Z0-9_-]+$/;
+
 const CreateProviderSchema = Type.Object({
   name: Type.String({ minLength: 1 }),
   api_type: Type.Union([Type.Literal("openai"), Type.Literal("anthropic")]),
@@ -50,6 +54,9 @@ export const adminProviderRoutes: FastifyPluginCallback<ProviderRoutesOptions> =
 
   app.post("/admin/api/providers", { schema: { body: CreateProviderSchema } }, async (request, reply) => {
     const body = request.body as Static<typeof CreateProviderSchema>;
+    if (!PROVIDER_NAME_RE.test(body.name)) {
+      return reply.status(400).send({ error: { message: "Provider 名称仅允许英文大小写字母、数字、横线和下划线" } });
+    }
     const encryptedKey = encrypt(body.api_key, getSetting(db, "encryption_key")!);
     const id = createProvider(db, {
       name: body.name,
@@ -70,6 +77,9 @@ export const adminProviderRoutes: FastifyPluginCallback<ProviderRoutesOptions> =
       return reply.code(HTTP_NOT_FOUND).send({ error: { message: "Provider not found" } });
     }
     const body = request.body as Static<typeof UpdateProviderSchema>;
+    if (body.name !== undefined && !PROVIDER_NAME_RE.test(body.name)) {
+      return reply.status(400).send({ error: { message: "Provider 名称仅允许英文大小写字母、数字、横线和下划线" } });
+    }
     const fields: Partial<Pick<Provider, 'name' | 'api_type' | 'base_url' | 'api_key' | 'api_key_preview' | 'models' | 'is_active'>> = {};
     if (body.name !== undefined) fields.name = body.name;
     if (body.api_type !== undefined) fields.api_type = body.api_type;

--- a/src/admin/proxy-enhancement.ts
+++ b/src/admin/proxy-enhancement.ts
@@ -1,6 +1,11 @@
 import { FastifyPluginCallback } from "fastify";
 import Database from "better-sqlite3";
 import { getSetting, setSetting } from "../db/settings.js";
+import {
+  getSessionStates,
+  getSessionHistory,
+} from "../db/session-states.js";
+import { modelState } from "../proxy/model-state.js";
 
 interface ProxyEnhancementOptions {
   db: Database.Database;
@@ -32,6 +37,29 @@ export const adminProxyEnhancementRoutes: FastifyPluginCallback<ProxyEnhancement
     setSetting(db, "proxy_enhancement", JSON.stringify(config));
     return reply.send({ success: true });
   });
+
+  app.get("/admin/api/session-states", async (_req, reply) => {
+    const states = getSessionStates(db);
+    return reply.send(states);
+  });
+
+  app.get<{ Params: { keyId: string; sessionId: string } }>(
+    "/admin/api/session-states/:keyId/:sessionId/history",
+    async (req, reply) => {
+      const { keyId, sessionId } = req.params;
+      const history = getSessionHistory(db, keyId, sessionId);
+      return reply.send(history);
+    },
+  );
+
+  app.delete<{ Params: { keyId: string; sessionId: string } }>(
+    "/admin/api/session-states/:keyId/:sessionId",
+    async (req, reply) => {
+      const { keyId, sessionId } = req.params;
+      modelState.delete(keyId, sessionId);
+      return reply.send({ success: true });
+    },
+  );
 
   done();
 };

--- a/src/admin/proxy-enhancement.ts
+++ b/src/admin/proxy-enhancement.ts
@@ -1,0 +1,34 @@
+import { FastifyPluginCallback } from "fastify";
+import Database from "better-sqlite3";
+import { getSetting, setSetting } from "../db/settings.js";
+
+interface ProxyEnhancementOptions {
+  db: Database.Database;
+}
+
+interface ProxyEnhancementConfig {
+  claude_code_enabled: boolean;
+}
+
+export const adminProxyEnhancementRoutes: FastifyPluginCallback<ProxyEnhancementOptions> = (app, options, done) => {
+  const { db } = options;
+
+  app.get("/proxy-enhancement", async (_req, reply) => {
+    const raw = getSetting(db, "proxy_enhancement");
+    const config: ProxyEnhancementConfig = raw
+      ? JSON.parse(raw)
+      : { claude_code_enabled: false };
+    return reply.send(config);
+  });
+
+  app.put("/proxy-enhancement", async (req, reply) => {
+    const body = req.body as { claude_code_enabled?: boolean };
+    const config: ProxyEnhancementConfig = {
+      claude_code_enabled: body.claude_code_enabled ?? false,
+    };
+    setSetting(db, "proxy_enhancement", JSON.stringify(config));
+    return reply.send({ success: true });
+  });
+
+  done();
+};

--- a/src/admin/proxy-enhancement.ts
+++ b/src/admin/proxy-enhancement.ts
@@ -13,7 +13,7 @@ interface ProxyEnhancementConfig {
 export const adminProxyEnhancementRoutes: FastifyPluginCallback<ProxyEnhancementOptions> = (app, options, done) => {
   const { db } = options;
 
-  app.get("/proxy-enhancement", async (_req, reply) => {
+  app.get("/admin/api/proxy-enhancement", async (_req, reply) => {
     const raw = getSetting(db, "proxy_enhancement");
     const config: ProxyEnhancementConfig = raw
       ? JSON.parse(raw)
@@ -21,10 +21,13 @@ export const adminProxyEnhancementRoutes: FastifyPluginCallback<ProxyEnhancement
     return reply.send(config);
   });
 
-  app.put("/proxy-enhancement", async (req, reply) => {
-    const body = req.body as { claude_code_enabled?: boolean };
+  app.put("/admin/api/proxy-enhancement", async (req, reply) => {
+    const body = req.body as Record<string, unknown>;
+    if (typeof body.claude_code_enabled !== "boolean") {
+      return reply.status(400).send({ error: "claude_code_enabled must be a boolean" }); // eslint-disable-line no-magic-numbers
+    }
     const config: ProxyEnhancementConfig = {
-      claude_code_enabled: body.claude_code_enabled ?? false,
+      claude_code_enabled: body.claude_code_enabled,
     };
     setSetting(db, "proxy_enhancement", JSON.stringify(config));
     return reply.send({ success: true });

--- a/src/admin/routes.ts
+++ b/src/admin/routes.ts
@@ -8,6 +8,7 @@ import { adminRetryRuleRoutes } from "./retry-rules.js";
 import { adminLogRoutes } from "./logs.js";
 import { adminStatsRoutes } from "./stats.js";
 import { adminMetricsRoutes } from "./metrics.js";
+import { adminProxyEnhancementRoutes } from "./proxy-enhancement.js";
 import { adminRouterKeyRoutes } from "./router-keys.js";
 import { adminSetupRoutes } from "./setup.js";
 import { RetryRuleMatcher } from "../proxy/retry-rules.js";
@@ -30,5 +31,6 @@ export const adminRoutes: FastifyPluginCallback<AdminRoutesOptions> = (app, opti
   app.register(adminRouterKeyRoutes, { db: options.db });
   app.register(adminStatsRoutes, { db: options.db });
   app.register(adminMetricsRoutes, { db: options.db });
+  app.register(adminProxyEnhancementRoutes, { db: options.db });
   done();
 };

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -115,3 +115,13 @@ export { getStats } from "./stats.js";
 export type { Stats, StatsPeriod } from "./stats.js";
 
 export { getSetting, setSetting, isInitialized } from "./settings.js";
+
+export {
+  getSessionStates,
+  getSessionState,
+  getSessionHistory,
+  upsertSessionState,
+  insertSessionHistory,
+  deleteSessionState,
+} from "./session-states.js";
+export type { SessionModelState, SessionModelHistory, UpsertSessionStateInput, InsertSessionHistoryInput } from "./session-states.js";

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -75,8 +75,10 @@ export {
   createMappingGroup,
   updateMappingGroup,
   deleteMappingGroup,
+  getActiveProviderModels,
+  resolveByProviderModel,
 } from "./mappings.js";
-export type { ModelMapping, MappingGroup } from "./mappings.js";
+export type { ModelMapping, MappingGroup, ProviderModelEntry } from "./mappings.js";
 
 export {
   getActiveRetryRules,

--- a/src/db/logs.ts
+++ b/src/db/logs.ts
@@ -66,29 +66,31 @@ export type MetricsInsert = {
 
 // --- request_logs ---
 
+export interface RequestLogInsert {
+  id: string;
+  api_type: string;
+  model: string | null;
+  provider_id: string | null;
+  status_code: number | null;
+  latency_ms: number | null;
+  is_stream: number;
+  error_message: string | null;
+  created_at: string;
+  request_body?: string | null;
+  response_body?: string | null;
+  client_request?: string | null;
+  upstream_request?: string | null;
+  upstream_response?: string | null;
+  client_response?: string | null;
+  is_retry?: number;
+  original_request_id?: string | null;
+  router_key_id?: string | null;
+  original_model?: string | null;
+}
+
 export function insertRequestLog(
   db: Database.Database,
-  log: {
-    id: string;
-    api_type: string;
-    model: string | null;
-    provider_id: string | null;
-    status_code: number | null;
-    latency_ms: number | null;
-    is_stream: number;
-    error_message: string | null;
-    created_at: string;
-    request_body?: string | null;
-    response_body?: string | null;
-    client_request?: string | null;
-    upstream_request?: string | null;
-    upstream_response?: string | null;
-    client_response?: string | null;
-    is_retry?: number;
-    original_request_id?: string | null;
-    router_key_id?: string | null;
-    original_model?: string | null;
-  },
+  log: RequestLogInsert,
 ): void {
   db.prepare(
     `INSERT INTO request_logs (id, api_type, model, provider_id, status_code, latency_ms, is_stream, error_message, created_at, request_body, response_body, client_request, upstream_request, upstream_response, client_response, is_retry, original_request_id, router_key_id, original_model)

--- a/src/db/logs.ts
+++ b/src/db/logs.ts
@@ -21,6 +21,7 @@ export interface RequestLog {
   client_response: string | null;
   is_retry: number;
   original_request_id: string | null;
+  original_model: string | null;
 }
 
 /** 列表查询扩展字段：JOIN request_metrics + providers 获得 */
@@ -86,18 +87,19 @@ export function insertRequestLog(
     is_retry?: number;
     original_request_id?: string | null;
     router_key_id?: string | null;
+    original_model?: string | null;
   },
 ): void {
   db.prepare(
-    `INSERT INTO request_logs (id, api_type, model, provider_id, status_code, latency_ms, is_stream, error_message, created_at, request_body, response_body, client_request, upstream_request, upstream_response, client_response, is_retry, original_request_id, router_key_id)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    `INSERT INTO request_logs (id, api_type, model, provider_id, status_code, latency_ms, is_stream, error_message, created_at, request_body, response_body, client_request, upstream_request, upstream_response, client_response, is_retry, original_request_id, router_key_id, original_model)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
     log.id, log.api_type, log.model, log.provider_id, log.status_code,
     log.latency_ms, log.is_stream, log.error_message, log.created_at,
     log.request_body ?? null, log.response_body ?? null,
     log.client_request ?? null, log.upstream_request ?? null,
     log.upstream_response ?? null, log.client_response ?? null,
-    log.is_retry ?? 0, log.original_request_id ?? null, log.router_key_id ?? null,
+    log.is_retry ?? 0, log.original_request_id ?? null, log.router_key_id ?? null, log.original_model ?? null,
   );
 }
 
@@ -132,7 +134,7 @@ export function getRequestLogs(
   const data = db
     .prepare(
       `SELECT rl.id, rl.api_type, rl.model, rl.provider_id, rl.status_code, rl.latency_ms,
-              rl.is_stream, rl.error_message, rl.created_at, rl.is_retry, rl.original_request_id,
+              rl.is_stream, rl.error_message, rl.created_at, rl.is_retry, rl.original_request_id, rl.original_model,
               rm.backend_model, COALESCE(p.name, rl.provider_id) AS provider_name
        FROM request_logs rl
        LEFT JOIN request_metrics rm ON rm.request_log_id = rl.id

--- a/src/db/logs.ts
+++ b/src/db/logs.ts
@@ -137,6 +137,7 @@ export function getRequestLogs(
     .prepare(
       `SELECT rl.id, rl.api_type, rl.model, rl.provider_id, rl.status_code, rl.latency_ms,
               rl.is_stream, rl.error_message, rl.created_at, rl.is_retry, rl.original_request_id, rl.original_model,
+              CASE WHEN rl.provider_id = 'router' THEN rl.upstream_request ELSE NULL END AS upstream_request,
               rm.backend_model, COALESCE(p.name, rl.provider_id) AS provider_name
        FROM request_logs rl
        LEFT JOIN request_metrics rm ON rm.request_log_id = rl.id

--- a/src/db/mappings.ts
+++ b/src/db/mappings.ts
@@ -118,83 +118,83 @@ export function deleteMappingGroup(db: Database.Database, id: string): void {
 export interface ProviderModelEntry {
   provider_name: string;
   backend_model: string;
-  client_model: string;
 }
 
-/** 从 mapping_groups 的 rule JSON 提取所有 target，JOIN providers 获取名称 */
+/** 从 providers.models 获取所有可用模型 */
 export function getActiveProviderModels(db: Database.Database): ProviderModelEntry[] {
-  const groups = db.prepare("SELECT client_model, rule FROM mapping_groups").all() as { client_model: string; rule: string }[];
-  const providers = db.prepare("SELECT id, name FROM providers").all() as { id: string; name: string }[];
-  const providerMap = new Map(providers.map(p => [p.id, p.name]));
-
+  const providers = db.prepare("SELECT name, models, is_active FROM providers WHERE is_active = 1").all() as { name: string; models: string; is_active: number }[];
   const results: ProviderModelEntry[] = [];
-  for (const g of groups) {
+  for (const p of providers) {
     try {
-      const rule = JSON.parse(g.rule);
-      // 提取所有 Target（支持 scheduled/round-robin/random/failover 策略格式）
-      const targets = extractTargets(rule);
-      for (const t of targets) {
-        const providerName = providerMap.get(t.provider_id);
-        if (providerName) {
-          results.push({ provider_name: providerName, backend_model: t.backend_model, client_model: g.client_model });
-        }
+      const models: string[] = JSON.parse(p.models);
+      for (const m of models) {
+        results.push({ provider_name: p.name, backend_model: m });
       }
-    } catch { /* 忽略解析失败的 rule */ }
+    } catch { /* 忽略解析失败 */ }
   }
   return results;
 }
 
-/** 根据 "provider_name/backend_model" 从 mapping_groups 的 rule 中解析出 client_model */
+// --- 从 mapping_groups rule JSON 中提取 target 条目 ---
+
+interface TargetEntry {
+  backend_model: string;
+  provider_id: string;
+}
+
+function isTargetLike(obj: unknown): obj is TargetEntry {
+  return typeof obj === "object" && obj !== null &&
+    typeof (obj as Record<string, unknown>).backend_model === "string" &&
+    typeof (obj as Record<string, unknown>).provider_id === "string";
+}
+
+function extractTargets(rule: Record<string, unknown>): TargetEntry[] {
+  const results: TargetEntry[] = [];
+  if (isTargetLike(rule.default)) results.push(rule.default);
+  if (Array.isArray(rule.targets)) {
+    for (const t of rule.targets) {
+      if (isTargetLike(t)) results.push(t);
+    }
+  }
+  if (Array.isArray(rule.windows)) {
+    for (const w of rule.windows) {
+      if (w && typeof w === "object" && isTargetLike((w as Record<string, unknown>).target)) {
+        results.push((w as Record<string, unknown>).target as TargetEntry);
+      }
+    }
+  }
+  return results;
+}
+
+/**
+ * 根据 "provider_name/backend_model" 验证模型是否存在于 provider 配置中。
+ * 同时尝试从 mapping_groups 中找到对应的 client_model 用于路由。
+ * 如果找不到 mapping，返回 backend_model 本身（由 proxy-core 兜底处理）。
+ */
 export function resolveByProviderModel(
   db: Database.Database,
   providerName: string,
   backendModel: string,
-): string | null {
-  const providerRow = db.prepare("SELECT id FROM providers WHERE name = ?").get(providerName) as { id: string } | undefined;
+): { client_model: string; provider_id: string; backend_model: string } | null {
+  const providerRow = db.prepare("SELECT id, models FROM providers WHERE name = ? AND is_active = 1").get(providerName) as { id: string; models: string } | undefined;
   if (!providerRow) return null;
+  try {
+    const models: string[] = JSON.parse(providerRow.models);
+    if (!models.includes(backendModel)) return null;
+  } catch { return null; }
 
+  // 尝试从 mapping_groups 找到包含此 provider+backend_model 的 client_model
   const groups = db.prepare("SELECT client_model, rule FROM mapping_groups").all() as { client_model: string; rule: string }[];
   for (const g of groups) {
     try {
       const rule = JSON.parse(g.rule);
       const targets = extractTargets(rule);
-      if (targets.some(t => t.provider_id === providerRow.id && t.backend_model === backendModel)) {
-        return g.client_model;
+      const match = targets.find(t => t.provider_id === providerRow.id && t.backend_model === backendModel);
+      if (match) {
+        return { client_model: g.client_model, provider_id: providerRow.id, backend_model: backendModel };
       }
     } catch { /* continue */ }
   }
-  return null;
-}
-
-interface Target { provider_id: string; backend_model: string }
-
-/** 从 rule JSON 中提取所有 Target（覆盖各策略格式） */
-function extractTargets(rule: unknown): Target[] {
-  const targets: Target[] = [];
-  if (typeof rule !== "object" || rule === null) return targets;
-  const r = rule as Record<string, unknown>;
-
-  // targets-based 策略（round-robin/random/failover）: { targets: [...] }
-  if (Array.isArray(r.targets)) {
-    for (const t of r.targets) {
-      if (isTargetLike(t)) targets.push(t as Target);
-    }
-  }
-
-  // scheduled 策略: { default: Target, windows: [{ target: Target }] }
-  if (r.default && isTargetLike(r.default)) targets.push(r.default as Target);
-  if (Array.isArray(r.windows)) {
-    for (const w of r.windows) {
-      if (w && typeof w === "object" && "target" in w && isTargetLike((w as Record<string, unknown>).target)) {
-        targets.push((w as Record<string, unknown>).target as Target);
-      }
-    }
-  }
-  return targets;
-}
-
-function isTargetLike(v: unknown): v is Target {
-  return typeof v === "object" && v !== null &&
-    "provider_id" in v && typeof (v as Target).provider_id === "string" &&
-    "backend_model" in v && typeof (v as Target).backend_model === "string";
+  // provider 有这个模型但没有 mapping group，直接返回 provider 维度信息
+  return { client_model: backendModel, provider_id: providerRow.id, backend_model: backendModel };
 }

--- a/src/db/mappings.ts
+++ b/src/db/mappings.ts
@@ -112,3 +112,89 @@ export function updateMappingGroup(
 export function deleteMappingGroup(db: Database.Database, id: string): void {
   deleteById(db, "mapping_groups", id);
 }
+
+// --- Provider-Model 查询（代理增强用）---
+
+export interface ProviderModelEntry {
+  provider_name: string;
+  backend_model: string;
+  client_model: string;
+}
+
+/** 从 mapping_groups 的 rule JSON 提取所有 target，JOIN providers 获取名称 */
+export function getActiveProviderModels(db: Database.Database): ProviderModelEntry[] {
+  const groups = db.prepare("SELECT client_model, rule FROM mapping_groups").all() as { client_model: string; rule: string }[];
+  const providers = db.prepare("SELECT id, name FROM providers").all() as { id: string; name: string }[];
+  const providerMap = new Map(providers.map(p => [p.id, p.name]));
+
+  const results: ProviderModelEntry[] = [];
+  for (const g of groups) {
+    try {
+      const rule = JSON.parse(g.rule);
+      // 提取所有 Target（支持 scheduled/round-robin/random/failover 策略格式）
+      const targets = extractTargets(rule);
+      for (const t of targets) {
+        const providerName = providerMap.get(t.provider_id);
+        if (providerName) {
+          results.push({ provider_name: providerName, backend_model: t.backend_model, client_model: g.client_model });
+        }
+      }
+    } catch { /* 忽略解析失败的 rule */ }
+  }
+  return results;
+}
+
+/** 根据 "provider_name/backend_model" 从 mapping_groups 的 rule 中解析出 client_model */
+export function resolveByProviderModel(
+  db: Database.Database,
+  providerName: string,
+  backendModel: string,
+): string | null {
+  const providerRow = db.prepare("SELECT id FROM providers WHERE name = ?").get(providerName) as { id: string } | undefined;
+  if (!providerRow) return null;
+
+  const groups = db.prepare("SELECT client_model, rule FROM mapping_groups").all() as { client_model: string; rule: string }[];
+  for (const g of groups) {
+    try {
+      const rule = JSON.parse(g.rule);
+      const targets = extractTargets(rule);
+      if (targets.some(t => t.provider_id === providerRow.id && t.backend_model === backendModel)) {
+        return g.client_model;
+      }
+    } catch { /* continue */ }
+  }
+  return null;
+}
+
+interface Target { provider_id: string; backend_model: string }
+
+/** 从 rule JSON 中提取所有 Target（覆盖各策略格式） */
+function extractTargets(rule: unknown): Target[] {
+  const targets: Target[] = [];
+  if (typeof rule !== "object" || rule === null) return targets;
+  const r = rule as Record<string, unknown>;
+
+  // targets-based 策略（round-robin/random/failover）: { targets: [...] }
+  if (Array.isArray(r.targets)) {
+    for (const t of r.targets) {
+      if (isTargetLike(t)) targets.push(t as Target);
+    }
+  }
+
+  // scheduled 策略: { default: Target, windows: [{ target: Target }] }
+  if (r.default && isTargetLike(r.default)) targets.push(r.default as Target);
+  if (Array.isArray(r.windows)) {
+    for (const w of r.windows) {
+      if (w && typeof w === "object" && "target" in w && isTargetLike((w as Record<string, unknown>).target)) {
+        targets.push((w as Record<string, unknown>).target as Target);
+      }
+    }
+  }
+  return targets;
+}
+
+function isTargetLike(v: unknown): v is Target {
+  return typeof v === "object" && v !== null &&
+    "provider_id" in v && typeof (v as Target).provider_id === "string" &&
+    "backend_model" in v && typeof (v as Target).backend_model === "string";
+}

--- a/src/db/migrations/015_add_original_model.sql
+++ b/src/db/migrations/015_add_original_model.sql
@@ -1,0 +1,1 @@
+ALTER TABLE request_logs ADD COLUMN original_model TEXT;

--- a/src/db/migrations/016_create_session_model_tables.sql
+++ b/src/db/migrations/016_create_session_model_tables.sql
@@ -1,0 +1,24 @@
+CREATE TABLE IF NOT EXISTS session_model_states (
+  id TEXT PRIMARY KEY,
+  router_key_id TEXT NOT NULL,
+  session_id TEXT NOT NULL,
+  current_model TEXT NOT NULL,
+  original_model TEXT,
+  last_active_at TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  UNIQUE(router_key_id, session_id),
+  FOREIGN KEY (router_key_id) REFERENCES router_keys(id)
+);
+CREATE INDEX idx_sms_router_key ON session_model_states(router_key_id);
+
+CREATE TABLE IF NOT EXISTS session_model_history (
+  id TEXT PRIMARY KEY,
+  router_key_id TEXT NOT NULL,
+  session_id TEXT NOT NULL,
+  old_model TEXT,
+  new_model TEXT NOT NULL,
+  trigger_type TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  FOREIGN KEY (router_key_id) REFERENCES router_keys(id)
+);
+CREATE INDEX idx_smh_session ON session_model_history(router_key_id, session_id);

--- a/src/db/session-states.ts
+++ b/src/db/session-states.ts
@@ -1,0 +1,134 @@
+import Database from "better-sqlite3";
+import { randomUUID } from "crypto";
+
+// --- Types ---
+
+export interface SessionModelState {
+  id: string;
+  router_key_id: string;
+  router_key_name?: string;
+  session_id: string;
+  current_model: string;
+  original_model: string | null;
+  last_active_at: string;
+  created_at: string;
+}
+
+export interface SessionModelHistory {
+  id: string;
+  router_key_id: string;
+  session_id: string;
+  old_model: string | null;
+  new_model: string;
+  trigger_type: string;
+  created_at: string;
+}
+
+export interface UpsertSessionStateInput {
+  id?: string;
+  router_key_id: string;
+  session_id: string;
+  current_model: string;
+  original_model?: string | null;
+}
+
+export interface InsertSessionHistoryInput {
+  router_key_id: string;
+  session_id: string;
+  old_model?: string | null;
+  new_model: string;
+  trigger_type: string;
+}
+
+// --- CRUD ---
+
+export function getSessionStates(db: Database.Database): SessionModelState[] {
+  return db.prepare(
+    `SELECT sms.*, rk.name AS router_key_name
+     FROM session_model_states sms
+     JOIN router_keys rk ON rk.id = sms.router_key_id
+     ORDER BY sms.last_active_at DESC`
+  ).all() as SessionModelState[];
+}
+
+export function getSessionHistory(
+  db: Database.Database,
+  routerKeyId: string,
+  sessionId: string,
+): SessionModelHistory[] {
+  return db.prepare(
+    `SELECT * FROM session_model_history
+     WHERE router_key_id = ? AND session_id = ?
+     ORDER BY created_at DESC`
+  ).all(routerKeyId, sessionId) as SessionModelHistory[];
+}
+
+export function upsertSessionState(
+  db: Database.Database,
+  input: UpsertSessionStateInput,
+): string {
+  const now = new Date().toISOString();
+  const id = input.id ?? randomUUID();
+
+  db.prepare(
+    `INSERT INTO session_model_states (id, router_key_id, session_id, current_model, original_model, last_active_at, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT(router_key_id, session_id) DO UPDATE SET
+       current_model = excluded.current_model,
+       original_model = excluded.original_model,
+       last_active_at = excluded.last_active_at`
+  ).run(
+    id,
+    input.router_key_id,
+    input.session_id,
+    input.current_model,
+    input.original_model ?? null,
+    now,
+    now,
+  );
+
+  return id;
+}
+
+export function insertSessionHistory(
+  db: Database.Database,
+  input: InsertSessionHistoryInput,
+): string {
+  const id = randomUUID();
+  const now = new Date().toISOString();
+
+  db.prepare(
+    `INSERT INTO session_model_history (id, router_key_id, session_id, old_model, new_model, trigger_type, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`
+  ).run(
+    id,
+    input.router_key_id,
+    input.session_id,
+    input.old_model ?? null,
+    input.new_model,
+    input.trigger_type,
+    now,
+  );
+
+  return id;
+}
+
+export function deleteSessionState(
+  db: Database.Database,
+  routerKeyId: string,
+  sessionId: string,
+): void {
+  db.prepare(
+    `DELETE FROM session_model_states WHERE router_key_id = ? AND session_id = ?`
+  ).run(routerKeyId, sessionId);
+}
+
+export function getSessionState(
+  db: Database.Database,
+  routerKeyId: string,
+  sessionId: string,
+): SessionModelState | undefined {
+  return db.prepare(
+    `SELECT * FROM session_model_states WHERE router_key_id = ? AND session_id = ?`
+  ).get(routerKeyId, sessionId) as SessionModelState | undefined;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ import { openaiProxy } from "./proxy/openai.js";
 import { anthropicProxy } from "./proxy/anthropic.js";
 import { adminRoutes } from "./admin/routes.js";
 import { RetryRuleMatcher } from "./proxy/retry-rules.js";
+import { modelState } from "./proxy/model-state.js";
 import fastifyStatic from "@fastify/static";
 import Database from "better-sqlite3";
 
@@ -121,6 +122,9 @@ export async function buildApp(
 
   // 首次启动时插入默认重试规则（表为空时）
   seedDefaultRules(db);
+
+  // 注入 DB 到 modelState 单例，启用会话级持久化
+  modelState.init(db);
   const matcher = new RetryRuleMatcher();
   matcher.load(db);
 

--- a/src/proxy/directive-parser.ts
+++ b/src/proxy/directive-parser.ts
@@ -1,0 +1,95 @@
+const MODEL_MAX_LEN = 128;
+const MODEL_RE = /^[a-zA-Z0-9][a-zA-Z0-9._:-]*$/;
+
+function isValidModelName(name: string): boolean {
+  return name.length <= MODEL_MAX_LEN && MODEL_RE.test(name) && !/^\d+$/.test(name);
+}
+
+export interface DirectiveParseResult {
+  modelName: string | null;
+  command: string | null;
+  cleanedBody: Record<string, unknown>;
+  isCommandMessage: boolean;
+}
+
+export function parseDirective(
+  body: Record<string, unknown>
+): DirectiveParseResult {
+  const messages = body.messages as
+    | Array<{ role: string; content: unknown }>
+    | undefined;
+  if (!messages?.length) {
+    return {
+      modelName: null,
+      command: null,
+      cleanedBody: body,
+      isCommandMessage: false,
+    };
+  }
+
+  let lastUserIdx = -1;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i].role === "user") {
+      lastUserIdx = i;
+      break;
+    }
+  }
+  if (lastUserIdx < 0) {
+    return {
+      modelName: null,
+      command: null,
+      cleanedBody: body,
+      isCommandMessage: false,
+    };
+  }
+
+  // Deep clone to avoid mutating the original request body
+  const cleanedBody = JSON.parse(JSON.stringify(body));
+  const cleanedMessages = cleanedBody.messages as Array<{
+    role: string;
+    content: unknown;
+  }>;
+  const lastUser = cleanedMessages[lastUserIdx];
+  const content = Array.isArray(lastUser.content)
+    ? lastUser.content
+    : [lastUser.content];
+
+  let modelName: string | null = null;
+  let command: string | null = null;
+  let isCommandMessage = false;
+
+  const reInline = /\$SELECT-MODEL=([a-zA-Z0-9._:-]+)/g;
+  const reHtmlComment = /<!--\s*router:model=([a-zA-Z0-9._\/:-]+)\s*-->/g;
+  const reCommand = /<!--\s*router:command=(\S+(?:\s+\S+)?)\s*-->/g;
+
+  for (const block of content) {
+    if (!block || typeof block !== "object") continue;
+    const b = block as { type?: string; text?: string };
+    if (b.type !== "text" || !b.text) continue;
+
+    let text = b.text;
+
+    const cmdMatch = reCommand.exec(text);
+    if (cmdMatch) {
+      command = cmdMatch[1];
+      isCommandMessage = true;
+      text = text.replace(reCommand, "").trim();
+    }
+
+    const inlineMatch = reInline.exec(text);
+    if (inlineMatch && isValidModelName(inlineMatch[1])) {
+      modelName = inlineMatch[1];
+      text = text.replace(reInline, "").trim();
+    }
+
+    const commentMatch = reHtmlComment.exec(text);
+    if (commentMatch && isValidModelName(commentMatch[1])) {
+      modelName = commentMatch[1];
+      text = text.replace(reHtmlComment, "").trim();
+    }
+
+    b.text = text;
+  }
+
+  return { modelName, command, cleanedBody, isCommandMessage };
+}

--- a/src/proxy/directive-parser.ts
+++ b/src/proxy/directive-parser.ts
@@ -59,8 +59,8 @@ export function parseDirective(
   let isCommandMessage = false;
 
   const reInline = /\$SELECT-MODEL=([a-zA-Z0-9._:-]+)/g;
-  const reHtmlComment = /<!--\s*router:model=([a-zA-Z0-9._\/:-]+)\s*-->/g;
-  const reCommand = /<!--\s*router:command=(\S+(?:\s+\S+)?)\s*-->/g;
+  const reModelTag = /\[router-model:\s*([a-zA-Z0-9._\/:-]+)\s*\]/g;
+  const reCommand = /\[router-command:\s*(\S+(?:\s+\S+)?)\s*\]/g;
 
   for (const block of content) {
     if (!block || typeof block !== "object") continue;
@@ -82,10 +82,10 @@ export function parseDirective(
       text = text.replace(reInline, "").trim();
     }
 
-    const commentMatch = reHtmlComment.exec(text);
-    if (commentMatch && isValidModelName(commentMatch[1])) {
-      modelName = commentMatch[1];
-      text = text.replace(reHtmlComment, "").trim();
+    const modelTagMatch = reModelTag.exec(text);
+    if (modelTagMatch && isValidModelName(modelTagMatch[1])) {
+      modelName = modelTagMatch[1];
+      text = text.replace(reModelTag, "").trim();
     }
 
     b.text = text;

--- a/src/proxy/enhancement-handler.ts
+++ b/src/proxy/enhancement-handler.ts
@@ -1,0 +1,70 @@
+import type { FastifyRequest } from "fastify";
+import Database from "better-sqlite3";
+import { getSetting } from "../db/settings.js";
+import { resolveMapping } from "./mapping-resolver.js";
+import { parseDirective } from "./directive-parser.js";
+import { modelState } from "./model-state.js";
+import { cleanRouterResponses } from "./response-cleaner.js";
+
+export interface EnhancementResult {
+  effectiveModel: string;
+  originalModel: string | null;
+}
+
+const MODEL_INFO_TAG_TYPE = "model-info";
+
+/**
+ * 在代理转发前应用代理增强逻辑（指令解析 + 会话记忆 + 模型替换）。
+ * 仅当 proxy_enhancement.claude_code_enabled 开启时生效。
+ */
+export function applyEnhancement(
+  db: Database.Database,
+  request: FastifyRequest,
+  clientModel: string,
+): EnhancementResult {
+  const enhancementRaw = getSetting(db, "proxy_enhancement");
+  let enhancement: { claude_code_enabled?: boolean } | null = null;
+  try {
+    enhancement = enhancementRaw ? JSON.parse(enhancementRaw) : null;
+  } catch {
+    request.log.warn("Invalid proxy_enhancement JSON, feature disabled");
+  }
+
+  if (enhancement?.claude_code_enabled !== true) {
+    return { effectiveModel: clientModel, originalModel: null };
+  }
+
+  // 清理历史消息中的 <router-response> 标签
+  const cleaned = cleanRouterResponses(request.body as Record<string, unknown>);
+  (request.body as Record<string, unknown>).messages = cleaned.messages;
+
+  const directive = parseDirective(request.body as Record<string, unknown>);
+
+  if (directive.modelName) {
+    // 内联模型指令 → resolveMapping 验证
+    const resolvedDirective = resolveMapping(db, directive.modelName, { now: new Date() });
+    if (resolvedDirective) {
+      modelState.set(request.routerKey?.id ?? null, directive.modelName);
+      (request.body as Record<string, unknown>).messages = directive.cleanedBody.messages;
+      return { effectiveModel: directive.modelName, originalModel: clientModel };
+    }
+    // 映射失败时保留原始请求（降级策略）
+    return { effectiveModel: clientModel, originalModel: null };
+  }
+
+  // 无指令 → 查询会话记忆
+  const remembered = modelState.get(request.routerKey?.id ?? null);
+  if (remembered) {
+    const resolvedRemembered = resolveMapping(db, remembered, { now: new Date() });
+    if (resolvedRemembered) {
+      return { effectiveModel: remembered, originalModel: clientModel };
+    }
+  }
+
+  return { effectiveModel: clientModel, originalModel: null };
+}
+
+/** 生成注入到非流式响应中的模型信息标签 */
+export function buildModelInfoTag(effectiveModel: string): string {
+  return `<router-response type="${MODEL_INFO_TAG_TYPE}">当前模型: ${effectiveModel}</router-response>`;
+}

--- a/src/proxy/enhancement-handler.ts
+++ b/src/proxy/enhancement-handler.ts
@@ -2,7 +2,7 @@ import { randomUUID } from "crypto";
 import type { FastifyRequest } from "fastify";
 import Database from "better-sqlite3";
 import { getSetting } from "../db/settings.js";
-import { getAllMappingGroups, getAllModelMappings } from "../db/index.js";
+import { getActiveProviderModels, resolveByProviderModel } from "../db/index.js";
 import { resolveMapping } from "./mapping-resolver.js";
 import { parseDirective } from "./directive-parser.js";
 import { modelState } from "./model-state.js";
@@ -22,6 +22,16 @@ export interface EnhancementResult {
 }
 
 const MODEL_INFO_TAG_TYPE = "model-info";
+
+/**
+ * 解析 "provider_name/backend_model" 格式，返回对应的 client_model。
+ * provider_name 只允许 [a-zA-Z0-9_-]，/ 作为分隔符。
+ */
+function resolveProviderModel(db: Database.Database, providerSlashModel: string): string | null {
+  const match = /^([a-zA-Z0-9_-]+)\/(.+)$/.exec(providerSlashModel);
+  if (!match) return null;
+  return resolveByProviderModel(db, match[1], match[2]);
+}
 
 /**
  * 在代理转发前应用代理增强逻辑（指令解析 + 会话记忆 + 模型替换 + 命令拦截）。
@@ -61,16 +71,17 @@ export function applyEnhancement(
 
     // 带参数：设置模型并返回确认
     if (arg && arg !== "") {
-      const resolved = resolveMapping(db, arg, { now: new Date() });
-      if (resolved) {
+      const resolvedClientModel = resolveProviderModel(db, arg);
+      if (resolvedClientModel) {
+        // 存储 provider_name/backend_model 格式，便于回显；同时传入 client_model 用于记录原始模型
         modelState.set(routerKeyId, arg, sessionId, clientModel, "command");
       }
       return {
-        effectiveModel: clientModel,
+        effectiveModel: resolvedClientModel ?? clientModel,
         originalModel: null,
         interceptResponse: {
-          ...buildSelectModelResponse(db, routerKeyId, request.routerKey?.allowed_models, resolved ? arg : undefined),
-          meta: { action: resolved ? "模型选择" : "模型选择失败", detail: arg },
+          ...buildSelectModelResponse(db, request.routerKey?.allowed_models ?? null, resolvedClientModel ? arg : undefined),
+          meta: { action: resolvedClientModel ? "模型选择" : "模型选择失败", detail: arg },
         },
       };
     }
@@ -80,14 +91,14 @@ export function applyEnhancement(
       effectiveModel: clientModel,
       originalModel: null,
       interceptResponse: {
-        ...buildSelectModelResponse(db, routerKeyId, request.routerKey?.allowed_models),
+        ...buildSelectModelResponse(db, request.routerKey?.allowed_models ?? null),
         meta: { action: "模型列表" },
       },
     };
   }
 
   if (directive.modelName) {
-    // 内联模型指令 → resolveMapping 验证
+    // 内联模型指令 → resolveMapping 验证（client_model 格式）
     const resolvedDirective = resolveMapping(db, directive.modelName, { now: new Date() });
     if (resolvedDirective) {
       modelState.set(request.routerKey?.id ?? null, directive.modelName, sessionId, clientModel, "directive");
@@ -101,6 +112,12 @@ export function applyEnhancement(
   // 无指令 → 查询会话记忆
   const remembered = modelState.get(request.routerKey?.id ?? null, sessionId);
   if (remembered) {
+    // 优先尝试 provider_name/backend_model 格式（select-model 命令存储）
+    const providerResolved = resolveProviderModel(db, remembered);
+    if (providerResolved) {
+      return { effectiveModel: providerResolved, originalModel: clientModel, interceptResponse: null };
+    }
+    // 回退到 client_model 格式（内联指令存储）
     const resolvedRemembered = resolveMapping(db, remembered, { now: new Date() });
     if (resolvedRemembered) {
       return { effectiveModel: remembered, originalModel: clientModel, interceptResponse: null };
@@ -110,26 +127,15 @@ export function applyEnhancement(
   return nullResult;
 }
 
-/** 查询所有可用的 client_model 并构造 Anthropic 格式响应 */
+/** 查询所有可用的 provider_model 并构造 Anthropic 格式响应 */
 function buildSelectModelResponse(
   db: Database.Database,
-  _routerKeyId: string | null,
-  allowedModelsRaw?: string | null,
+  allowedModelsRaw: string | null | undefined,
   selectedModel?: string | null,
 ): InterceptResponse {
-  // mapping_groups 是路由的核心数据源，model_mappings 是可选的辅助映射
-  const groups = getAllMappingGroups(db);
-  const allMappings = getAllModelMappings(db);
-  const activeMappingModels = new Set(
-    allMappings.filter(m => m.is_active).map(m => m.client_model),
-  );
-  // 合并去重：有分组的（可路由）+ 活跃的辅助映射
-  const models = [...new Set([
-    ...groups.map(g => g.client_model),
-    ...activeMappingModels,
-  ])];
+  const providerModels = getActiveProviderModels(db);
 
-  // 按 allowed_models 过滤
+  // 按 allowed_models 过滤（allowed_models 存储的是 client_model 列表）
   let allowedSet: Set<string> | null = null;
   if (allowedModelsRaw) {
     try {
@@ -137,18 +143,31 @@ function buildSelectModelResponse(
       if (parsed.length > 0) allowedSet = new Set(parsed);
     } catch { /* 忽略解析失败 */ }
   }
-  const filtered = allowedSet ? models.filter(m => allowedSet!.has(m)) : models;
+  const filtered = allowedSet
+    ? providerModels.filter(m => allowedSet!.has(m.client_model))
+    : providerModels;
 
-  // 构造文本
-  let text: string;
-  if (selectedModel) {
-    // 带参数调用：返回选择确认
-    text = `已选择模型: ${selectedModel}`;
-  } else if (filtered.length > 0) {
-    text = filtered.map((m, i) => `${i + 1}. ${m}`).join("\n");
-  } else {
-    text = "（无可用模型）";
+  // 去重并格式化为 "provider_name/backend_model"
+  const seen = new Set<string>();
+  const displayModels: string[] = [];
+  for (const m of filtered) {
+    const key = `${m.provider_name}/${m.backend_model}`;
+    if (!seen.has(key)) {
+      seen.add(key);
+      displayModels.push(key);
+    }
   }
+
+  // 构造文本（用 <router-response> 包裹，使 response-cleaner 能过滤历史消息）
+  let inner: string;
+  if (selectedModel) {
+    inner = `已选择模型: ${selectedModel}`;
+  } else if (displayModels.length > 0) {
+    inner = displayModels.map((m, i) => `${i + 1}. ${m}`).join("\n");
+  } else {
+    inner = "（无可用模型）";
+  }
+  const text = `<router-response type="${selectedModel ? "model-selected" : "model-list"}">${inner}</router-response>`;
 
   const body = {
     id: `msg-${randomUUID()}`,

--- a/src/proxy/enhancement-handler.ts
+++ b/src/proxy/enhancement-handler.ts
@@ -1,27 +1,40 @@
+import { randomUUID } from "crypto";
 import type { FastifyRequest } from "fastify";
 import Database from "better-sqlite3";
 import { getSetting } from "../db/settings.js";
+import { getAllMappingGroups, getAllModelMappings } from "../db/index.js";
 import { resolveMapping } from "./mapping-resolver.js";
 import { parseDirective } from "./directive-parser.js";
 import { modelState } from "./model-state.js";
 import { cleanRouterResponses } from "./response-cleaner.js";
 
+export interface InterceptResponse {
+  statusCode: number;
+  body: unknown;
+  /** 拦截元数据，用于日志记录 */
+  meta?: { action: string; detail?: string };
+}
+
 export interface EnhancementResult {
   effectiveModel: string;
   originalModel: string | null;
+  interceptResponse: InterceptResponse | null;
 }
 
 const MODEL_INFO_TAG_TYPE = "model-info";
 
 /**
- * 在代理转发前应用代理增强逻辑（指令解析 + 会话记忆 + 模型替换）。
+ * 在代理转发前应用代理增强逻辑（指令解析 + 会话记忆 + 模型替换 + 命令拦截）。
  * 仅当 proxy_enhancement.claude_code_enabled 开启时生效。
  */
 export function applyEnhancement(
   db: Database.Database,
   request: FastifyRequest,
   clientModel: string,
+  sessionId?: string,
 ): EnhancementResult {
+  const nullResult: EnhancementResult = { effectiveModel: clientModel, originalModel: null, interceptResponse: null };
+
   const enhancementRaw = getSetting(db, "proxy_enhancement");
   let enhancement: { claude_code_enabled?: boolean } | null = null;
   try {
@@ -31,7 +44,7 @@ export function applyEnhancement(
   }
 
   if (enhancement?.claude_code_enabled !== true) {
-    return { effectiveModel: clientModel, originalModel: null };
+    return nullResult;
   }
 
   // 清理历史消息中的 <router-response> 标签
@@ -40,28 +53,115 @@ export function applyEnhancement(
 
   const directive = parseDirective(request.body as Record<string, unknown>);
 
+  // 命令拦截：select-model → 返回可用模型列表
+  if (directive.isCommandMessage && directive.command?.startsWith("select-model")) {
+    const routerKeyId = request.routerKey?.id ?? null;
+    const parts = directive.command.trim().split(/\s+/);
+    const arg = parts.length > 1 ? parts.slice(1).join(" ") : null;
+
+    // 带参数：设置模型并返回确认
+    if (arg && arg !== "") {
+      const resolved = resolveMapping(db, arg, { now: new Date() });
+      if (resolved) {
+        modelState.set(routerKeyId, arg, sessionId, clientModel, "command");
+      }
+      return {
+        effectiveModel: clientModel,
+        originalModel: null,
+        interceptResponse: {
+          ...buildSelectModelResponse(db, routerKeyId, request.routerKey?.allowed_models, resolved ? arg : undefined),
+          meta: { action: resolved ? "模型选择" : "模型选择失败", detail: arg },
+        },
+      };
+    }
+
+    // 无参数：返回模型列表
+    return {
+      effectiveModel: clientModel,
+      originalModel: null,
+      interceptResponse: {
+        ...buildSelectModelResponse(db, routerKeyId, request.routerKey?.allowed_models),
+        meta: { action: "模型列表" },
+      },
+    };
+  }
+
   if (directive.modelName) {
     // 内联模型指令 → resolveMapping 验证
     const resolvedDirective = resolveMapping(db, directive.modelName, { now: new Date() });
     if (resolvedDirective) {
-      modelState.set(request.routerKey?.id ?? null, directive.modelName);
+      modelState.set(request.routerKey?.id ?? null, directive.modelName, sessionId, clientModel, "directive");
       (request.body as Record<string, unknown>).messages = directive.cleanedBody.messages;
-      return { effectiveModel: directive.modelName, originalModel: clientModel };
+      return { effectiveModel: directive.modelName, originalModel: clientModel, interceptResponse: null };
     }
     // 映射失败时保留原始请求（降级策略）
-    return { effectiveModel: clientModel, originalModel: null };
+    return nullResult;
   }
 
   // 无指令 → 查询会话记忆
-  const remembered = modelState.get(request.routerKey?.id ?? null);
+  const remembered = modelState.get(request.routerKey?.id ?? null, sessionId);
   if (remembered) {
     const resolvedRemembered = resolveMapping(db, remembered, { now: new Date() });
     if (resolvedRemembered) {
-      return { effectiveModel: remembered, originalModel: clientModel };
+      return { effectiveModel: remembered, originalModel: clientModel, interceptResponse: null };
     }
   }
 
-  return { effectiveModel: clientModel, originalModel: null };
+  return nullResult;
+}
+
+/** 查询所有可用的 client_model 并构造 Anthropic 格式响应 */
+function buildSelectModelResponse(
+  db: Database.Database,
+  _routerKeyId: string | null,
+  allowedModelsRaw?: string | null,
+  selectedModel?: string | null,
+): InterceptResponse {
+  // mapping_groups 是路由的核心数据源，model_mappings 是可选的辅助映射
+  const groups = getAllMappingGroups(db);
+  const allMappings = getAllModelMappings(db);
+  const activeMappingModels = new Set(
+    allMappings.filter(m => m.is_active).map(m => m.client_model),
+  );
+  // 合并去重：有分组的（可路由）+ 活跃的辅助映射
+  const models = [...new Set([
+    ...groups.map(g => g.client_model),
+    ...activeMappingModels,
+  ])];
+
+  // 按 allowed_models 过滤
+  let allowedSet: Set<string> | null = null;
+  if (allowedModelsRaw) {
+    try {
+      const parsed: string[] = JSON.parse(allowedModelsRaw).filter((s: string) => s.trim() !== "");
+      if (parsed.length > 0) allowedSet = new Set(parsed);
+    } catch { /* 忽略解析失败 */ }
+  }
+  const filtered = allowedSet ? models.filter(m => allowedSet!.has(m)) : models;
+
+  // 构造文本
+  let text: string;
+  if (selectedModel) {
+    // 带参数调用：返回选择确认
+    text = `已选择模型: ${selectedModel}`;
+  } else if (filtered.length > 0) {
+    text = filtered.map((m, i) => `${i + 1}. ${m}`).join("\n");
+  } else {
+    text = "（无可用模型）";
+  }
+
+  const body = {
+    id: `msg-${randomUUID()}`,
+    type: "message",
+    role: "assistant",
+    content: [{ type: "text", text }],
+    model: "router",
+    stop_reason: "end_turn",
+    stop_sequence: null,
+    usage: { input_tokens: 0, output_tokens: 0 },
+  };
+
+  return { statusCode: 200, body };
 }
 
 /** 生成注入到非流式响应中的模型信息标签 */

--- a/src/proxy/enhancement-handler.ts
+++ b/src/proxy/enhancement-handler.ts
@@ -78,7 +78,8 @@ export function applyEnhancement(
         modelState.set(routerKeyId, arg, sessionId, clientModel, "command");
       }
       return {
-        effectiveModel: resolvedClientModel ?? clientModel,
+        // 保留 provider_name/backend_model 格式，resolveMapping 会直接解析
+        effectiveModel: resolvedClientModel ? arg : clientModel,
         originalModel: null,
         interceptResponse: {
           ...buildSelectModelResponse(db, request.routerKey?.allowed_models ?? null, resolvedClientModel ? arg : undefined),
@@ -114,9 +115,10 @@ export function applyEnhancement(
   const remembered = modelState.get(request.routerKey?.id ?? null, sessionId);
   if (remembered) {
     // 优先尝试 provider_name/backend_model 格式（select-model 命令存储）
+    // 直接保留该格式，resolveMapping 会解析出 provider + model
     const providerResolved = resolveProviderModel(db, remembered);
     if (providerResolved) {
-      return { effectiveModel: providerResolved, originalModel: clientModel, interceptResponse: null };
+      return { effectiveModel: remembered, originalModel: clientModel, interceptResponse: null };
     }
     // 回退到 client_model 格式（内联指令存储）
     const resolvedRemembered = resolveMapping(db, remembered, { now: new Date() });

--- a/src/proxy/enhancement-handler.ts
+++ b/src/proxy/enhancement-handler.ts
@@ -30,7 +30,8 @@ const MODEL_INFO_TAG_TYPE = "model-info";
 function resolveProviderModel(db: Database.Database, providerSlashModel: string): string | null {
   const match = /^([a-zA-Z0-9_-]+)\/(.+)$/.exec(providerSlashModel);
   if (!match) return null;
-  return resolveByProviderModel(db, match[1], match[2]);
+  const resolved = resolveByProviderModel(db, match[1], match[2]);
+  return resolved?.client_model ?? null;
 }
 
 /**
@@ -144,7 +145,7 @@ function buildSelectModelResponse(
     } catch { /* 忽略解析失败 */ }
   }
   const filtered = allowedSet
-    ? providerModels.filter(m => allowedSet!.has(m.client_model))
+    ? providerModels.filter(m => allowedSet!.has(m.backend_model))
     : providerModels;
 
   // 去重并格式化为 "provider_name/backend_model"

--- a/src/proxy/log-helpers.ts
+++ b/src/proxy/log-helpers.ts
@@ -1,0 +1,85 @@
+import Database from "better-sqlite3";
+import type { Provider } from "../db/index.js";
+import { insertRequestLog } from "../db/index.js";
+import type { RawHeaders } from "./proxy-core.js";
+
+export interface RequestLogParams {
+  id: string;
+  apiType: string;
+  model: string;
+  provider: Provider;
+  isStream: boolean;
+  startTime: number;
+  reqBody: string;
+  clientReq: string;
+  upstreamReq: string;
+  status: number;
+  respBody: string | null;
+  upHdrs: Record<string, string>;
+  cliHdrs: Record<string, string>;
+  isRetry?: boolean;
+  originalRequestId?: string | null;
+  routerKeyId?: string | null;
+  originalModel?: string | null;
+}
+
+/** 插入成功请求日志，供 openai/anthropic 插件共享 */
+export function insertSuccessLog(
+  db: Database.Database,
+  params: RequestLogParams,
+): void {
+  const { id: logId, apiType, model, provider, isStream, startTime,
+    reqBody, clientReq, upstreamReq, status, respBody, upHdrs, cliHdrs,
+    isRetry = false, originalRequestId = null, routerKeyId = null, originalModel = null } = params;
+
+  insertRequestLog(db, {
+    id: logId, api_type: apiType, model, provider_id: provider.id,
+    status_code: status, latency_ms: Date.now() - startTime,
+    is_stream: isStream ? 1 : 0, error_message: null,
+    created_at: new Date().toISOString(), request_body: reqBody,
+    response_body: respBody, client_request: clientReq, upstream_request: upstreamReq,
+    upstream_response: JSON.stringify({ statusCode: status, headers: upHdrs, body: respBody }),
+    client_response: JSON.stringify({ statusCode: status, headers: cliHdrs, body: respBody }),
+    is_retry: isRetry ? 1 : 0, original_request_id: originalRequestId,
+    router_key_id: routerKeyId, original_model: originalModel,
+  });
+}
+
+export interface RejectedLogParams {
+  db: Database.Database;
+  logId: string;
+  apiType: string;
+  model: string;
+  statusCode: number;
+  errorMessage: string;
+  startTime: number;
+  isStream: boolean;
+  routerKeyId: string | null;
+  originalBody: Record<string, unknown>;
+  clientHeaders: RawHeaders;
+  providerId?: string | null;
+  originalModel?: string | null;
+}
+
+/** Log a request rejected before reaching upstream */
+export function insertRejectedLog(params: RejectedLogParams): void {
+  const { db, logId, apiType, model, statusCode, errorMessage,
+    startTime, isStream, routerKeyId, originalBody, clientHeaders,
+    providerId = null, originalModel = null } = params;
+
+  insertRequestLog(db, {
+    id: logId,
+    api_type: apiType,
+    model,
+    provider_id: providerId,
+    status_code: statusCode,
+    latency_ms: Date.now() - startTime,
+    is_stream: isStream ? 1 : 0,
+    error_message: errorMessage,
+    created_at: new Date().toISOString(),
+    request_body: JSON.stringify(originalBody),
+    client_request: JSON.stringify({ headers: clientHeaders, body: originalBody }),
+    router_key_id: routerKeyId,
+    original_model: originalModel,
+  });
+}

--- a/src/proxy/mapping-resolver.ts
+++ b/src/proxy/mapping-resolver.ts
@@ -23,8 +23,39 @@ export function resolveMapping(
   clientModel: string,
   context: ResolveContext,
 ): Target | null {
+  // 优先处理 provider_name/backend_model 格式（如 kimi-coding-plan/kimi-for-coding）
+  // 这种格式直接路由到指定 provider，不需要 mapping group
+  const slashMatch = /^([a-zA-Z0-9_-]+)\/(.+)$/.exec(clientModel);
+  if (slashMatch) {
+    const providerName = slashMatch[1];
+    const backendModel = slashMatch[2];
+    const provider = db.prepare("SELECT id, models FROM providers WHERE name = ? AND is_active = 1").get(providerName) as { id: string; models: string } | undefined;
+    if (provider) {
+      try {
+        const models: string[] = JSON.parse(provider.models);
+        if (models.includes(backendModel)) {
+          return { backend_model: backendModel, provider_id: provider.id };
+        }
+      } catch { /* 忽略解析失败 */ }
+    }
+    // 明确的 provider/model 格式解析失败，不再 fallback 到 mapping group
+    return null;
+  }
+
   const group = getMappingGroup(db, clientModel);
-  if (!group) return null;
+  if (!group) {
+    // Fallback: 没有 mapping group 时，直接查 provider 的 models 字段
+    const providers = db.prepare("SELECT id, models FROM providers WHERE is_active = 1").all() as { id: string; models: string }[];
+    for (const p of providers) {
+      try {
+        const models: string[] = JSON.parse(p.models);
+        if (models.includes(clientModel)) {
+          return { backend_model: clientModel, provider_id: p.id };
+        }
+      } catch { /* 忽略解析失败 */ }
+    }
+    return null;
+  }
 
   let rule: unknown;
   try { rule = JSON.parse(group.rule); } catch { console.warn(`[mapping-resolver] Failed to parse rule for client_model '${group.client_model}'`); return null; }

--- a/src/proxy/model-state.ts
+++ b/src/proxy/model-state.ts
@@ -1,0 +1,31 @@
+const TTL_MS = 24 * 60 * 60 * 1000;
+
+interface StateEntry {
+  model: string;
+  updatedAt: number;
+}
+
+export class ModelStateManager {
+  private store = new Map<string | null, StateEntry>();
+
+  set(routerKeyId: string | null, model: string): void {
+    if (model === "default") {
+      this.store.delete(routerKeyId);
+      return;
+    }
+    this.store.set(routerKeyId, { model, updatedAt: Date.now() });
+  }
+
+  get(routerKeyId: string | null): string | null {
+    const entry = this.store.get(routerKeyId);
+    if (!entry) return null;
+    if (Date.now() - entry.updatedAt > TTL_MS) {
+      this.store.delete(routerKeyId);
+      return null;
+    }
+    return entry.model;
+  }
+}
+
+// singleton
+export const modelState = new ModelStateManager();

--- a/src/proxy/model-state.ts
+++ b/src/proxy/model-state.ts
@@ -1,4 +1,7 @@
-const TTL_MS = 24 * 60 * 60 * 1000;
+const HOUR_MS = 3600_000;
+// 会话记忆在 24 小时后过期（滑动窗口）
+const TTL_HOURS = 24;
+const TTL_MS = TTL_HOURS * HOUR_MS;
 
 interface StateEntry {
   model: string;

--- a/src/proxy/model-state.ts
+++ b/src/proxy/model-state.ts
@@ -1,5 +1,13 @@
-const HOUR_MS = 3600_000;
+import type Database from "better-sqlite3";
+import {
+  upsertSessionState,
+  getSessionState,
+  deleteSessionState,
+  insertSessionHistory,
+} from "../db/session-states.js";
+
 // 会话记忆在 24 小时后过期（滑动窗口）
+const HOUR_MS = 3600_000;
 const TTL_HOURS = 24;
 const TTL_MS = TTL_HOURS * HOUR_MS;
 
@@ -9,24 +17,125 @@ interface StateEntry {
 }
 
 export class ModelStateManager {
-  private store = new Map<string | null, StateEntry>();
+  private store = new Map<string, StateEntry>();
+  private db: Database.Database | null = null;
 
-  set(routerKeyId: string | null, model: string): void {
-    if (model === "default") {
-      this.store.delete(routerKeyId);
-      return;
-    }
-    this.store.set(routerKeyId, { model, updatedAt: Date.now() });
+  /** 单例注入 DB 实例，启动时调用一次 */
+  init(db: Database.Database): void {
+    this.db = db;
   }
 
-  get(routerKeyId: string | null): string | null {
-    const entry = this.store.get(routerKeyId);
-    if (!entry) return null;
-    if (Date.now() - entry.updatedAt > TTL_MS) {
-      this.store.delete(routerKeyId);
-      return null;
+  /** 构造内存 Map 的 key：有 sessionId 时用复合键 */
+  buildKey(routerKeyId: string | null, sessionId?: string): string {
+    if (sessionId) {
+      return `${routerKeyId ?? "null"}:${sessionId}`;
     }
-    return entry.model;
+    return String(routerKeyId);
+  }
+
+  /**
+   * 写入模型状态。
+   * - 始终写内存
+   * - 有 sessionId 时双写 DB（事务：upsert + history）
+   * - model="default" 时删除记忆
+   */
+  set(
+    routerKeyId: string | null,
+    model: string,
+    sessionId?: string,
+    originalModel?: string,
+    triggerType?: string,
+  ): void {
+    const key = this.buildKey(routerKeyId, sessionId);
+
+    if (model === "default") {
+      this.store.delete(key);
+      if (sessionId && routerKeyId && this.db) {
+        this.db.transaction(() => {
+          deleteSessionState(this.db!, routerKeyId, sessionId);
+          insertSessionHistory(this.db!, {
+            router_key_id: routerKeyId,
+            session_id: sessionId,
+            old_model: null,
+            new_model: "default",
+            trigger_type: triggerType ?? "command",
+          });
+        })();
+      }
+      return;
+    }
+
+    this.store.set(key, { model, updatedAt: Date.now() });
+
+    if (sessionId && routerKeyId && this.db) {
+      this.db.transaction(() => {
+        upsertSessionState(this.db!, {
+          router_key_id: routerKeyId,
+          session_id: sessionId,
+          current_model: model,
+          original_model: originalModel ?? null,
+        });
+        insertSessionHistory(this.db!, {
+          router_key_id: routerKeyId,
+          session_id: sessionId,
+          old_model: null,
+          new_model: model,
+          trigger_type: triggerType ?? "command",
+        });
+      })();
+    }
+  }
+
+  /**
+   * 读取模型状态。
+   * - 先查内存，命中且未过期直接返回
+   * - 未命中且有 sessionId 时查 DB 并回填内存
+   */
+  get(routerKeyId: string | null, sessionId?: string): string | null {
+    const key = this.buildKey(routerKeyId, sessionId);
+    const entry = this.store.get(key);
+
+    // 内存命中
+    if (entry) {
+      if (Date.now() - entry.updatedAt > TTL_MS) {
+        this.store.delete(key);
+        return null;
+      }
+      return entry.model;
+    }
+
+    // 内存未命中，尝试从 DB 回填
+    if (sessionId && routerKeyId && this.db) {
+      const row = getSessionState(this.db, routerKeyId, sessionId);
+      if (row) {
+        this.store.set(key, { model: row.current_model, updatedAt: Date.now() });
+        return row.current_model;
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * 删除模型状态。
+   * - 同时清除内存和 DB
+   */
+  delete(routerKeyId: string, sessionId: string): void {
+    const key = this.buildKey(routerKeyId, sessionId);
+    this.store.delete(key);
+
+    if (this.db) {
+      this.db.transaction(() => {
+        deleteSessionState(this.db!, routerKeyId, sessionId);
+        insertSessionHistory(this.db!, {
+          router_key_id: routerKeyId,
+          session_id: sessionId,
+          old_model: null,
+          new_model: "default",
+          trigger_type: "manual_clear",
+        });
+      })();
+    }
   }
 }
 

--- a/src/proxy/proxy-core.ts
+++ b/src/proxy/proxy-core.ts
@@ -1,413 +1,31 @@
 import { randomUUID } from "crypto";
-import { request as httpRequestFn, IncomingMessage } from "http";
-import { request as httpsRequestFn } from "https";
-import { PassThrough } from "stream";
 import type { FastifyReply, FastifyRequest } from "fastify";
 import Database from "better-sqlite3";
 import type { Provider } from "../db/index.js";
 import { getProviderById, insertRequestLog, insertMetrics } from "../db/index.js";
 import { decrypt } from "../utils/crypto.js";
 import { getSetting } from "../db/settings.js";
-import { SSEMetricsTransform } from "../metrics/sse-metrics-transform.js";
 import { MetricsExtractor } from "../metrics/metrics-extractor.js";
-import type { MetricsResult } from "../metrics/metrics-extractor.js";
 import { getMappingGroup } from "../db/index.js";
 import { resolveMapping } from "./mapping-resolver.js";
 import { retryableCall, buildRetryConfig } from "./retry.js";
 import type { RetryRuleMatcher } from "./retry-rules.js";
 import type { Target } from "./strategy/types.js";
-import { parseDirective } from "./directive-parser.js";
-import { modelState } from "./model-state.js";
-import { cleanRouterResponses } from "./response-cleaner.js";
+import { SSEMetricsTransform } from "../metrics/sse-metrics-transform.js";
+import {
+  proxyNonStream as upstreamNonStream,
+  proxyStream as upstreamStream,
+  proxyGetRequest as upstreamGet,
+  type ProxyResult,
+  type StreamProxyResult,
+  type GetProxyResult,
+} from "./upstream-call.js";
+import { insertSuccessLog, insertRejectedLog } from "./log-helpers.js";
+import { applyEnhancement, buildModelInfoTag } from "./enhancement-handler.js";
 
 // ---------- Types ----------
 
 export type RawHeaders = Record<string, string | string[] | undefined>;
-
-export interface UpstreamRequestOptions {
-  hostname: string;
-  port: number;
-  path: string;
-  method: string;
-  headers: Record<string, string>;
-}
-
-export interface ProxyResult {
-  statusCode: number;
-  body: string;
-  headers: Record<string, string>;
-  sentHeaders: Record<string, string>;
-  sentBody: string;
-}
-
-export interface StreamProxyResult {
-  statusCode: number;
-  responseBody?: string;
-  upstreamResponseHeaders?: Record<string, string>;
-  sentHeaders?: Record<string, string>;
-  /** 流结束时从 SSEMetricsTransform 采集的指标，仅当传入了 metricsTransform 时存在 */
-  metricsResult?: MetricsResult;
-}
-
-export interface GetProxyResult {
-  statusCode: number;
-  body: string;
-  headers: Record<string, string>;
-}
-
-// ---------- Constants ----------
-
-export const UPSTREAM_SUCCESS = 200;
-// failover 判断上游请求失败的 HTTP 状态码阈值
-const FAILOVER_FAIL_THRESHOLD = 400;
-const HTTPS_DEFAULT_PORT = 443;
-const HTTP_DEFAULT_PORT = 80;
-const UPSTREAM_BAD_GATEWAY = 502;
-
-// ---------- Header utilities ----------
-
-export const SKIP_UPSTREAM = new Set([
-  "host",
-  "content-length",
-  "accept-encoding",
-  "authorization",
-  "connection",
-  "keep-alive",
-  "transfer-encoding",
-  "upgrade",
-]);
-
-export const SKIP_DOWNSTREAM = new Set([
-  "content-length",
-  "transfer-encoding",
-  "connection",
-  "keep-alive",
-]);
-
-export function selectHeaders(
-  raw: RawHeaders,
-  skip: Set<string>
-): Record<string, string> {
-  const out: Record<string, string> = {};
-  for (const [key, value] of Object.entries(raw)) {
-    if (value == null || skip.has(key.toLowerCase())) continue;
-    out[key] = Array.isArray(value) ? value.join(", ") : value;
-  }
-  return out;
-}
-
-// 当前两个 provider 都使用 Bearer token（commit eaa4f7d 将 Anthropic 从 x-api-key 改为 Bearer）
-// 如果未来需要支持其他鉴权方式，需要参数化 header 构造
-/** 构建发往上游的请求 headers：过滤客户端 headers + 注入后端 API key */
-export function buildUpstreamHeaders(
-  clientHeaders: RawHeaders,
-  apiKey: string,
-  payloadBytes?: number
-): Record<string, string> {
-  const headers = selectHeaders(clientHeaders, SKIP_UPSTREAM);
-  headers["Authorization"] = `Bearer ${apiKey}`;
-  if (payloadBytes !== undefined) {
-    headers["Content-Type"] = "application/json";
-    headers["Content-Length"] = String(payloadBytes);
-  }
-  return headers;
-}
-
-// ---------- Request utilities ----------
-
-/** 根据 URL scheme 选择 http 或 https 模块 */
-export function createUpstreamRequest(url: URL, options: UpstreamRequestOptions) {
-  return url.protocol === "https:" ? httpsRequestFn(options) : httpRequestFn(options);
-}
-
-/** 从 URL + headers 构造 Node.js http.request 所需的 options */
-export function buildRequestOptions(
-  url: URL,
-  headers: Record<string, string>,
-  method = "POST"
-): UpstreamRequestOptions {
-  return {
-    hostname: url.hostname,
-    port: Number(url.port) || (url.protocol === "https:" ? HTTPS_DEFAULT_PORT : HTTP_DEFAULT_PORT),
-    path: url.pathname,
-    method,
-    headers,
-  };
-}
-
-// ---------- Logging ----------
-
-/** 插入成功请求日志，供 openai/anthropic 插件共享 */
-export function insertSuccessLog(
-  db: Database.Database,
-  apiType: string,
-  logId: string,
-  model: string,
-  provider: Provider,
-  isStream: boolean,
-  startTime: number,
-  reqBody: string,
-  clientReq: string,
-  upstreamReq: string,
-  status: number,
-  respBody: string | null,
-  upHdrs: Record<string, string>,
-  cliHdrs: Record<string, string>,
-  isRetry: boolean = false, originalRequestId: string | null = null,
-  routerKeyId: string | null = null,
-  originalModel: string | null = null,
-) {
-  insertRequestLog(db, {
-    id: logId, api_type: apiType, model, provider_id: provider.id,
-    status_code: status, latency_ms: Date.now() - startTime,
-    is_stream: isStream ? 1 : 0, error_message: null,
-    created_at: new Date().toISOString(), request_body: reqBody,
-    response_body: respBody, client_request: clientReq, upstream_request: upstreamReq,
-    upstream_response: JSON.stringify({ statusCode: status, headers: upHdrs, body: respBody }),
-    client_response: JSON.stringify({ statusCode: status, headers: cliHdrs, body: respBody }),
-    is_retry: isRetry ? 1 : 0, original_request_id: originalRequestId,
-    router_key_id: routerKeyId, original_model: originalModel,
-  });
-}
-
-/** Log a request rejected before reaching upstream */
-function insertRejectedLog(
-  db: Database.Database,
-  logId: string,
-  apiType: string,
-  model: string,
-  statusCode: number,
-  errorMessage: string,
-  startTime: number,
-  isStream: boolean,
-  routerKeyId: string | null,
-  originalBody: Record<string, unknown>,
-  clientHeaders: RawHeaders,
-  providerId?: string | null,
-  originalModel: string | null = null,
-): void {
-  insertRequestLog(db, {
-    id: logId,
-    api_type: apiType,
-    model,
-    provider_id: providerId ?? null,
-    status_code: statusCode,
-    latency_ms: Date.now() - startTime,
-    is_stream: isStream ? 1 : 0,
-    error_message: errorMessage,
-    created_at: new Date().toISOString(),
-    request_body: JSON.stringify(originalBody),
-    client_request: JSON.stringify({ headers: clientHeaders, body: originalBody }),
-    router_key_id: routerKeyId,
-    original_model: originalModel,
-  });
-}
-
-export function proxyNonStream(
-  backend: Provider,
-  apiKey: string,
-  body: Record<string, unknown>,
-  clientHeaders: RawHeaders,
-  upstreamPath: string
-): Promise<ProxyResult> {
-  return new Promise((resolve, reject) => {
-    const url = new URL(`${backend.base_url}${upstreamPath}`);
-    const payload = JSON.stringify(body);
-    const upstreamHeaders = buildUpstreamHeaders(clientHeaders, apiKey, Buffer.byteLength(payload));
-    const options = buildRequestOptions(url, upstreamHeaders);
-
-    const req = createUpstreamRequest(url, options);
-    req.on("response", (res: IncomingMessage) => {
-      const chunks: Buffer[] = [];
-      res.on("data", (chunk: Buffer) => chunks.push(chunk));
-      res.on("end", () => {
-        resolve({
-          statusCode: res.statusCode || UPSTREAM_BAD_GATEWAY,
-          body: Buffer.concat(chunks).toString("utf-8"),
-          headers: selectHeaders(res.headers as RawHeaders, SKIP_DOWNSTREAM),
-          sentHeaders: { ...upstreamHeaders },
-          sentBody: payload,
-        });
-      });
-    });
-    req.on("error", (err) => reject(err));
-    req.write(payload);
-    req.end();
-  });
-}
-
-// ---------- Stream proxy (SSE) ----------
-
-export function proxyStream(
-  backend: Provider,
-  apiKey: string,
-  body: Record<string, unknown>,
-  clientHeaders: RawHeaders,
-  reply: FastifyReply,
-  timeoutMs: number,
-  upstreamPath: string,
-  metricsTransform?: SSEMetricsTransform
-): Promise<StreamProxyResult> {
-  return new Promise((resolve, reject) => {
-    const url = new URL(`${backend.base_url}${upstreamPath}`);
-    const payload = JSON.stringify(body);
-    const upstreamHeaders = buildUpstreamHeaders(clientHeaders, apiKey, Buffer.byteLength(payload));
-    const options = buildRequestOptions(url, upstreamHeaders);
-
-    const upstreamReq = createUpstreamRequest(url, options);
-    upstreamReq.on("response", (upstreamRes: IncomingMessage) => {
-      const statusCode = upstreamRes.statusCode || UPSTREAM_BAD_GATEWAY;
-
-      if (statusCode !== UPSTREAM_SUCCESS) {
-        // 非200路径：仅返回错误信息，不操作 reply
-        const chunks: Buffer[] = [];
-        upstreamRes.on("data", (chunk: Buffer) => chunks.push(chunk));
-        upstreamRes.on("end", () => {
-          const errorBody = Buffer.concat(chunks).toString("utf-8");
-          resolve({
-            statusCode,
-            responseBody: errorBody,
-            upstreamResponseHeaders: selectHeaders(upstreamRes.headers as RawHeaders, SKIP_DOWNSTREAM),
-            sentHeaders: upstreamHeaders,
-          });
-        });
-        return;
-      }
-
-      const sseHeaders = selectHeaders(upstreamRes.headers as RawHeaders, SKIP_DOWNSTREAM);
-      sseHeaders["Content-Type"] = "text/event-stream";
-      sseHeaders["Cache-Control"] = "no-cache";
-      sseHeaders["Connection"] = "keep-alive";
-      reply.raw.writeHead(statusCode, sseHeaders);
-
-      const passThrough = new PassThrough();
-      if (metricsTransform) {
-        // 管道: upstreamRes → metricsTransform → passThrough → reply.raw
-        metricsTransform.pipe(passThrough).pipe(reply.raw);
-      } else {
-        passThrough.pipe(reply.raw);
-      }
-
-      // 管道入口：有 metricsTransform 时写入它，否则直接写 passThrough
-      const pipeEntry = metricsTransform ?? passThrough;
-
-      const captureChunks: Buffer[] = [];
-      let idleTimer: NodeJS.Timeout | null = null;
-      let resolved = false;
-
-      function cleanup() {
-        if (idleTimer) clearTimeout(idleTimer);
-        idleTimer = null;
-        if (!passThrough.destroyed) passThrough.destroy();
-        if (metricsTransform && !metricsTransform.destroyed) metricsTransform.destroy();
-        if (!upstreamRes.destroyed) upstreamRes.destroy();
-      }
-
-      /** 从 metricsTransform 中提取指标，供 resolve 时附带 */
-      function collectMetrics(isComplete: boolean): MetricsResult | undefined {
-        if (!metricsTransform) return undefined;
-        const result = metricsTransform.getExtractor().getMetrics();
-        if (!isComplete) {
-          return { ...result, is_complete: 0 };
-        }
-        return result;
-      }
-
-      reply.raw.on("close", () => {
-        if (!resolved) {
-          cleanup();
-          resolve({ statusCode, responseBody: undefined, upstreamResponseHeaders: sseHeaders, sentHeaders: upstreamHeaders, metricsResult: collectMetrics(false) });
-        }
-      });
-
-      passThrough.on("error", () => {
-        cleanup();
-        if (!resolved) {
-          resolved = true;
-          resolve({ statusCode, responseBody: undefined, upstreamResponseHeaders: sseHeaders, sentHeaders: upstreamHeaders, metricsResult: collectMetrics(false) });
-        }
-      });
-
-      function resetIdleTimer() {
-        if (idleTimer) clearTimeout(idleTimer);
-        idleTimer = setTimeout(() => {
-          cleanup();
-          if (!resolved) {
-            resolved = true;
-            resolve({ statusCode, responseBody: undefined, upstreamResponseHeaders: sseHeaders, sentHeaders: upstreamHeaders, metricsResult: collectMetrics(false) });
-          }
-        }, timeoutMs);
-      }
-
-      resetIdleTimer();
-
-      upstreamRes.on("data", (chunk: Buffer) => {
-        if (resolved) return;
-        resetIdleTimer();
-        pipeEntry.write(chunk);
-        captureChunks.push(chunk);
-      });
-
-      upstreamRes.on("end", () => {
-        if (resolved) return;
-        resolved = true;
-        if (idleTimer) clearTimeout(idleTimer);
-        pipeEntry.end();
-        reply.raw.end();
-        resolve({
-          statusCode,
-          responseBody: Buffer.concat(captureChunks).toString("utf-8"),
-          upstreamResponseHeaders: sseHeaders,
-          sentHeaders: upstreamHeaders,
-          metricsResult: collectMetrics(true),
-        });
-      });
-
-      upstreamRes.on("error", (err) => {
-        if (resolved) return;
-        resolved = true;
-        cleanup();
-        reject(err);
-      });
-    });
-
-    upstreamReq.on("error", (err) => reject(err));
-    upstreamReq.write(payload);
-    upstreamReq.end();
-  });
-}
-
-// ---------- GET proxy ----------
-
-export function proxyGetRequest(
-  backend: Provider,
-  apiKey: string,
-  clientHeaders: RawHeaders,
-  upstreamPath: string
-): Promise<GetProxyResult> {
-  return new Promise((resolve, reject) => {
-    const url = new URL(`${backend.base_url}${upstreamPath}`);
-    const headers = buildUpstreamHeaders(clientHeaders, apiKey);
-    const options = buildRequestOptions(url, headers, "GET");
-
-    const req = createUpstreamRequest(url, options);
-    req.on("response", (res: IncomingMessage) => {
-      const chunks: Buffer[] = [];
-      res.on("data", (chunk: Buffer) => chunks.push(chunk));
-      res.on("end", () => {
-        resolve({
-          statusCode: res.statusCode || UPSTREAM_BAD_GATEWAY,
-          body: Buffer.concat(chunks).toString("utf-8"),
-          headers: selectHeaders(res.headers as RawHeaders, SKIP_DOWNSTREAM),
-        });
-      });
-    });
-    req.on("error", (err) => reject(err));
-    req.end();
-  });
-}
-
-// ---------- Shared proxy handler ----------
 
 export interface ProxyErrorResponse {
   statusCode: number;
@@ -430,12 +48,72 @@ export interface ProxyHandlerDeps {
   matcher?: RetryRuleMatcher;
 }
 
+// Re-export upstream types for external consumers
+export type { ProxyResult, StreamProxyResult, GetProxyResult };
+
+// ---------- Constants ----------
+
+const UPSTREAM_SUCCESS = 200;
+const FAILOVER_FAIL_THRESHOLD = 400;
+
+// ---------- Header utilities ----------
+
+export const SKIP_UPSTREAM = new Set([
+  "host",
+  "content-length",
+  "accept-encoding",
+  "authorization",
+  "connection",
+  "keep-alive",
+  "transfer-encoding",
+  "upgrade",
+]);
+
+export function selectHeaders(
+  raw: RawHeaders,
+  skip: Set<string>
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(raw)) {
+    if (value == null || skip.has(key.toLowerCase())) continue;
+    out[key] = Array.isArray(value) ? value.join(", ") : value;
+  }
+  return out;
+}
+
+// 当前两个 provider 都使用 Bearer token
+// 如果未来需要支持其他鉴权方式，需要参数化 header 构造
+export function buildUpstreamHeaders(
+  clientHeaders: RawHeaders,
+  apiKey: string,
+  payloadBytes?: number
+): Record<string, string> {
+  const headers = selectHeaders(clientHeaders, SKIP_UPSTREAM);
+  headers["Authorization"] = `Bearer ${apiKey}`;
+  if (payloadBytes !== undefined) {
+    headers["Content-Type"] = "application/json";
+    headers["Content-Length"] = String(payloadBytes);
+  }
+  return headers;
+}
+
+// ---------- GET proxy (thin wrapper) ----------
+
+export function proxyGetRequest(
+  backend: Provider,
+  apiKey: string,
+  clientHeaders: RawHeaders,
+  upstreamPath: string
+): Promise<GetProxyResult> {
+  return upstreamGet(backend, apiKey, clientHeaders, upstreamPath, buildUpstreamHeaders);
+}
+
+// ---------- Shared proxy handler ----------
+
 const HTTP_BAD_GATEWAY = 502;
 
 /**
- * 共享 POST handler，参数化 apiType/errorFormat/upstreamPath 等差异，
- * 消除 openai.ts / anthropic.ts 中约 120 行重复代码。
- *
+ * 共享 POST handler，参数化 apiType/errorFormat/upstreamPath 等差异。
  * 当分组策略为 failover 时，在 while 循环中依次尝试不同 target，
  * 直到成功（或 headers 已发送）才返回。
  */
@@ -455,43 +133,8 @@ export async function handleProxyPost(
   request.raw.socket.on("error", (err) => request.log.debug({ err }, "client socket error"));
   const clientModel = ((request.body as Record<string, unknown>).model as string) || "unknown";
 
-  // --- 代理增强：指令解析 + 模型替换 ---
-  let originalModel: string | null = null;
-  let effectiveModel = clientModel;
-
-  const enhancementRaw = getSetting(db, "proxy_enhancement");
-  let enhancement: { claude_code_enabled?: boolean } | null = null;
-  try { enhancement = enhancementRaw ? JSON.parse(enhancementRaw) : null; } catch { /* ignore */ }
-  const enhancementEnabled = enhancement?.claude_code_enabled === true;
-
-  if (enhancementEnabled) {
-    // 清理历史消息中的 <router-response> 标签
-    const cleaned = cleanRouterResponses(request.body as Record<string, unknown>);
-    (request.body as Record<string, unknown>).messages = cleaned.messages;
-
-    const directive = parseDirective(request.body as Record<string, unknown>);
-
-    if (directive.modelName) {
-      // 内联模型指令 → resolveMapping 验证
-      const resolvedDirective = resolveMapping(db, directive.modelName, { now: new Date() });
-      if (resolvedDirective) {
-        originalModel = clientModel;
-        effectiveModel = directive.modelName;
-        modelState.set(request.routerKey?.id ?? null, directive.modelName);
-        (request.body as Record<string, unknown>).messages = directive.cleanedBody.messages;
-      }
-    } else {
-      // 无指令 → 查询会话记忆
-      const remembered = modelState.get(request.routerKey?.id ?? null);
-      if (remembered) {
-        const resolvedRemembered = resolveMapping(db, remembered, { now: new Date() });
-        if (resolvedRemembered) {
-          originalModel = clientModel;
-          effectiveModel = remembered;
-        }
-      }
-    }
-  }
+  // 代理增强：指令解析 + 模型替换
+  const { effectiveModel, originalModel } = applyEnhancement(db, request, clientModel);
 
   // 查询分组策略（只查一次）
   const group = getMappingGroup(db, effectiveModel);
@@ -510,16 +153,16 @@ export async function handleProxyPost(
     const resolved = resolveMapping(db, effectiveModel, { now: new Date(), excludeTargets });
     if (!resolved) {
       if (isFailover && excludeTargets.length > 0) {
-        // 所有 failover target 都已尝试，reply 已在上一轮发送
         return reply;
       }
       const e = errors.modelNotFound(effectiveModel);
-      insertRejectedLog(db, logId, apiType, effectiveModel, e.statusCode,
-        `No mapping found for model '${effectiveModel}'`, startTime, isStream, routerKeyId, originalBody, cliHdrs, undefined, originalModel);
+      insertRejectedLog({ db, logId, apiType, model: effectiveModel, statusCode: e.statusCode,
+        errorMessage: `No mapping found for model '${effectiveModel}'`, startTime, isStream,
+        routerKeyId, originalBody, clientHeaders: cliHdrs, originalModel });
       return reply.status(e.statusCode).send(e.body);
     }
 
-    // 白名单校验（只在首次循环检查，allowed_models 基于 clientModel 而非 backend_model）
+    // 白名单校验
     if (excludeTargets.length === 0) {
       const allowedModels = request.routerKey?.allowed_models;
       if (allowedModels) {
@@ -527,35 +170,37 @@ export async function handleProxyPost(
           const models: string[] = JSON.parse(allowedModels).filter((m: string) => m.trim() !== "");
           if (models.length > 0 && !models.includes(resolved.backend_model)) {
             const e = errors.modelNotAllowed(resolved.backend_model);
-            insertRejectedLog(db, logId, apiType, effectiveModel, e.statusCode,
-              `Model '${resolved.backend_model}' not allowed for this API key`,
-              startTime, isStream, routerKeyId, originalBody, cliHdrs, resolved.provider_id, originalModel);
+            insertRejectedLog({ db, logId, apiType, model: effectiveModel, statusCode: e.statusCode,
+              errorMessage: `Model '${resolved.backend_model}' not allowed for this API key`,
+              startTime, isStream, routerKeyId, originalBody, clientHeaders: cliHdrs,
+              providerId: resolved.provider_id, originalModel });
             return reply.status(e.statusCode).send(e.body);
           }
-        } catch { request.log.warn("Invalid allowed_models JSON, allowing all models"); }
+        } catch { request.log.warn({ allowedModels: allowedModels?.slice(0, 80) }, "Invalid allowed_models JSON, allowing all models"); } // eslint-disable-line no-magic-numbers
       }
     }
 
     const provider = getProviderById(db, resolved.provider_id);
     if (!provider || !provider.is_active) {
       const e = errors.providerUnavailable();
-      insertRejectedLog(db, logId, apiType, effectiveModel, e.statusCode,
-        `Provider '${resolved.provider_id}' unavailable or inactive`,
-        startTime, isStream, routerKeyId, originalBody, cliHdrs, resolved.provider_id, originalModel);
+      insertRejectedLog({ db, logId, apiType, model: effectiveModel, statusCode: e.statusCode,
+        errorMessage: `Provider '${resolved.provider_id}' unavailable or inactive`,
+        startTime, isStream, routerKeyId, originalBody, clientHeaders: cliHdrs,
+        providerId: resolved.provider_id, originalModel });
       return reply.status(e.statusCode).send(e.body);
     }
     if (provider.api_type !== apiType) {
       const e = errors.providerTypeMismatch();
-      insertRejectedLog(db, logId, apiType, effectiveModel, e.statusCode,
-        `Provider API type mismatch: expected '${apiType}', got '${provider.api_type}'`,
-        startTime, isStream, routerKeyId, originalBody, cliHdrs, resolved.provider_id, originalModel);
+      insertRejectedLog({ db, logId, apiType, model: effectiveModel, statusCode: e.statusCode,
+        errorMessage: `Provider API type mismatch: expected '${apiType}', got '${provider.api_type}'`,
+        startTime, isStream, routerKeyId, originalBody, clientHeaders: cliHdrs,
+        providerId: resolved.provider_id, originalModel });
       return reply.status(e.statusCode).send(e.body);
     }
 
     body.model = resolved.backend_model;
     const apiKey = decrypt(provider.api_key, getSetting(db, "encryption_key")!);
 
-    // 允许调用方在发送代理请求前修改 body（如 openai 的 stream_options 注入）
     options?.beforeSendProxy?.(body, isStream);
 
     const reqBodyStr = JSON.stringify(body);
@@ -568,13 +213,13 @@ export async function handleProxyPost(
         ? await retryableCall(
             () => {
               const metricsTransform = new SSEMetricsTransform(apiType, startTime);
-              return proxyStream(provider, apiKey, body, cliHdrs, reply, streamTimeoutMs, upstreamPath, metricsTransform);
+              return upstreamStream(provider, apiKey, body, cliHdrs, reply, streamTimeoutMs, upstreamPath, buildUpstreamHeaders, metricsTransform);
             },
             retryConfig,
             reply,
           )
         : await retryableCall(
-            () => proxyNonStream(provider, apiKey, body, cliHdrs, upstreamPath),
+            () => upstreamNonStream(provider, apiKey, body, cliHdrs, upstreamPath, buildUpstreamHeaders),
             retryConfig,
             reply,
           );
@@ -611,9 +256,11 @@ export async function handleProxyPost(
           const h = isStream
             ? ((r as StreamProxyResult).upstreamResponseHeaders ?? {})
             : ((r as ProxyResult).headers);
-          insertSuccessLog(db, apiType, attemptLogId, effectiveModel, provider, isStream, startTime,
-            reqBodyStr, clientReq, upstreamReqBase, r.statusCode, attempt.responseBody, h, h,
-            !isOriginal, isOriginal ? null : logId, routerKeyId, originalModel);
+          insertSuccessLog(db, { apiType, model: effectiveModel, provider, isStream, startTime,
+            reqBody: reqBodyStr, clientReq, upstreamReq: upstreamReqBase, id: attemptLogId,
+            status: r.statusCode, respBody: attempt.responseBody, upHdrs: h, cliHdrs: h,
+            isRetry: !isOriginal, originalRequestId: isOriginal ? null : logId,
+            routerKeyId, originalModel });
           lastSuccessLogId = attemptLogId;
         }
       }
@@ -637,10 +284,10 @@ export async function handleProxyPost(
           try {
             const bodyObj = JSON.parse(pr.body as string);
             if (bodyObj.content?.[0]?.text) {
-              bodyObj.content[0].text += `\n\n<router-response type="model-info">当前模型: ${effectiveModel}</router-response>`;
+              bodyObj.content[0].text += `\n\n${buildModelInfoTag(effectiveModel)}`;
               pr.body = JSON.stringify(bodyObj);
             }
-          } catch { /* non-JSON response, skip */ }
+          } catch { request.log.debug("Failed to inject model-info tag into non-JSON response"); }
         }
         for (const [k, v] of Object.entries(pr.headers)) reply.header(k, v);
         return reply.status(pr.statusCode).send(pr.body);

--- a/src/proxy/proxy-core.ts
+++ b/src/proxy/proxy-core.ts
@@ -184,6 +184,7 @@ function insertRejectedLog(
   originalBody: Record<string, unknown>,
   clientHeaders: RawHeaders,
   providerId?: string | null,
+  originalModel: string | null = null,
 ): void {
   insertRequestLog(db, {
     id: logId,
@@ -198,10 +199,9 @@ function insertRejectedLog(
     request_body: JSON.stringify(originalBody),
     client_request: JSON.stringify({ headers: clientHeaders, body: originalBody }),
     router_key_id: routerKeyId,
+    original_model: originalModel,
   });
 }
-
-// ---------- Non-stream proxy ----------
 
 export function proxyNonStream(
   backend: Provider,
@@ -515,7 +515,7 @@ export async function handleProxyPost(
       }
       const e = errors.modelNotFound(effectiveModel);
       insertRejectedLog(db, logId, apiType, effectiveModel, e.statusCode,
-        `No mapping found for model '${effectiveModel}'`, startTime, isStream, routerKeyId, originalBody, cliHdrs);
+        `No mapping found for model '${effectiveModel}'`, startTime, isStream, routerKeyId, originalBody, cliHdrs, undefined, originalModel);
       return reply.status(e.statusCode).send(e.body);
     }
 
@@ -529,7 +529,7 @@ export async function handleProxyPost(
             const e = errors.modelNotAllowed(resolved.backend_model);
             insertRejectedLog(db, logId, apiType, effectiveModel, e.statusCode,
               `Model '${resolved.backend_model}' not allowed for this API key`,
-              startTime, isStream, routerKeyId, originalBody, cliHdrs, resolved.provider_id);
+              startTime, isStream, routerKeyId, originalBody, cliHdrs, resolved.provider_id, originalModel);
             return reply.status(e.statusCode).send(e.body);
           }
         } catch { request.log.warn("Invalid allowed_models JSON, allowing all models"); }
@@ -541,14 +541,14 @@ export async function handleProxyPost(
       const e = errors.providerUnavailable();
       insertRejectedLog(db, logId, apiType, effectiveModel, e.statusCode,
         `Provider '${resolved.provider_id}' unavailable or inactive`,
-        startTime, isStream, routerKeyId, originalBody, cliHdrs, resolved.provider_id);
+        startTime, isStream, routerKeyId, originalBody, cliHdrs, resolved.provider_id, originalModel);
       return reply.status(e.statusCode).send(e.body);
     }
     if (provider.api_type !== apiType) {
       const e = errors.providerTypeMismatch();
       insertRejectedLog(db, logId, apiType, effectiveModel, e.statusCode,
         `Provider API type mismatch: expected '${apiType}', got '${provider.api_type}'`,
-        startTime, isStream, routerKeyId, originalBody, cliHdrs, resolved.provider_id);
+        startTime, isStream, routerKeyId, originalBody, cliHdrs, resolved.provider_id, originalModel);
       return reply.status(e.statusCode).send(e.body);
     }
 

--- a/src/proxy/proxy-core.ts
+++ b/src/proxy/proxy-core.ts
@@ -133,8 +133,30 @@ export async function handleProxyPost(
   request.raw.socket.on("error", (err) => request.log.debug({ err }, "client socket error"));
   const clientModel = ((request.body as Record<string, unknown>).model as string) || "unknown";
 
-  // 代理增强：指令解析 + 模型替换
-  const { effectiveModel, originalModel } = applyEnhancement(db, request, clientModel);
+  // 代理增强：指令解析 + 模型替换 + 命令拦截
+  const sessionId = (request.headers as RawHeaders)["x-claude-code-session-id"] as string | undefined;
+  const { effectiveModel, originalModel, interceptResponse } = applyEnhancement(db, request, clientModel, sessionId);
+
+  // 命令拦截（如 select-model）：直接返回，不转发上游
+  if (interceptResponse) {
+    const logId = randomUUID();
+    const isStream = (request.body as Record<string, unknown>).stream === true;
+    const interceptRespBody = JSON.stringify(interceptResponse.body);
+    insertRequestLog(db, {
+      id: logId, api_type: apiType, model: clientModel, provider_id: "router",
+      status_code: interceptResponse.statusCode, latency_ms: 0,
+      is_stream: isStream ? 1 : 0, error_message: null,
+      created_at: new Date().toISOString(),
+      request_body: JSON.stringify(request.body),
+      response_body: interceptRespBody,
+      client_request: JSON.stringify({ headers: request.headers as RawHeaders, body: request.body }),
+      upstream_request: interceptResponse.meta ? JSON.stringify(interceptResponse.meta) : null,
+      client_response: JSON.stringify({ statusCode: interceptResponse.statusCode, body: interceptRespBody }),
+      is_retry: 0, original_request_id: null,
+      router_key_id: request.routerKey?.id ?? null, original_model: null,
+    });
+    return reply.status(interceptResponse.statusCode).send(interceptResponse.body);
+  }
 
   // 查询分组策略（只查一次）
   const group = getMappingGroup(db, effectiveModel);

--- a/src/proxy/proxy-core.ts
+++ b/src/proxy/proxy-core.ts
@@ -16,6 +16,9 @@ import { resolveMapping } from "./mapping-resolver.js";
 import { retryableCall, buildRetryConfig } from "./retry.js";
 import type { RetryRuleMatcher } from "./retry-rules.js";
 import type { Target } from "./strategy/types.js";
+import { parseDirective } from "./directive-parser.js";
+import { modelState } from "./model-state.js";
+import { cleanRouterResponses } from "./response-cleaner.js";
 
 // ---------- Types ----------
 
@@ -152,6 +155,7 @@ export function insertSuccessLog(
   cliHdrs: Record<string, string>,
   isRetry: boolean = false, originalRequestId: string | null = null,
   routerKeyId: string | null = null,
+  originalModel: string | null = null,
 ) {
   insertRequestLog(db, {
     id: logId, api_type: apiType, model, provider_id: provider.id,
@@ -162,7 +166,7 @@ export function insertSuccessLog(
     upstream_response: JSON.stringify({ statusCode: status, headers: upHdrs, body: respBody }),
     client_response: JSON.stringify({ statusCode: status, headers: cliHdrs, body: respBody }),
     is_retry: isRetry ? 1 : 0, original_request_id: originalRequestId,
-    router_key_id: routerKeyId,
+    router_key_id: routerKeyId, original_model: originalModel,
   });
 }
 
@@ -451,8 +455,46 @@ export async function handleProxyPost(
   request.raw.socket.on("error", (err) => request.log.debug({ err }, "client socket error"));
   const clientModel = ((request.body as Record<string, unknown>).model as string) || "unknown";
 
+  // --- 代理增强：指令解析 + 模型替换 ---
+  let originalModel: string | null = null;
+  let effectiveModel = clientModel;
+
+  const enhancementRaw = getSetting(db, "proxy_enhancement");
+  let enhancement: { claude_code_enabled?: boolean } | null = null;
+  try { enhancement = enhancementRaw ? JSON.parse(enhancementRaw) : null; } catch { /* ignore */ }
+  const enhancementEnabled = enhancement?.claude_code_enabled === true;
+
+  if (enhancementEnabled) {
+    // 清理历史消息中的 <router-response> 标签
+    const cleaned = cleanRouterResponses(request.body as Record<string, unknown>);
+    (request.body as Record<string, unknown>).messages = cleaned.messages;
+
+    const directive = parseDirective(request.body as Record<string, unknown>);
+
+    if (directive.modelName) {
+      // 内联模型指令 → resolveMapping 验证
+      const resolvedDirective = resolveMapping(db, directive.modelName, { now: new Date() });
+      if (resolvedDirective) {
+        originalModel = clientModel;
+        effectiveModel = directive.modelName;
+        modelState.set(request.routerKey?.id ?? null, directive.modelName);
+        (request.body as Record<string, unknown>).messages = directive.cleanedBody.messages;
+      }
+    } else {
+      // 无指令 → 查询会话记忆
+      const remembered = modelState.get(request.routerKey?.id ?? null);
+      if (remembered) {
+        const resolvedRemembered = resolveMapping(db, remembered, { now: new Date() });
+        if (resolvedRemembered) {
+          originalModel = clientModel;
+          effectiveModel = remembered;
+        }
+      }
+    }
+  }
+
   // 查询分组策略（只查一次）
-  const group = getMappingGroup(db, clientModel);
+  const group = getMappingGroup(db, effectiveModel);
   const isFailover = group?.strategy === "failover";
   const excludeTargets: Target[] = [];
 
@@ -465,15 +507,15 @@ export async function handleProxyPost(
     const isStream = body.stream === true;
     const cliHdrs: RawHeaders = request.headers as RawHeaders;
 
-    const resolved = resolveMapping(db, clientModel, { now: new Date(), excludeTargets });
+    const resolved = resolveMapping(db, effectiveModel, { now: new Date(), excludeTargets });
     if (!resolved) {
       if (isFailover && excludeTargets.length > 0) {
         // 所有 failover target 都已尝试，reply 已在上一轮发送
         return reply;
       }
-      const e = errors.modelNotFound(clientModel);
-      insertRejectedLog(db, logId, apiType, clientModel, e.statusCode,
-        `No mapping found for model '${clientModel}'`, startTime, isStream, routerKeyId, originalBody, cliHdrs);
+      const e = errors.modelNotFound(effectiveModel);
+      insertRejectedLog(db, logId, apiType, effectiveModel, e.statusCode,
+        `No mapping found for model '${effectiveModel}'`, startTime, isStream, routerKeyId, originalBody, cliHdrs);
       return reply.status(e.statusCode).send(e.body);
     }
 
@@ -485,7 +527,7 @@ export async function handleProxyPost(
           const models: string[] = JSON.parse(allowedModels).filter((m: string) => m.trim() !== "");
           if (models.length > 0 && !models.includes(resolved.backend_model)) {
             const e = errors.modelNotAllowed(resolved.backend_model);
-            insertRejectedLog(db, logId, apiType, clientModel, e.statusCode,
+            insertRejectedLog(db, logId, apiType, effectiveModel, e.statusCode,
               `Model '${resolved.backend_model}' not allowed for this API key`,
               startTime, isStream, routerKeyId, originalBody, cliHdrs, resolved.provider_id);
             return reply.status(e.statusCode).send(e.body);
@@ -497,14 +539,14 @@ export async function handleProxyPost(
     const provider = getProviderById(db, resolved.provider_id);
     if (!provider || !provider.is_active) {
       const e = errors.providerUnavailable();
-      insertRejectedLog(db, logId, apiType, clientModel, e.statusCode,
+      insertRejectedLog(db, logId, apiType, effectiveModel, e.statusCode,
         `Provider '${resolved.provider_id}' unavailable or inactive`,
         startTime, isStream, routerKeyId, originalBody, cliHdrs, resolved.provider_id);
       return reply.status(e.statusCode).send(e.body);
     }
     if (provider.api_type !== apiType) {
       const e = errors.providerTypeMismatch();
-      insertRejectedLog(db, logId, apiType, clientModel, e.statusCode,
+      insertRejectedLog(db, logId, apiType, effectiveModel, e.statusCode,
         `Provider API type mismatch: expected '${apiType}', got '${provider.api_type}'`,
         startTime, isStream, routerKeyId, originalBody, cliHdrs, resolved.provider_id);
       return reply.status(e.statusCode).send(e.body);
@@ -545,17 +587,17 @@ export async function handleProxyPost(
 
         if (attempt.error) {
           insertRequestLog(db, {
-            id: attemptLogId, api_type: apiType, model: clientModel, provider_id: provider.id,
+            id: attemptLogId, api_type: apiType, model: effectiveModel, provider_id: provider.id,
             status_code: HTTP_BAD_GATEWAY, latency_ms: attempt.latencyMs,
             is_stream: isStream ? 1 : 0, error_message: attempt.error,
             created_at: new Date().toISOString(), request_body: reqBodyStr,
             client_request: clientReq, upstream_request: upstreamReqBase,
             is_retry: isOriginal ? 0 : 1, original_request_id: isOriginal ? null : logId,
-            router_key_id: routerKeyId,
+            router_key_id: routerKeyId, original_model: originalModel,
           });
         } else if (attempt.statusCode !== UPSTREAM_SUCCESS) {
           insertRequestLog(db, {
-            id: attemptLogId, api_type: apiType, model: clientModel, provider_id: provider.id,
+            id: attemptLogId, api_type: apiType, model: effectiveModel, provider_id: provider.id,
             status_code: attempt.statusCode, latency_ms: attempt.latencyMs,
             is_stream: isStream ? 1 : 0, error_message: null,
             created_at: new Date().toISOString(), request_body: reqBodyStr,
@@ -563,15 +605,15 @@ export async function handleProxyPost(
             upstream_response: JSON.stringify({ statusCode: attempt.statusCode, body: attempt.responseBody }),
             client_response: JSON.stringify({ statusCode: attempt.statusCode, body: attempt.responseBody }),
             is_retry: isOriginal ? 0 : 1, original_request_id: isOriginal ? null : logId,
-            router_key_id: routerKeyId,
+            router_key_id: routerKeyId, original_model: originalModel,
           });
         } else {
           const h = isStream
             ? ((r as StreamProxyResult).upstreamResponseHeaders ?? {})
             : ((r as ProxyResult).headers);
-          insertSuccessLog(db, apiType, attemptLogId, clientModel, provider, isStream, startTime,
+          insertSuccessLog(db, apiType, attemptLogId, effectiveModel, provider, isStream, startTime,
             reqBodyStr, clientReq, upstreamReqBase, r.statusCode, attempt.responseBody, h, h,
-            !isOriginal, isOriginal ? null : logId, routerKeyId);
+            !isOriginal, isOriginal ? null : logId, routerKeyId, originalModel);
           lastSuccessLogId = attemptLogId;
         }
       }
@@ -590,6 +632,16 @@ export async function handleProxyPost(
         }
       } else {
         const pr = r as ProxyResult;
+        // 非流式响应：模型替换时注入 router-response 标签
+        if (originalModel && pr.statusCode === UPSTREAM_SUCCESS) {
+          try {
+            const bodyObj = JSON.parse(pr.body as string);
+            if (bodyObj.content?.[0]?.text) {
+              bodyObj.content[0].text += `\n\n<router-response type="model-info">当前模型: ${effectiveModel}</router-response>`;
+              pr.body = JSON.stringify(bodyObj);
+            }
+          } catch { /* non-JSON response, skip */ }
+        }
         for (const [k, v] of Object.entries(pr.headers)) reply.header(k, v);
         return reply.status(pr.statusCode).send(pr.body);
       }
@@ -615,12 +667,12 @@ export async function handleProxyPost(
       const sentH = buildUpstreamHeaders(cliHdrs, apiKey, Buffer.byteLength(reqBodyStr));
       const upstreamReq = JSON.stringify({ url: `${provider.base_url}${upstreamPath}`, headers: sentH, body: reqBodyStr });
       insertRequestLog(db, {
-        id: logId, api_type: apiType, model: clientModel, provider_id: provider.id,
+        id: logId, api_type: apiType, model: effectiveModel, provider_id: provider.id,
         status_code: HTTP_BAD_GATEWAY, latency_ms: Date.now() - startTime,
         is_stream: isStream ? 1 : 0, error_message: errMsg || "Upstream connection failed",
         created_at: new Date().toISOString(), request_body: reqBodyStr,
         client_request: clientReq, upstream_request: upstreamReq,
-        router_key_id: routerKeyId,
+        router_key_id: routerKeyId, original_model: originalModel,
       });
 
       // --- Failover 检查（异常路径）---

--- a/src/proxy/response-cleaner.ts
+++ b/src/proxy/response-cleaner.ts
@@ -1,34 +1,49 @@
 const RE_ROUTER_RESPONSE = /<router-response[^>]*>[\s\S]*?<\/router-response>/g;
-const RE_COMMAND = /<!--\s*router:command=/;
+const RE_COMMAND = /\[router-command:/;
 
+/**
+ * 清理历史消息中的路由相关内容（命令消息和 router-response 标签）。
+ * 只清理历史轮次，跳过最后一条 user 消息（当前轮由 directive-parser 处理）。
+ */
 export function cleanRouterResponses(body: Record<string, unknown>): Record<string, unknown> {
   const messages = body.messages as Array<{ role: string; content: unknown }> | undefined;
   if (!messages?.length) return body;
 
   const cleaned = JSON.parse(JSON.stringify(body));
-  const cleanedMsgs = (cleaned.messages as Array<{ role: string; content: unknown }>)
-    .filter((msg) => {
-      if (msg.role === "user") {
-        const blocks = Array.isArray(msg.content) ? msg.content : [msg.content];
-        for (const b of blocks) {
-          if (b && typeof b === "object" && "text" in b && typeof b.text === "string") {
-            if (RE_COMMAND.test(b.text)) return false;
-          }
+  const cleanedMsgs = (cleaned.messages as Array<{ role: string; content: unknown }>);
+
+  // 定位最后一条 user 消息（当前轮），不参与整条过滤
+  let lastUserIdx = -1;
+  for (let i = cleanedMsgs.length - 1; i >= 0; i--) {
+    if (cleanedMsgs[i].role === "user") { lastUserIdx = i; break; }
+  }
+
+  const filtered = cleanedMsgs.filter((msg, idx) => {
+    // 当前轮的 user 消息保留，由 directive-parser 处理
+    if (idx === lastUserIdx) return true;
+
+    if (msg.role === "user") {
+      const blocks = Array.isArray(msg.content) ? msg.content : [msg.content];
+      for (const b of blocks) {
+        if (b && typeof b === "object" && "text" in b && typeof b.text === "string") {
+          if (RE_COMMAND.test(b.text)) return false;
         }
       }
-      if (msg.role === "assistant") {
-        const blocks = Array.isArray(msg.content) ? msg.content : [msg.content];
-        const texts = blocks
-          .filter((b): b is { type: string; text: string } => b?.type === "text" && typeof b.text === "string")
-          .map((b) => b.text);
-        const combined = texts.join("");
-        const stripped = combined.replace(RE_ROUTER_RESPONSE, "").trim();
-        if (!stripped) return false;
-      }
-      return true;
-    });
+    }
+    if (msg.role === "assistant") {
+      const blocks = Array.isArray(msg.content) ? msg.content : [msg.content];
+      const texts = blocks
+        .filter((b): b is { type: string; text: string } => b?.type === "text" && typeof b.text === "string")
+        .map((b) => b.text);
+      const combined = texts.join("");
+      const stripped = combined.replace(RE_ROUTER_RESPONSE, "").trim();
+      if (!stripped) return false;
+    }
+    return true;
+  });
 
-  for (const msg of cleanedMsgs) {
+  // 剥离所有消息中的 <router-response> 标签（包括当前轮）
+  for (const msg of filtered) {
     const blocks = Array.isArray(msg.content) ? msg.content : [msg.content];
     for (const b of blocks) {
       if (b && typeof b === "object" && "text" in b && typeof b.text === "string") {
@@ -40,6 +55,6 @@ export function cleanRouterResponses(body: Record<string, unknown>): Record<stri
     }
   }
 
-  cleaned.messages = cleanedMsgs;
+  cleaned.messages = filtered;
   return cleaned;
 }

--- a/src/proxy/response-cleaner.ts
+++ b/src/proxy/response-cleaner.ts
@@ -1,0 +1,45 @@
+const RE_ROUTER_RESPONSE = /<router-response[^>]*>[\s\S]*?<\/router-response>/g;
+const RE_COMMAND = /<!--\s*router:command=/;
+
+export function cleanRouterResponses(body: Record<string, unknown>): Record<string, unknown> {
+  const messages = body.messages as Array<{ role: string; content: unknown }> | undefined;
+  if (!messages?.length) return body;
+
+  const cleaned = JSON.parse(JSON.stringify(body));
+  const cleanedMsgs = (cleaned.messages as Array<{ role: string; content: unknown }>)
+    .filter((msg) => {
+      if (msg.role === "user") {
+        const blocks = Array.isArray(msg.content) ? msg.content : [msg.content];
+        for (const b of blocks) {
+          if (b && typeof b === "object" && "text" in b && typeof b.text === "string") {
+            if (RE_COMMAND.test(b.text)) return false;
+          }
+        }
+      }
+      if (msg.role === "assistant") {
+        const blocks = Array.isArray(msg.content) ? msg.content : [msg.content];
+        const texts = blocks
+          .filter((b): b is { type: string; text: string } => b?.type === "text" && typeof b.text === "string")
+          .map((b) => b.text);
+        const combined = texts.join("");
+        const stripped = combined.replace(RE_ROUTER_RESPONSE, "").trim();
+        if (!stripped) return false;
+      }
+      return true;
+    });
+
+  for (const msg of cleanedMsgs) {
+    const blocks = Array.isArray(msg.content) ? msg.content : [msg.content];
+    for (const b of blocks) {
+      if (b && typeof b === "object" && "text" in b && typeof b.text === "string") {
+        (b as { text: string }).text = b.text
+          .replace(RE_ROUTER_RESPONSE, "")
+          .replace(/\n{3,}/g, "\n\n")
+          .trim();
+      }
+    }
+  }
+
+  cleaned.messages = cleanedMsgs;
+  return cleaned;
+}

--- a/src/proxy/upstream-call.ts
+++ b/src/proxy/upstream-call.ts
@@ -1,0 +1,291 @@
+import { request as httpRequestFn, IncomingMessage } from "http";
+import { request as httpsRequestFn } from "https";
+import { PassThrough } from "stream";
+import type { FastifyReply } from "fastify";
+import type { RawHeaders } from "./proxy-core.js";
+import type { MetricsResult } from "../metrics/metrics-extractor.js";
+import { SSEMetricsTransform } from "../metrics/sse-metrics-transform.js";
+
+// ---------- Types ----------
+
+export interface UpstreamRequestOptions {
+  hostname: string;
+  port: number;
+  path: string;
+  method: string;
+  headers: Record<string, string>;
+}
+
+export interface ProxyResult {
+  statusCode: number;
+  body: string;
+  headers: Record<string, string>;
+  sentHeaders: Record<string, string>;
+  sentBody: string;
+}
+
+export interface StreamProxyResult {
+  statusCode: number;
+  responseBody?: string;
+  upstreamResponseHeaders?: Record<string, string>;
+  sentHeaders?: Record<string, string>;
+  metricsResult?: MetricsResult;
+}
+
+export interface GetProxyResult {
+  statusCode: number;
+  body: string;
+  headers: Record<string, string>;
+}
+
+// ---------- Constants ----------
+
+const UPSTREAM_SUCCESS = 200;
+const UPSTREAM_BAD_GATEWAY = 502;
+const HTTPS_DEFAULT_PORT = 443;
+const HTTP_DEFAULT_PORT = 80;
+
+// ---------- Request utilities ----------
+
+/** 根据 URL scheme 选择 http 或 https 模块 */
+export function createUpstreamRequest(url: URL, options: UpstreamRequestOptions) {
+  return url.protocol === "https:" ? httpsRequestFn(options) : httpRequestFn(options);
+}
+
+/** 从 URL + headers 构造 Node.js http.request 所需的 options */
+export function buildRequestOptions(
+  url: URL,
+  headers: Record<string, string>,
+  method = "POST"
+): UpstreamRequestOptions {
+  return {
+    hostname: url.hostname,
+    port: Number(url.port) || (url.protocol === "https:" ? HTTPS_DEFAULT_PORT : HTTP_DEFAULT_PORT),
+    path: url.pathname,
+    method,
+    headers,
+  };
+}
+
+// ---------- Non-stream proxy ----------
+
+export function proxyNonStream(
+  backend: { base_url: string },
+  apiKey: string,
+  body: Record<string, unknown>,
+  clientHeaders: RawHeaders,
+  upstreamPath: string,
+  buildHeaders: (cliHdrs: RawHeaders, key: string, bytes?: number) => Record<string, string>,
+): Promise<ProxyResult> {
+  return new Promise((resolve, reject) => {
+    const url = new URL(`${backend.base_url}${upstreamPath}`);
+    const payload = JSON.stringify(body);
+    const upstreamHeaders = buildHeaders(clientHeaders, apiKey, Buffer.byteLength(payload));
+    const options = buildRequestOptions(url, upstreamHeaders);
+
+    const req = createUpstreamRequest(url, options);
+    req.on("response", (res: IncomingMessage) => {
+      const chunks: Buffer[] = [];
+      res.on("data", (chunk: Buffer) => chunks.push(chunk));
+      res.on("end", () => {
+        resolve({
+          statusCode: res.statusCode || UPSTREAM_BAD_GATEWAY,
+          body: Buffer.concat(chunks).toString("utf-8"),
+          headers: filterHeaders(res.headers as RawHeaders),
+          sentHeaders: { ...upstreamHeaders },
+          sentBody: payload,
+        });
+      });
+    });
+    req.on("error", (err) => reject(err));
+    req.write(payload);
+    req.end();
+  });
+}
+
+// ---------- Stream proxy (SSE) ----------
+
+export function proxyStream(
+  backend: { base_url: string },
+  apiKey: string,
+  body: Record<string, unknown>,
+  clientHeaders: RawHeaders,
+  reply: FastifyReply,
+  timeoutMs: number,
+  upstreamPath: string,
+  buildHeaders: (cliHdrs: RawHeaders, key: string, bytes?: number) => Record<string, string>,
+  metricsTransform?: SSEMetricsTransform
+): Promise<StreamProxyResult> {
+  return new Promise((resolve, reject) => {
+    const url = new URL(`${backend.base_url}${upstreamPath}`);
+    const payload = JSON.stringify(body);
+    const upstreamHeaders = buildHeaders(clientHeaders, apiKey, Buffer.byteLength(payload));
+    const options = buildRequestOptions(url, upstreamHeaders);
+
+    const upstreamReq = createUpstreamRequest(url, options);
+    upstreamReq.on("response", (upstreamRes: IncomingMessage) => {
+      const statusCode = upstreamRes.statusCode || UPSTREAM_BAD_GATEWAY;
+
+      if (statusCode !== UPSTREAM_SUCCESS) {
+        const chunks: Buffer[] = [];
+        upstreamRes.on("data", (chunk: Buffer) => chunks.push(chunk));
+        upstreamRes.on("end", () => {
+          const errorBody = Buffer.concat(chunks).toString("utf-8");
+          resolve({
+            statusCode,
+            responseBody: errorBody,
+            upstreamResponseHeaders: filterHeaders(upstreamRes.headers as RawHeaders),
+            sentHeaders: upstreamHeaders,
+          });
+        });
+        return;
+      }
+
+      const sseHeaders = filterHeaders(upstreamRes.headers as RawHeaders);
+      sseHeaders["Content-Type"] = "text/event-stream";
+      sseHeaders["Cache-Control"] = "no-cache";
+      sseHeaders["Connection"] = "keep-alive";
+      reply.raw.writeHead(statusCode, sseHeaders);
+
+      const passThrough = new PassThrough();
+      if (metricsTransform) {
+        metricsTransform.pipe(passThrough).pipe(reply.raw);
+      } else {
+        passThrough.pipe(reply.raw);
+      }
+
+      const pipeEntry = metricsTransform ?? passThrough;
+
+      const captureChunks: Buffer[] = [];
+      let idleTimer: NodeJS.Timeout | null = null;
+      let resolved = false;
+
+      function cleanup() {
+        if (idleTimer) clearTimeout(idleTimer);
+        idleTimer = null;
+        if (!passThrough.destroyed) passThrough.destroy();
+        if (metricsTransform && !metricsTransform.destroyed) metricsTransform.destroy();
+        if (!upstreamRes.destroyed) upstreamRes.destroy();
+      }
+
+      function collectMetrics(isComplete: boolean): MetricsResult | undefined {
+        if (!metricsTransform) return undefined;
+        const result = metricsTransform.getExtractor().getMetrics();
+        if (!isComplete) {
+          return { ...result, is_complete: 0 };
+        }
+        return result;
+      }
+
+      reply.raw.on("close", () => {
+        if (!resolved) {
+          cleanup();
+          resolve({ statusCode, responseBody: undefined, upstreamResponseHeaders: sseHeaders, sentHeaders: upstreamHeaders, metricsResult: collectMetrics(false) });
+        }
+      });
+
+      passThrough.on("error", () => {
+        cleanup();
+        if (!resolved) {
+          resolved = true;
+          resolve({ statusCode, responseBody: undefined, upstreamResponseHeaders: sseHeaders, sentHeaders: upstreamHeaders, metricsResult: collectMetrics(false) });
+        }
+      });
+
+      function resetIdleTimer() {
+        if (idleTimer) clearTimeout(idleTimer);
+        idleTimer = setTimeout(() => {
+          cleanup();
+          if (!resolved) {
+            resolved = true;
+            resolve({ statusCode, responseBody: undefined, upstreamResponseHeaders: sseHeaders, sentHeaders: upstreamHeaders, metricsResult: collectMetrics(false) });
+          }
+        }, timeoutMs);
+      }
+
+      resetIdleTimer();
+
+      upstreamRes.on("data", (chunk: Buffer) => {
+        if (resolved) return;
+        resetIdleTimer();
+        pipeEntry.write(chunk);
+        captureChunks.push(chunk);
+      });
+
+      upstreamRes.on("end", () => {
+        if (resolved) return;
+        resolved = true;
+        if (idleTimer) clearTimeout(idleTimer);
+        pipeEntry.end();
+        reply.raw.end();
+        resolve({
+          statusCode,
+          responseBody: Buffer.concat(captureChunks).toString("utf-8"),
+          upstreamResponseHeaders: sseHeaders,
+          sentHeaders: upstreamHeaders,
+          metricsResult: collectMetrics(true),
+        });
+      });
+
+      upstreamRes.on("error", (err) => {
+        if (resolved) return;
+        resolved = true;
+        cleanup();
+        reject(err);
+      });
+    });
+
+    upstreamReq.on("error", (err) => reject(err));
+    upstreamReq.write(payload);
+    upstreamReq.end();
+  });
+}
+
+// ---------- GET proxy ----------
+
+export function proxyGetRequest(
+  backend: { base_url: string },
+  apiKey: string,
+  clientHeaders: RawHeaders,
+  upstreamPath: string,
+  buildHeaders: (cliHdrs: RawHeaders, key: string) => Record<string, string>,
+): Promise<GetProxyResult> {
+  return new Promise((resolve, reject) => {
+    const url = new URL(`${backend.base_url}${upstreamPath}`);
+    const headers = buildHeaders(clientHeaders, apiKey);
+    const options = buildRequestOptions(url, headers, "GET");
+
+    const req = createUpstreamRequest(url, options);
+    req.on("response", (res: IncomingMessage) => {
+      const chunks: Buffer[] = [];
+      res.on("data", (chunk: Buffer) => chunks.push(chunk));
+      res.on("end", () => {
+        resolve({
+          statusCode: res.statusCode || UPSTREAM_BAD_GATEWAY,
+          body: Buffer.concat(chunks).toString("utf-8"),
+          headers: filterHeaders(res.headers as RawHeaders),
+        });
+      });
+    });
+    req.on("error", (err) => reject(err));
+    req.end();
+  });
+}
+
+// ---------- Shared header filter ----------
+
+const SKIP_DOWNSTREAM = new Set([
+  "content-length",
+  "transfer-encoding",
+  "connection",
+  "keep-alive",
+]);
+
+function filterHeaders(raw: RawHeaders): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(raw)) {
+    if (value == null || SKIP_DOWNSTREAM.has(key.toLowerCase())) continue;
+    out[key] = Array.isArray(value) ? value.join(", ") : value;
+  }
+  return out;
+}

--- a/tests/admin-groups.test.ts
+++ b/tests/admin-groups.test.ts
@@ -56,7 +56,7 @@ describe("Mapping Group CRUD", () => {
       url: "/admin/api/providers",
       headers: { cookie, "content-type": "application/json" },
       payload: {
-        name: "Test Provider",
+        name: "Test-Provider",
         api_type: "openai",
         base_url: "https://api.openai.com",
         api_key: "sk-test-abc123xyz",

--- a/tests/admin-mappings.test.ts
+++ b/tests/admin-mappings.test.ts
@@ -57,7 +57,7 @@ describe("Mapping CRUD", () => {
       url: "/admin/api/providers",
       headers: { cookie, "content-type": "application/json" },
       payload: {
-        name: "Test Provider",
+        name: "Test-Provider",
         api_type: "openai",
         base_url: "https://api.openai.com",
         api_key: "sk-test-abc123xyz",

--- a/tests/admin-providers.test.ts
+++ b/tests/admin-providers.test.ts
@@ -130,7 +130,7 @@ describe("Provider CRUD", () => {
       url: "/admin/api/providers",
       headers: { cookie, "content-type": "application/json" },
       payload: {
-        name: "Test OpenAI",
+        name: "Test-OpenAI",
         api_type: "openai",
         base_url: "https://api.openai.com",
         api_key: "sk-test-abc123xyz",
@@ -146,7 +146,7 @@ describe("Provider CRUD", () => {
       url: "/admin/api/providers",
       headers: { cookie, "content-type": "application/json" },
       payload: {
-        name: "Test OpenAI",
+        name: "Test-OpenAI",
         api_type: "openai",
         base_url: "https://api.openai.com",
         api_key: "sk-test-abc123xyz",
@@ -171,7 +171,7 @@ describe("Provider CRUD", () => {
       url: "/admin/api/providers",
       headers: { cookie, "content-type": "application/json" },
       payload: {
-        name: "Test OpenAI",
+        name: "Test-OpenAI",
         api_type: "openai",
         base_url: "https://api.openai.com",
         api_key: "sk-test-key123",
@@ -183,7 +183,7 @@ describe("Provider CRUD", () => {
       method: "PUT",
       url: `/admin/api/providers/${id}`,
       headers: { cookie, "content-type": "application/json" },
-      payload: { name: "Updated Name" },
+      payload: { name: "Updated-Name" },
     });
     expect(updateRes.statusCode).toBe(200);
 
@@ -192,7 +192,7 @@ describe("Provider CRUD", () => {
       url: "/admin/api/providers",
       headers: { cookie },
     });
-    expect(getRes.json()[0].name).toBe("Updated Name");
+    expect(getRes.json()[0].name).toBe("Updated-Name");
   });
 
   it("DELETE removes service", async () => {
@@ -201,7 +201,7 @@ describe("Provider CRUD", () => {
       url: "/admin/api/providers",
       headers: { cookie, "content-type": "application/json" },
       payload: {
-        name: "Test OpenAI",
+        name: "Test-OpenAI",
         api_type: "openai",
         base_url: "https://api.openai.com",
         api_key: "sk-test-key456",
@@ -232,5 +232,21 @@ describe("Provider CRUD", () => {
       payload: { name: "NoKey" },
     });
     expect(res.statusCode).toBe(400);
+  });
+
+  it("POST rejects provider name with spaces", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/admin/api/providers",
+      headers: { cookie, "content-type": "application/json" },
+      payload: {
+        name: "Invalid Name",
+        api_type: "openai",
+        base_url: "https://api.openai.com",
+        api_key: "sk-test",
+      },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error.message).toContain("英文大小写字母");
   });
 });

--- a/tests/admin-providers.test.ts
+++ b/tests/admin-providers.test.ts
@@ -140,7 +140,7 @@ describe("Provider CRUD", () => {
     expect(res.json().id).toBeDefined();
   });
 
-  it("GET returns services with api_key_preview instead of raw api_key", async () => {
+  it("GET returns services with decrypted api_key", async () => {
     await app.inject({
       method: "POST",
       url: "/admin/api/providers",
@@ -161,8 +161,8 @@ describe("Provider CRUD", () => {
     expect(res.statusCode).toBe(200);
     const services = res.json();
     expect(services.length).toBe(1);
-    expect(services[0].api_key_preview).toBe("sk-t...3xyz");
-    expect(services[0].api_key).toBeUndefined();
+    expect(services[0].api_key).toBe("sk-test-abc123xyz");
+    expect(services[0].api_key_preview).toBeUndefined();
   });
 
   it("PUT updates service", async () => {

--- a/tests/admin-session-states.test.ts
+++ b/tests/admin-session-states.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { FastifyInstance } from "fastify";
+import { buildApp } from "../src/index.js";
+import { initDatabase } from "../src/db/index.js";
+import { setSetting } from "../src/db/settings.js";
+import { hashPassword } from "../src/utils/password.js";
+import { upsertSessionState, insertSessionHistory } from "../src/db/session-states.js";
+
+const TEST_ENCRYPTION_KEY = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+function makeConfig() {
+  return {
+    PORT: 9981,
+    DB_PATH: ":memory:",
+    LOG_LEVEL: "silent",
+    TZ: "Asia/Shanghai",
+    STREAM_TIMEOUT_MS: 5000,
+    RETRY_MAX_ATTEMPTS: 0,
+    RETRY_BASE_DELAY_MS: 0,
+  };
+}
+
+async function login(app: FastifyInstance): Promise<string> {
+  const res = await app.inject({
+    method: "POST",
+    url: "/admin/api/login",
+    payload: { password: "test-admin-pass" },
+  });
+  const setCookie = res.headers["set-cookie"];
+  expect(setCookie).toBeDefined();
+  const match = (setCookie as string).match(/admin_token=([^;]+)/);
+  expect(match).toBeTruthy();
+  return `admin_token=${match![1]}`;
+}
+
+function seedSettings(db: ReturnType<typeof initDatabase>) {
+  setSetting(db, "encryption_key", TEST_ENCRYPTION_KEY);
+  setSetting(db, "jwt_secret", "test-jwt-secret-for-testing");
+  setSetting(db, "admin_password_hash", hashPassword("test-admin-pass"));
+  setSetting(db, "initialized", "true");
+}
+
+describe("Admin Session States", () => {
+  let app: FastifyInstance;
+  let db: ReturnType<typeof initDatabase>;
+  let close: () => Promise<void>;
+  let cookie: string;
+  let routerKeyId: string;
+
+  beforeEach(async () => {
+    db = initDatabase(":memory:");
+    seedSettings(db);
+    const result = await buildApp({ config: makeConfig() as any, db });
+    app = result.app;
+    close = result.close;
+    cookie = await login(app);
+
+    // 通过 API 创建 router_key
+    const res = await app.inject({
+      method: "POST",
+      url: "/admin/api/router-keys",
+      headers: { cookie, "content-type": "application/json" },
+      payload: { name: "Test Router Key" },
+    });
+    expect(res.statusCode).toBe(201);
+    routerKeyId = res.json().id;
+
+    // 直接用 DB 函数写入 session state 数据
+    upsertSessionState(db, {
+      router_key_id: routerKeyId,
+      session_id: "sess-001",
+      current_model: "claude-opus-4-20250514",
+      original_model: "claude-sonnet-4-20250514",
+    });
+    insertSessionHistory(db, {
+      router_key_id: routerKeyId,
+      session_id: "sess-001",
+      old_model: "claude-sonnet-4-20250514",
+      new_model: "claude-opus-4-20250514",
+      trigger_type: "directive",
+    });
+  });
+
+  afterEach(async () => {
+    await close();
+  });
+
+  it("GET /admin/api/session-states returns list with router_key_name", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: "/admin/api/session-states",
+      headers: { cookie },
+    });
+    expect(res.statusCode).toBe(200);
+    const states = res.json();
+    expect(states).toHaveLength(1);
+    expect(states[0].router_key_name).toBe("Test Router Key");
+    expect(states[0].session_id).toBe("sess-001");
+    expect(states[0].current_model).toBe("claude-opus-4-20250514");
+  });
+
+  it("GET /admin/api/session-states/:keyId/:sessionId/history returns history", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: `/admin/api/session-states/${routerKeyId}/sess-001/history`,
+      headers: { cookie },
+    });
+    expect(res.statusCode).toBe(200);
+    const history = res.json();
+    expect(history).toHaveLength(1);
+    expect(history[0].old_model).toBe("claude-sonnet-4-20250514");
+    expect(history[0].new_model).toBe("claude-opus-4-20250514");
+    expect(history[0].trigger_type).toBe("directive");
+  });
+
+  it("DELETE /admin/api/session-states/:keyId/:sessionId deletes state", async () => {
+    const delRes = await app.inject({
+      method: "DELETE",
+      url: `/admin/api/session-states/${routerKeyId}/sess-001`,
+      headers: { cookie },
+    });
+    expect(delRes.statusCode).toBe(200);
+    expect(delRes.json()).toEqual({ success: true });
+
+    // 验证 session state 已被删除
+    const getRes = await app.inject({
+      method: "GET",
+      url: "/admin/api/session-states",
+      headers: { cookie },
+    });
+    expect(getRes.json()).toHaveLength(0);
+  });
+
+  it("unauthenticated access returns 401", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: "/admin/api/session-states",
+    });
+    expect(res.statusCode).toBe(401);
+  });
+});

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -39,7 +39,7 @@ describe("initDatabase", () => {
       .prepare("SELECT name FROM migrations")
       .all() as { name: string }[];
 
-    expect(rows.length).toBe(14);
+    expect(rows.length).toBe(15);
     expect(rows[0].name).toBe("001_init.sql");
     expect(rows[1].name).toBe("002_add_request_response_body.sql");
     expect(rows[2].name).toBe("003_add_full_request_chain_log.sql");

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach } from "vitest";
-import { initDatabase } from "../src/db/index.js";
+import { initDatabase, getSessionStates, getSessionHistory, upsertSessionState, insertSessionHistory, deleteSessionState } from "../src/db/index.js";
 import Database from "better-sqlite3";
 
 describe("initDatabase", () => {
@@ -39,7 +39,7 @@ describe("initDatabase", () => {
       .prepare("SELECT name FROM migrations")
       .all() as { name: string }[];
 
-    expect(rows.length).toBe(15);
+    expect(rows.length).toBe(16);
     expect(rows[0].name).toBe("001_init.sql");
     expect(rows[1].name).toBe("002_add_request_response_body.sql");
     expect(rows[2].name).toBe("003_add_full_request_chain_log.sql");
@@ -136,5 +136,95 @@ describe("initDatabase", () => {
          VALUES (?, ?, ?, ?, ?, ?)`
       ).run("map-2", "gpt-4", "gpt-4o", "svc-1", 1, now)
     ).toThrow();
+  });
+});
+
+describe("session states", () => {
+  let db: Database.Database;
+
+  afterEach(() => {
+    if (db) db.close();
+  });
+
+  function setupDb(): Database.Database {
+    db = initDatabase(":memory:");
+    const now = new Date().toISOString();
+    db.prepare(
+      `INSERT INTO providers (id, name, api_type, base_url, api_key, is_active, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+    ).run("prov-1", "Test", "openai", "https://api.openai.com", "key", 1, now, now);
+    db.prepare(
+      `INSERT INTO router_keys (id, name, key_hash, key_prefix, key_encrypted, is_active, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+    ).run("rk-1", "Test Key", "hash1", "sk-", "enc", 1, now, now);
+    return db;
+  }
+
+  it("should create session state and query it back", () => {
+    const database = setupDb();
+    upsertSessionState(database, {
+      router_key_id: "rk-1",
+      session_id: "sess-001",
+      current_model: "claude-sonnet-4-20250514",
+      original_model: "claude-sonnet-4-20250514",
+    });
+
+    const states = getSessionStates(database);
+    expect(states).toHaveLength(1);
+    expect(states[0].session_id).toBe("sess-001");
+    expect(states[0].current_model).toBe("claude-sonnet-4-20250514");
+    expect(states[0].router_key_name).toBe("Test Key");
+  });
+
+  it("should upsert update existing state", () => {
+    const database = setupDb();
+    upsertSessionState(database, {
+      router_key_id: "rk-1",
+      session_id: "sess-001",
+      current_model: "claude-sonnet-4-20250514",
+      original_model: "claude-sonnet-4-20250514",
+    });
+
+    upsertSessionState(database, {
+      router_key_id: "rk-1",
+      session_id: "sess-001",
+      current_model: "claude-opus-4-20250514",
+      original_model: "claude-sonnet-4-20250514",
+    });
+
+    const states = getSessionStates(database);
+    expect(states).toHaveLength(1);
+    expect(states[0].current_model).toBe("claude-opus-4-20250514");
+  });
+
+  it("should insert and query history", () => {
+    const database = setupDb();
+    insertSessionHistory(database, {
+      router_key_id: "rk-1",
+      session_id: "sess-001",
+      old_model: "claude-sonnet-4-20250514",
+      new_model: "claude-opus-4-20250514",
+      trigger_type: "directive",
+    });
+
+    const history = getSessionHistory(database, "rk-1", "sess-001");
+    expect(history).toHaveLength(1);
+    expect(history[0].old_model).toBe("claude-sonnet-4-20250514");
+    expect(history[0].new_model).toBe("claude-opus-4-20250514");
+    expect(history[0].trigger_type).toBe("directive");
+  });
+
+  it("should delete session state", () => {
+    const database = setupDb();
+    upsertSessionState(database, {
+      router_key_id: "rk-1",
+      session_id: "sess-001",
+      current_model: "claude-sonnet-4-20250514",
+      original_model: "claude-sonnet-4-20250514",
+    });
+
+    deleteSessionState(database, "rk-1", "sess-001");
+    const states = getSessionStates(database);
+    expect(states).toHaveLength(0);
   });
 });

--- a/tests/directive-parser.test.ts
+++ b/tests/directive-parser.test.ts
@@ -16,27 +16,27 @@ describe("parseDirective", () => {
     expect(cleaned).not.toContain("$SELECT-MODEL");
   });
 
-  it("解析 HTML 注释指令", () => {
+  it("解析 [router-model] 标签指令", () => {
     const result = parseDirective(
-      baseBody("hello <!-- router:model=deepseek-v3 -->")
+      baseBody("hello [router-model: deepseek-v3]")
     );
     expect(result.modelName).toBe("deepseek-v3");
     const cleaned = result.cleanedBody.messages![0].content[0].text;
-    expect(cleaned).not.toContain("router:model");
+    expect(cleaned).not.toContain("router-model");
     expect(cleaned).toContain("hello");
   });
 
-  it("解析 router:command 指令", () => {
+  it("解析 [router-command] 指令", () => {
     const result = parseDirective(
-      baseBody("<!-- router:command=select-model -->")
+      baseBody("[router-command: select-model]")
     );
     expect(result.command).toBe("select-model");
     expect(result.isCommandMessage).toBe(true);
   });
 
-  it("解析 router:command 带参数", () => {
+  it("解析 [router-command] 带参数", () => {
     const result = parseDirective(
-      baseBody("<!-- router:command=select-model A -->")
+      baseBody("[router-command: select-model A]")
     );
     expect(result.command).toBe("select-model A");
     expect(result.isCommandMessage).toBe(true);

--- a/tests/directive-parser.test.ts
+++ b/tests/directive-parser.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from "vitest";
+import { parseDirective } from "../src/proxy/directive-parser.js";
+
+describe("parseDirective", () => {
+  const baseBody = (text: string) => ({
+    model: "claude-sonnet-4-5",
+    messages: [{ role: "user", content: [{ type: "text", text }] }],
+    stream: true,
+  });
+
+  it("解析 $SELECT-MODEL 指令", () => {
+    const result = parseDirective(baseBody("$SELECT-MODEL=glm-5.1"));
+    expect(result.modelName).toBe("glm-5.1");
+    expect(result.command).toBeNull();
+    const cleaned = result.cleanedBody.messages![0].content[0].text;
+    expect(cleaned).not.toContain("$SELECT-MODEL");
+  });
+
+  it("解析 HTML 注释指令", () => {
+    const result = parseDirective(
+      baseBody("hello <!-- router:model=deepseek-v3 -->")
+    );
+    expect(result.modelName).toBe("deepseek-v3");
+    const cleaned = result.cleanedBody.messages![0].content[0].text;
+    expect(cleaned).not.toContain("router:model");
+    expect(cleaned).toContain("hello");
+  });
+
+  it("解析 router:command 指令", () => {
+    const result = parseDirective(
+      baseBody("<!-- router:command=select-model -->")
+    );
+    expect(result.command).toBe("select-model");
+    expect(result.isCommandMessage).toBe(true);
+  });
+
+  it("解析 router:command 带参数", () => {
+    const result = parseDirective(
+      baseBody("<!-- router:command=select-model A -->")
+    );
+    expect(result.command).toBe("select-model A");
+    expect(result.isCommandMessage).toBe(true);
+  });
+
+  it("无指令时返回 null", () => {
+    const result = parseDirective(baseBody("normal message"));
+    expect(result.modelName).toBeNull();
+    expect(result.command).toBeNull();
+    expect(result.isCommandMessage).toBe(false);
+  });
+
+  it("仅扫描最后一条 user 消息", () => {
+    const body = {
+      model: "opus",
+      messages: [
+        {
+          role: "user",
+          content: [{ type: "text", text: "$SELECT-MODEL=old" }],
+        },
+        { role: "assistant", content: [{ type: "text", text: "ok" }] },
+        { role: "user", content: [{ type: "text", text: "new message" }] },
+      ],
+    };
+    const result = parseDirective(body);
+    expect(result.modelName).toBeNull();
+  });
+
+  it("模型名校验：拒绝纯数字", () => {
+    const result = parseDirective(baseBody("$SELECT-MODEL=12345"));
+    expect(result.modelName).toBeNull();
+  });
+
+  it("模型名校验：拒绝以点开头", () => {
+    const result = parseDirective(baseBody("$SELECT-MODEL=.hidden"));
+    expect(result.modelName).toBeNull();
+  });
+
+  it("模型名校验：拒绝超长名称", () => {
+    const long = "a".repeat(129);
+    const result = parseDirective(baseBody(`$SELECT-MODEL=${long}`));
+    expect(result.modelName).toBeNull();
+  });
+
+  it("不扫描 tool_result 类型", () => {
+    const body = {
+      model: "opus",
+      messages: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "x",
+              content: "$SELECT-MODEL=glm-5.1",
+            },
+            { type: "text", text: "normal" },
+          ],
+        },
+      ],
+    };
+    const result = parseDirective(body);
+    expect(result.modelName).toBeNull();
+  });
+
+  it("default 指令返回特殊标记", () => {
+    const result = parseDirective(baseBody("$SELECT-MODEL=default"));
+    expect(result.modelName).toBe("default");
+  });
+});

--- a/tests/metrics.test.ts
+++ b/tests/metrics.test.ts
@@ -29,13 +29,14 @@ describe("request_metrics migration and insertMetrics", () => {
       .prepare("SELECT name FROM migrations")
       .all() as { name: string }[];
 
-    expect(rows).toHaveLength(15);
+    expect(rows).toHaveLength(16);
     expect(rows[5].name).toBe("006_create_request_metrics.sql");
     expect(rows[6].name).toBe("007_add_retry_fields.sql");
     expect(rows[7].name).toBe("008_create_router_keys.sql");
     expect(rows[8].name).toBe("009_add_request_logs_indexes.sql");
     expect(rows[9].name).toBe("010_add_key_encrypted.sql");
     expect(rows[10].name).toBe("011_create_mapping_groups.sql");
+    expect(rows[15].name).toBe("016_create_session_model_tables.sql");
   });
 
   it("should create indexes", () => {

--- a/tests/metrics.test.ts
+++ b/tests/metrics.test.ts
@@ -29,7 +29,7 @@ describe("request_metrics migration and insertMetrics", () => {
       .prepare("SELECT name FROM migrations")
       .all() as { name: string }[];
 
-    expect(rows).toHaveLength(14);
+    expect(rows).toHaveLength(15);
     expect(rows[5].name).toBe("006_create_request_metrics.sql");
     expect(rows[6].name).toBe("007_add_retry_fields.sql");
     expect(rows[7].name).toBe("008_create_router_keys.sql");

--- a/tests/model-state.test.ts
+++ b/tests/model-state.test.ts
@@ -50,3 +50,104 @@ describe("ModelStateManager", () => {
     expect(mgr.get("unknown")).toBeNull();
   });
 });
+
+// --- Session-scoped tests ---
+
+function createMockDb() {
+  const mockRun = vi.fn();
+  const mockGet = vi.fn().mockReturnValue(undefined);
+  const mockAll = vi.fn().mockReturnValue([]);
+  return {
+    transaction: vi.fn((fn: () => void) => fn),
+    prepare: vi.fn(() => ({ run: mockRun, get: mockGet, all: mockAll })),
+    // 暴露内部 mock 以便断言
+    _run: mockRun,
+    _get: mockGet,
+    _all: mockAll,
+  };
+}
+
+describe("session-scoped", () => {
+  let mgr: ModelStateManager;
+  let mockDb: ReturnType<typeof createMockDb>;
+
+  beforeEach(() => {
+    mgr = new ModelStateManager();
+    mockDb = createMockDb();
+    mgr.init(mockDb as unknown as import("better-sqlite3").Database);
+    vi.useFakeTimers();
+  });
+
+  it("set with sessionId writes to memory", () => {
+    mgr.set("key-1", "glm-5.1", "sess-1");
+    expect(mgr.get("key-1", "sess-1")).toBe("glm-5.1");
+  });
+
+  it("set with sessionId calls DB transaction", () => {
+    mgr.set("key-1", "glm-5.1", "sess-1");
+    expect(mockDb.transaction).toHaveBeenCalled();
+  });
+
+  it("get memory hit does not query DB", () => {
+    mgr.set("key-1", "glm-5.1", "sess-1");
+    mockDb.prepare.mockClear();
+    expect(mgr.get("key-1", "sess-1")).toBe("glm-5.1");
+    expect(mockDb.prepare).not.toHaveBeenCalled();
+  });
+
+  it("get memory miss queries DB and backfills", () => {
+    // 模拟 DB 返回一行
+    mockDb._get.mockReturnValueOnce({
+      current_model: "deepseek-v3",
+      router_key_id: "key-1",
+      session_id: "sess-1",
+    });
+
+    // 不 set，直接 get（内存 miss）
+    const result = mgr.get("key-1", "sess-1");
+    expect(result).toBe("deepseek-v3");
+
+    // 第二次 get 应命中内存，不再查 DB
+    mockDb.prepare.mockClear();
+    const result2 = mgr.get("key-1", "sess-1");
+    expect(result2).toBe("deepseek-v3");
+    expect(mockDb.prepare).not.toHaveBeenCalled();
+  });
+
+  it("get memory miss + DB miss returns null", () => {
+    mockDb._get.mockReturnValueOnce(undefined);
+    expect(mgr.get("key-1", "sess-1")).toBeNull();
+  });
+
+  it("delete clears memory + DB", () => {
+    mgr.set("key-1", "glm-5.1", "sess-1");
+    expect(mgr.get("key-1", "sess-1")).toBe("glm-5.1");
+
+    mgr.delete("key-1", "sess-1");
+    expect(mgr.get("key-1", "sess-1")).toBeNull();
+    expect(mockDb.transaction).toHaveBeenCalled();
+  });
+
+  it("set default with sessionId deletes memory + DB", () => {
+    mgr.set("key-1", "glm-5.1", "sess-1");
+    expect(mgr.get("key-1", "sess-1")).toBe("glm-5.1");
+
+    mgr.set("key-1", "default", "sess-1");
+    expect(mgr.get("key-1", "sess-1")).toBeNull();
+    expect(mockDb.transaction).toHaveBeenCalled();
+  });
+
+  it("no sessionId preserves original behavior", () => {
+    mgr.set("key-1", "glm-5.1");
+    expect(mgr.get("key-1")).toBe("glm-5.1");
+    // 不带 sessionId 不触发 DB 写入
+    expect(mockDb.transaction).not.toHaveBeenCalled();
+  });
+
+  it("different sessionIds are isolated", () => {
+    mgr.set("key-1", "glm-5.1", "sess-1");
+    mgr.set("key-1", "deepseek-v3", "sess-2");
+    expect(mgr.get("key-1", "sess-1")).toBe("glm-5.1");
+    expect(mgr.get("key-1", "sess-2")).toBe("deepseek-v3");
+  });
+});

--- a/tests/model-state.test.ts
+++ b/tests/model-state.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { ModelStateManager } from "../src/proxy/model-state.js";
+
+describe("ModelStateManager", () => {
+  let mgr: ModelStateManager;
+
+  beforeEach(() => {
+    mgr = new ModelStateManager();
+    vi.useFakeTimers();
+  });
+
+  it("记录和查询模型", () => {
+    mgr.set("key-1", "glm-5.1");
+    expect(mgr.get("key-1")).toBe("glm-5.1");
+  });
+
+  it("不同 key 隔离", () => {
+    mgr.set("key-1", "glm-5.1");
+    mgr.set("key-2", "deepseek-v3");
+    expect(mgr.get("key-1")).toBe("glm-5.1");
+    expect(mgr.get("key-2")).toBe("deepseek-v3");
+  });
+
+  it("default 清除记忆", () => {
+    mgr.set("key-1", "glm-5.1");
+    mgr.set("key-1", "default");
+    expect(mgr.get("key-1")).toBeNull();
+  });
+
+  it("null key 支持", () => {
+    mgr.set(null, "glm-5.1");
+    expect(mgr.get(null)).toBe("glm-5.1");
+  });
+
+  it("24h TTL 过期", () => {
+    mgr.set("key-1", "glm-5.1");
+    vi.advanceTimersByTime(24 * 60 * 60 * 1000 + 1);
+    expect(mgr.get("key-1")).toBeNull();
+  });
+
+  it("set 刷新 TTL", () => {
+    mgr.set("key-1", "glm-5.1");
+    vi.advanceTimersByTime(12 * 60 * 60 * 1000);
+    mgr.set("key-1", "glm-5.1"); // refresh
+    vi.advanceTimersByTime(12 * 60 * 60 * 1000);
+    expect(mgr.get("key-1")).toBe("glm-5.1"); // not expired yet
+  });
+
+  it("未记录返回 null", () => {
+    expect(mgr.get("unknown")).toBeNull();
+  });
+});

--- a/tests/response-cleaner.test.ts
+++ b/tests/response-cleaner.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { cleanRouterResponses } from "../src/proxy/response-cleaner.js";
+
+describe("cleanRouterResponses", () => {
+  it("移除 <router-response> 标签及其内容", () => {
+    const body = {
+      messages: [{
+        role: "assistant",
+        content: [{ type: "text", text: "hello\n\n<router-response type=\"model-info\">当前模型: glm-5.1</router-response>" }],
+      }],
+    };
+    const result = cleanRouterResponses(body);
+    const text = result.messages![0].content[0].text;
+    expect(text).toBe("hello");
+  });
+
+  it("整条移除包含 router:command= 的 user message", () => {
+    const body = {
+      messages: [
+        { role: "user", content: [{ type: "text", text: "normal" }] },
+        { role: "assistant", content: [{ type: "text", text: "response" }] },
+        { role: "user", content: [{ type: "text", text: "<!-- router:command=select-model -->" }] },
+        { role: "assistant", content: [{ type: "text", text: "<router-response type=\"model-list\">可用模型:</router-response>" }] },
+        { role: "user", content: [{ type: "text", text: "next message" }] },
+      ],
+    };
+    const result = cleanRouterResponses(body);
+    const msgs = result.messages!;
+    expect(msgs).toHaveLength(3);
+    expect(msgs[0].content[0].text).toBe("normal");
+    expect(msgs[2].content[0].text).toBe("next message");
+  });
+
+  it("移除所有纯 <router-response> 的 assistant 消息", () => {
+    const body = {
+      messages: [
+        { role: "user", content: [{ type: "text", text: "normal" }] },
+        { role: "assistant", content: [{ type: "text", text: "<router-response type=\"model-selected\">已选择: glm-5.1</router-response>" }] },
+      ],
+    };
+    const result = cleanRouterResponses(body);
+    const msgs = result.messages!;
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0].content[0].text).toBe("normal");
+  });
+
+  it("无标签时不变", () => {
+    const body = { messages: [{ role: "user", content: [{ type: "text", text: "hello" }] }] };
+    const result = cleanRouterResponses(body);
+    expect(result.messages![0].content[0].text).toBe("hello");
+  });
+
+  it("处理多行 <router-response>", () => {
+    const body = {
+      messages: [{
+        role: "assistant",
+        content: [{ type: "text", text: "line1\n\n<router-response type=\"model-list\">\n可用模型:\nA. glm-5.1\n</router-response>\n\nline2" }],
+      }],
+    };
+    const result = cleanRouterResponses(body);
+    const text = result.messages![0].content[0].text;
+    expect(text).toBe("line1\n\nline2");
+  });
+});

--- a/tests/response-cleaner.test.ts
+++ b/tests/response-cleaner.test.ts
@@ -14,21 +14,25 @@ describe("cleanRouterResponses", () => {
     expect(text).toBe("hello");
   });
 
-  it("整条移除包含 router:command= 的 user message", () => {
+  it("保留最后一条 user 消息（即使包含命令），只移除历史的命令消息", () => {
     const body = {
       messages: [
         { role: "user", content: [{ type: "text", text: "normal" }] },
         { role: "assistant", content: [{ type: "text", text: "response" }] },
-        { role: "user", content: [{ type: "text", text: "<!-- router:command=select-model -->" }] },
-        { role: "assistant", content: [{ type: "text", text: "<router-response type=\"model-list\">可用模型:</router-response>" }] },
-        { role: "user", content: [{ type: "text", text: "next message" }] },
+        { role: "user", content: [{ type: "text", text: "[router-command: select-model]" }] },
+        { role: "assistant", content: [{ type: "text", text: "<router-response type=\"model-list\">1. glm-5.1</router-response>" }] },
+        { role: "user", content: [{ type: "text", text: "[router-command: select-model glm-5.1]" }] },
       ],
     };
     const result = cleanRouterResponses(body);
     const msgs = result.messages!;
+    // 历史 user (idx 0) 保留, 历史 assistant (idx 1) 保留
+    // 历史 user command (idx 2) 移除, 历史 pure router-response (idx 3) 移除
+    // 最后一条 user (idx 4) 保留
     expect(msgs).toHaveLength(3);
     expect(msgs[0].content[0].text).toBe("normal");
-    expect(msgs[2].content[0].text).toBe("next message");
+    expect(msgs[1].content[0].text).toBe("response");
+    expect(msgs[2].content[0].text).toBe("[router-command: select-model glm-5.1]");
   });
 
   it("移除所有纯 <router-response> 的 assistant 消息", () => {
@@ -60,5 +64,16 @@ describe("cleanRouterResponses", () => {
     const result = cleanRouterResponses(body);
     const text = result.messages![0].content[0].text;
     expect(text).toBe("line1\n\nline2");
+  });
+
+  it("最后一条 user 消息中的 <router-response> 标签也会被剥离", () => {
+    const body = {
+      messages: [
+        { role: "user", content: [{ type: "text", text: "hello <router-response>leftover</router-response> world" }] },
+      ],
+    };
+    const result = cleanRouterResponses(body);
+    expect(result.messages!).toHaveLength(1);
+    expect(result.messages![0].content[0].text).toBe("hello  world");
   });
 });


### PR DESCRIPTION
## Summary

- 实现基于消息内嵌指令的动态模型切换，让 Claude Code 可在请求中通过 `$SELECT-MODEL=模型名` 或 `<!-- router:model=模型名 -->` 动态切换 Router 路由目标模型
- 新增会话状态记忆（按 API key，24h TTL），模型选择跨请求保持
- 新增 `<router-response>` 标签机制，Router 增强内容自动从历史消息中清理
- 管理后台新增"代理增强"页面，提供 Claude Code 动态模型切换开关和使用说明
- 日志页面增加"已替换"标识，标记被动态替换模型的请求
- `request_logs` 表新增 `original_model` 列记录原始模型

## 新增文件

| 文件 | 职责 |
|------|------|
| `src/proxy/directive-parser.ts` | 解析 `$SELECT-MODEL` / `router:command` 指令 |
| `src/proxy/model-state.ts` | 按 API key 记忆模型选择（24h TTL） |
| `src/proxy/response-cleaner.ts` | 清理 `<router-response>` 标签和命令消息 |
| `src/admin/proxy-enhancement.ts` | GET/PUT 代理增强配置 API |
| `src/db/migrations/015_add_original_model.sql` | 新增 original_model 列 |
| `frontend/src/views/ProxyEnhancement.vue` | 代理增强页面 |
| `tests/directive-parser.test.ts` | 指令解析器测试（11 用例） |
| `tests/model-state.test.ts` | 状态记忆测试（7 用例） |
| `tests/response-cleaner.test.ts` | 响应清理器测试（5 用例） |

## Test plan

- [x] 新增 23 个单元测试全部通过
- [x] 全量 242 测试用例通过
- [x] TypeScript 编译通过
- [ ] 手动测试：开启代理增强后发送含 `$SELECT-MODEL=xxx` 的请求，验证模型替换
- [ ] 手动测试：访问管理后台代理增强页面，验证开关和说明
- [ ] 手动测试：日志页面显示"已替换"标识

🤖 Generated with [Claude Code](https://claude.com/claude-code)