### PR TITLE
fix: extract shared monitor types to fix Docker CI

### DIFF
--- a/frontend/src/components/monitor/ActiveRequestList.vue
+++ b/frontend/src/components/monitor/ActiveRequestList.vue
@@ -58,37 +58,7 @@
 <script setup lang="ts">
 import { Badge } from '@/components/ui/badge'
 import { ScrollArea } from '@/components/ui/scroll-area'
-
-interface AttemptSnapshot {
-  statusCode: number | null
-  error: string | null
-  latencyMs: number
-  providerId: string
-}
-
-interface StreamMetricsSnapshot {
-  inputTokens: number | null
-  outputTokens: number | null
-  ttftMs: number | null
-  stopReason: string | null
-  isComplete: boolean
-}
-
-interface ActiveRequest {
-  id: string
-  apiType: 'openai' | 'anthropic'
-  model: string
-  providerId: string
-  providerName: string
-  isStream: boolean
-  startTime: number
-  status: 'pending' | 'completed' | 'failed'
-  retryCount: number
-  attempts: AttemptSnapshot[]
-  streamMetrics?: StreamMetricsSnapshot
-  clientIp?: string
-  completedAt?: number
-}
+import type { ActiveRequest } from '@/types/monitor'
 
 defineProps<{
   requests: ActiveRequest[]

--- a/frontend/src/components/monitor/ConcurrencyPanel.vue
+++ b/frontend/src/components/monitor/ConcurrencyPanel.vue
@@ -36,15 +36,7 @@
 
 <!-- eslint-disable no-magic-numbers -->
 <script setup lang="ts">
-interface ProviderConcurrencySnapshot {
-  providerId: string
-  providerName: string
-  maxConcurrency: number
-  active: number
-  queued: number
-  queueTimeoutMs: number
-  maxQueueSize: number
-}
+import type { ProviderConcurrencySnapshot } from '@/types/monitor'
 
 defineProps<{
   providers: ProviderConcurrencySnapshot[]

--- a/frontend/src/components/monitor/MonitorHeader.vue
+++ b/frontend/src/components/monitor/MonitorHeader.vue
@@ -50,19 +50,7 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { Card, CardContent } from '@/components/ui/card'
-
-interface StatsSnapshot {
-  totalRequests: number
-  successCount: number
-  errorCount: number
-  retryCount: number
-  failoverCount: number
-  avgLatencyMs: number
-  p50LatencyMs: number
-  p99LatencyMs: number
-  byProvider: Record<string, unknown>
-  byStatusCode: Record<number, number>
-}
+import type { StatsSnapshot } from '@/types/monitor'
 
 const props = defineProps<{
   stats: StatsSnapshot | null

--- a/frontend/src/components/monitor/ProviderStatsTable.vue
+++ b/frontend/src/components/monitor/ProviderStatsTable.vue
@@ -58,29 +58,7 @@ import {
   Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
 } from '@/components/ui/table'
 import { Badge } from '@/components/ui/badge'
-
-interface ProviderStats {
-  providerName: string
-  totalRequests: number
-  successCount: number
-  errorCount: number
-  avgLatencyMs: number
-  retryCount: number
-  topErrors: Array<{ code: number; count: number }>
-}
-
-interface StatsSnapshot {
-  totalRequests: number
-  successCount: number
-  errorCount: number
-  retryCount: number
-  failoverCount: number
-  avgLatencyMs: number
-  p50LatencyMs: number
-  p99LatencyMs: number
-  byProvider: Record<string, ProviderStats>
-  byStatusCode: Record<number, number>
-}
+import type { StatsSnapshot } from '@/types/monitor'
 
 const props = defineProps<{
   stats: StatsSnapshot | null

--- a/frontend/src/components/monitor/RequestDetailPanel.vue
+++ b/frontend/src/components/monitor/RequestDetailPanel.vue
@@ -107,37 +107,7 @@ import { computed } from 'vue'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Separator } from '@/components/ui/separator'
-
-interface AttemptSnapshot {
-  statusCode: number | null
-  error: string | null
-  latencyMs: number
-  providerId: string
-}
-
-interface StreamMetricsSnapshot {
-  inputTokens: number | null
-  outputTokens: number | null
-  ttftMs: number | null
-  stopReason: string | null
-  isComplete: boolean
-}
-
-interface ActiveRequest {
-  id: string
-  apiType: 'openai' | 'anthropic'
-  model: string
-  providerId: string
-  providerName: string
-  isStream: boolean
-  startTime: number
-  status: 'pending' | 'completed' | 'failed'
-  retryCount: number
-  attempts: AttemptSnapshot[]
-  streamMetrics?: StreamMetricsSnapshot
-  clientIp?: string
-  completedAt?: number
-}
+import type { ActiveRequest } from '@/types/monitor'
 
 const props = defineProps<{
   request: ActiveRequest | null

--- a/frontend/src/components/monitor/RuntimePanel.vue
+++ b/frontend/src/components/monitor/RuntimePanel.vue
@@ -52,22 +52,7 @@
 <!-- eslint-disable no-magic-numbers -->
 <script setup lang="ts">
 import { computed } from 'vue'
-
-interface MemoryUsage {
-  rss: number
-  heapTotal: number
-  heapUsed: number
-  external: number
-  arrayBuffers: number
-}
-
-interface RuntimeMetrics {
-  uptimeMs: number
-  memoryUsage: MemoryUsage
-  activeHandles: number
-  activeRequests: number
-  eventLoopDelayMs: number
-}
+import type { RuntimeMetrics } from '@/types/monitor'
 
 const props = defineProps<{
   runtime: RuntimeMetrics | null

--- a/frontend/src/components/monitor/StreamResponseViewer.vue
+++ b/frontend/src/components/monitor/StreamResponseViewer.vue
@@ -101,6 +101,7 @@
 <script setup lang="ts">
 import { ref, computed, watch, nextTick } from 'vue'
 import { Badge } from '@/components/ui/badge'
+import type { StreamMetricsSnapshot, StreamContentSnapshot } from '@/types/monitor'
 import {
   Collapsible,
   CollapsibleContent,
@@ -108,27 +109,6 @@ import {
 } from '@/components/ui/collapsible'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Brain, ChevronRight, MessageSquare, Wrench } from 'lucide-vue-next'
-
-interface StreamMetricsSnapshot {
-  inputTokens: number | null
-  outputTokens: number | null
-  ttftMs: number | null
-  stopReason: string | null
-  isComplete: boolean
-}
-
-interface ContentBlock {
-  type: 'thinking' | 'text' | 'tool_use'
-  content: string
-  name?: string
-}
-
-interface StreamContentSnapshot {
-  rawChunks: string
-  textContent: string
-  totalChars: number
-  blocks?: ContentBlock[]
-}
 
 const props = defineProps<{
   metrics: StreamMetricsSnapshot | null

--- a/frontend/src/types/monitor.ts
+++ b/frontend/src/types/monitor.ts
@@ -1,0 +1,86 @@
+export interface ContentBlock {
+  type: 'thinking' | 'text' | 'tool_use'
+  content: string
+  name?: string
+}
+
+export interface StreamContentSnapshot {
+  rawChunks: string
+  textContent: string
+  totalChars: number
+  blocks?: ContentBlock[]
+}
+
+export interface ActiveRequest {
+  id: string
+  apiType: 'openai' | 'anthropic'
+  model: string
+  providerId: string
+  providerName: string
+  isStream: boolean
+  queued?: boolean
+  startTime: number
+  status: 'pending' | 'completed' | 'failed'
+  retryCount: number
+  attempts: AttemptSnapshot[]
+  streamMetrics?: StreamMetricsSnapshot
+  streamContent?: StreamContentSnapshot
+  clientIp?: string
+  completedAt?: number
+}
+
+export interface AttemptSnapshot {
+  statusCode: number | null
+  error: string | null
+  latencyMs: number
+  providerId: string
+}
+
+export interface StreamMetricsSnapshot {
+  inputTokens: number | null
+  outputTokens: number | null
+  ttftMs: number | null
+  stopReason: string | null
+  isComplete: boolean
+}
+
+export interface ProviderConcurrencySnapshot {
+  providerId: string
+  providerName: string
+  maxConcurrency: number
+  active: number
+  queued: number
+  queueTimeoutMs: number
+  maxQueueSize: number
+}
+
+export interface ProviderStats {
+  providerName: string
+  totalRequests: number
+  successCount: number
+  errorCount: number
+  avgLatencyMs: number
+  retryCount: number
+  topErrors: Array<{ code: number; count: number }>
+}
+
+export interface StatsSnapshot {
+  totalRequests: number
+  successCount: number
+  errorCount: number
+  retryCount: number
+  failoverCount: number
+  avgLatencyMs: number
+  p50LatencyMs: number
+  p99LatencyMs: number
+  byProvider: Record<string, ProviderStats>
+  byStatusCode: Record<number, number>
+}
+
+export interface RuntimeMetrics {
+  uptimeMs: number
+  memoryUsage: { rss: number; heapTotal: number; heapUsed: number; external: number; arrayBuffers: number }
+  activeHandles: number
+  activeRequests: number
+  eventLoopDelayMs: number
+}

--- a/frontend/src/views/Monitor.vue
+++ b/frontend/src/views/Monitor.vue
@@ -208,85 +208,12 @@ import StreamResponseViewer from '@/components/monitor/StreamResponseViewer.vue'
 import ProviderStatsTable from '@/components/monitor/ProviderStatsTable.vue'
 import LogDetailDialog from '@/components/monitor/LogDetailDialog.vue'
 
-// --- Type definitions (matching backend src/monitor/types.ts) ---
-
-interface AttemptSnapshot {
-  statusCode: number | null
-  error: string | null
-  latencyMs: number
-  providerId: string
-}
-
-interface StreamMetricsSnapshot {
-  inputTokens: number | null
-  outputTokens: number | null
-  ttftMs: number | null
-  stopReason: string | null
-  isComplete: boolean
-}
-
-interface ActiveRequest {
-  id: string
-  apiType: 'openai' | 'anthropic'
-  model: string
-  providerId: string
-  providerName: string
-  isStream: boolean
-  startTime: number
-  status: 'pending' | 'completed' | 'failed'
-  retryCount: number
-  attempts: AttemptSnapshot[]
-  streamMetrics?: StreamMetricsSnapshot
-  queued?: boolean
-  streamContent?: {
-    rawChunks: string
-    textContent: string
-    totalChars: number
-    blocks?: Array<{ type: 'thinking' | 'text' | 'tool_use'; content: string; name?: string }>
-  }
-  clientIp?: string
-  completedAt?: number
-}
-
-interface ProviderConcurrencySnapshot {
-  providerId: string
-  providerName: string
-  maxConcurrency: number
-  active: number
-  queued: number
-  queueTimeoutMs: number
-  maxQueueSize: number
-}
-
-interface ProviderStats {
-  totalRequests: number
-  successCount: number
-  errorCount: number
-  avgLatencyMs: number
-  retryCount: number
-  topErrors: Array<{ code: number; count: number }>
-}
-
-interface StatsSnapshot {
-  totalRequests: number
-  successCount: number
-  errorCount: number
-  retryCount: number
-  failoverCount: number
-  avgLatencyMs: number
-  p50LatencyMs: number
-  p99LatencyMs: number
-  byProvider: Record<string, ProviderStats>
-  byStatusCode: Record<number, number>
-}
-
-interface RuntimeMetrics {
-  uptimeMs: number
-  memoryUsage: { rss: number; heapTotal: number; heapUsed: number; external: number; arrayBuffers: number }
-  activeHandles: number
-  activeRequests: number
-  eventLoopDelayMs: number
-}
+import type {
+  ActiveRequest,
+  ProviderConcurrencySnapshot,
+  StatsSnapshot,
+  RuntimeMetrics,
+} from '@/types/monitor'
 
 // --- Reactive state ---
 
@@ -395,7 +322,7 @@ function handleSSEMessage(event: MessageEvent) {
       break
     }
     case 'stats_update': {
-      stats.value = data as unknown as StatsSnapshot
+      stats.value = data as StatsSnapshot
       break
     }
     case 'runtime_update': {
@@ -458,7 +385,7 @@ async function loadInitialData() {
       recentCompleted.value = recent.value as ActiveRequest[]
     }
     if (statsData.status === 'fulfilled') {
-      stats.value = statsData.value as unknown as StatsSnapshot
+      stats.value = statsData.value as StatsSnapshot
     }
     if (concurrencyData.status === 'fulfilled') {
       concurrency.value = concurrencyData.value as ProviderConcurrencySnapshot[]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "llm-simple-router",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "llm-simple-router",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "license": "MIT",
       "dependencies": {
         "@fastify/cookie": "^11.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "llm-simple-router",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "LLM API proxy router with OpenAI/Anthropic support, model mapping, retry strategies, and admin dashboard",
   "license": "MIT",
   "author": "ZZzzswszzZZ",


### PR DESCRIPTION
## Summary
- 提取 7 个 monitor 组件中重复的 interface 到 `frontend/src/types/monitor.ts`
- 统一类型来源，消除 Docker 构建中 vue-tsc 的结构类型不兼容问题

## Test plan
- [x] `vue-tsc --noEmit` 零错误
- [x] ESLint + 代码规范通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)