### PR TITLE
fix: resolve frontend TS errors for Docker CI

### DIFF
--- a/frontend/src/views/Logs.vue
+++ b/frontend/src/views/Logs.vue
@@ -368,6 +368,7 @@ function enhancementLabel(raw: string | null): string {
     if (meta.action) {
       return meta.detail ? `${meta.action}: ${meta.detail}` : meta.action
     }
+    return raw
   } catch { return '未知' }
 }
 
@@ -385,6 +386,7 @@ function getClientRequestRaw(detail: LogEntry): string {
       try { cr.body = JSON.parse(detail.request_body) } catch { cr.body = detail.request_body }
       return JSON.stringify(cr)
     }
+    return detail.client_request
   } catch { return detail.client_request }
 }
 

--- a/frontend/src/views/Monitor.vue
+++ b/frontend/src/views/Monitor.vue
@@ -395,7 +395,7 @@ function handleSSEMessage(event: MessageEvent) {
       break
     }
     case 'stats_update': {
-      stats.value = data as StatsSnapshot
+      stats.value = data as unknown as StatsSnapshot
       break
     }
     case 'runtime_update': {
@@ -458,7 +458,7 @@ async function loadInitialData() {
       recentCompleted.value = recent.value as ActiveRequest[]
     }
     if (statsData.status === 'fulfilled') {
-      stats.value = statsData.value as StatsSnapshot
+      stats.value = statsData.value as unknown as StatsSnapshot
     }
     if (concurrencyData.status === 'fulfilled') {
       concurrency.value = concurrencyData.value as ProviderConcurrencySnapshot[]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "llm-simple-router",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "llm-simple-router",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "MIT",
       "dependencies": {
         "@fastify/cookie": "^11.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "llm-simple-router",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "LLM API proxy router with OpenAI/Anthropic support, model mapping, retry strategies, and admin dashboard",
   "license": "MIT",
   "author": "ZZzzswszzZZ",


### PR DESCRIPTION
## Summary
- Logs.vue: 补全 `enhancementLabel` 和 `getClientRequestRaw` 缺失的 return 语句
- Monitor.vue: SSE stats 数据使用双重类型断言

## Test plan
- [x] `vue-tsc --noEmit` 零错误
- [x] ESLint + 代码规范通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)