### PR TITLE
fix: ts-taste review — unify useLogs, deduplicate constants, fix type assertions

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -255,8 +255,8 @@ async function request<T>(
 // --- API ---
 
 export const api = {
-  login: (password: string) => request<void>('post', API.LOGIN, { password }),
-  logout: () => request<void>('post', API.LOGOUT),
+  login: (password: string) => request<{ success: boolean }>('post', API.LOGIN, { password }),
+  logout: () => request<{ success: boolean }>('post', API.LOGOUT),
 
   getSetupStatus: () => request<{ initialized: boolean }>('get', '/setup/status'),
   initializeSetup: (password: string) => request<{ success: boolean }>('post', '/setup/initialize', { password }),
@@ -266,6 +266,7 @@ export const api = {
   updateProvider: (id: string, data: Partial<ProviderPayload>) => request<{ success: boolean }>('put', `${API.PROVIDERS}/${id}`, data),
   deleteProvider: (id: string) => request<{ success: boolean }>('delete', `${API.PROVIDERS}/${id}`),
 
+  // TODO: 定义 Mapping 响应类型替换 unknown[]
   getMappings: () => request<unknown[]>('get', API.MAPPINGS),
   createMapping: (data: MappingPayload) => request<{ id: string }>('post', API.MAPPINGS, data),
   updateMapping: (id: string, data: MappingPayload) => request<{ success: boolean }>('put', `${API.MAPPINGS}/${id}`, data),

--- a/frontend/src/components/request-detail/RequestDiffViewer.vue
+++ b/frontend/src/components/request-detail/RequestDiffViewer.vue
@@ -150,8 +150,9 @@ interface ParsedRequest {
 function parseRequest(raw: string | null): ParsedRequest | null {
   if (!raw) return null
   try {
-    const parsed = JSON.parse(raw) as Record<string, unknown>
-    const headers = (parsed.headers ?? {}) as Record<string, string>
+    const parsed = JSON.parse(raw)
+    if (typeof parsed !== 'object' || parsed === null) return null
+    const headers = (typeof parsed.headers === 'object' && parsed.headers !== null ? parsed.headers : {}) as Record<string, string>
     let body = parsed.body
     if (typeof body === 'string') {
       // eslint-disable-next-line taste/no-silent-catch -- body 可能是普通字符串
@@ -168,8 +169,8 @@ function extractText(msg: Record<string, unknown>): string {
   if (typeof content === 'string') return content
   if (Array.isArray(content)) {
     return content
-      .filter((b: unknown) => typeof b === 'object' && b !== null && 'text' in (b as Record<string, unknown>))
-      .map((b: unknown) => (b as Record<string, unknown>).text as string)
+      .filter((b: unknown): b is Record<string, unknown> => typeof b === 'object' && b !== null && 'text' in b)
+      .map(b => typeof b.text === 'string' ? b.text : '')
       .join('')
   }
   return String(content ?? '')

--- a/frontend/src/components/request-detail/RequestOverviewPanel.vue
+++ b/frontend/src/components/request-detail/RequestOverviewPanel.vue
@@ -96,11 +96,9 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import type { UnifiedRequestOverview } from './types'
+import { MS_PER_SECOND, HTTP_ERROR_THRESHOLD } from './types'
 import { Badge } from '@/components/ui/badge'
 import { Separator } from '@/components/ui/separator'
-
-const MS_PER_SECOND = 1000
-const HTTP_ERROR_THRESHOLD = 400
 
 const props = defineProps<{ overview: UnifiedRequestOverview }>()
 

--- a/frontend/src/components/request-detail/ResponseViewer.vue
+++ b/frontend/src/components/request-detail/ResponseViewer.vue
@@ -101,8 +101,9 @@ const blocks = computed<ContentBlock[]>(() => {
     return [{ type: 'text' as const, content: props.responseBody }]
   }
 
+  const validTypes = ['thinking', 'text', 'tool_use', 'tool_result'] as const
   return assembledBlocks.value.map(b => ({
-    type: (['thinking', 'text', 'tool_use'].includes(b.type) ? b.type : 'text') as ContentBlock['type'],
+    type: validTypes.includes(b.type as typeof validTypes[number]) ? b.type as ContentBlock['type'] : 'text' as const,
     content: b.content,
     ...(b.toolName ? { name: b.toolName } : {}),
   }))

--- a/frontend/src/components/request-detail/UnifiedRequestDialog.vue
+++ b/frontend/src/components/request-detail/UnifiedRequestDialog.vue
@@ -28,7 +28,7 @@
 
       <!-- Main content area -->
       <template v-if="overview">
-        <div class="flex gap-0 px-4 pb-4" style="height: calc(85vh - 80px)">
+        <div class="flex gap-0 px-4 pb-4 h-[calc(85vh-80px)]">
           <!-- Left: Overview Panel -->
           <RequestOverviewPanel :overview="overview" />
 
@@ -72,7 +72,7 @@
 
       <!-- Empty state -->
       <template v-else>
-        <div class="flex items-center justify-center" style="height: calc(85vh - 80px)">
+        <div class="flex items-center justify-center h-[calc(85vh-80px)]">
           <p class="text-sm text-muted-foreground">
             {{ props.source === 'realtime' ? '加载中...' : '无选中请求' }}
           </p>

--- a/frontend/src/components/request-detail/types.ts
+++ b/frontend/src/components/request-detail/types.ts
@@ -3,8 +3,8 @@ import type { LogEntry } from '@/components/logs/types'
 
 export type DataSource = 'realtime' | 'history'
 
-const MS_PER_SECOND = 1000
-const HTTP_ERROR_THRESHOLD = 400
+export const MS_PER_SECOND = 1000
+export const HTTP_ERROR_THRESHOLD = 400
 
 export interface UnifiedRequestOverview {
   id: string
@@ -126,7 +126,7 @@ export function fromLogEntry(entry: LogEntry): UnifiedRequestOverview {
     originalModel: entry.original_model,
     statusCode: entry.status_code,
     isStream: !!entry.is_stream,
-    apiType: entry.api_type as 'openai' | 'anthropic',
+    apiType: entry.api_type === 'openai' || entry.api_type === 'anthropic' ? entry.api_type : 'openai',
     providerName: entry.provider_name,
     clientIp: undefined,
     sessionId: null,

--- a/frontend/src/composables/useLogs.ts
+++ b/frontend/src/composables/useLogs.ts
@@ -10,10 +10,9 @@ export function useLogs() {
   const logs = ref<LogEntry[]>([])
   const total = ref(0)
   const page = ref(1)
-  const filterType = ref('all')
-  const filterRouterKey = ref('all')
-  const routerKeys = ref<{ id: string; name: string }[]>([])
-  const cleanupDays = ref(30) // eslint-disable-line no-magic-numbers
+  const filterParams = ref<Record<string, string>>({})
+  const DEFAULT_CLEANUP_DAYS = 30
+  const cleanupDays = ref(DEFAULT_CLEANUP_DAYS)
   const showCleanup = ref(false)
 
   const expandedRows = ref<Set<string>>(new Set())
@@ -24,12 +23,11 @@ export function useLogs() {
 
   const hasMore = computed(() => logs.value.length >= PAGE_SIZE)
 
-  async function loadLogs() {
+  /** 加载日志列表。传入 params 会更新内部 filter 状态供 prevPage/nextPage 复用 */
+  async function loadLogs(params?: Record<string, string>) {
+    if (params) filterParams.value = params
     try {
-      const params: { page: number; limit: number; api_type?: string; router_key_id?: string; view?: string } = { page: page.value, limit: PAGE_SIZE, view: 'grouped' }
-      if (filterType.value && filterType.value !== 'all') params.api_type = filterType.value
-      if (filterRouterKey.value && filterRouterKey.value !== 'all') params.router_key_id = filterRouterKey.value
-      const res = await api.getLogs(params)
+      const res = await api.getLogs({ page: page.value, limit: PAGE_SIZE, view: 'grouped', ...filterParams.value })
       logs.value = res.data
       total.value = res.total
       expandedRows.value.clear()
@@ -39,11 +37,6 @@ export function useLogs() {
       console.error('Failed to load logs:', e)
       toast.error('加载日志失败')
     }
-  }
-
-  function handleFilterChange() {
-    page.value = 1
-    loadLogs()
   }
 
   function prevPage() {
@@ -69,16 +62,6 @@ export function useLogs() {
     } catch (e) {
       console.error('Failed to cleanup logs:', e)
       toast.error('清理日志失败')
-    }
-  }
-
-  async function loadRouterKeys() {
-    try {
-      const res = await api.getRouterKeys()
-      routerKeys.value = res
-    } catch (e) {
-      console.error('Failed to load router keys:', e)
-      toast.error('加载密钥列表失败')
     }
   }
 
@@ -112,16 +95,12 @@ export function useLogs() {
     }
   }
 
-  function init() {
-    loadRouterKeys()
-    loadLogs()
-  }
-
   return {
-    logs, total, page, filterType, filterRouterKey, routerKeys,
+    PAGE_SIZE,
+    logs, total, page, hasMore,
     cleanupDays, showCleanup, expandedRows, childLogs, childLoading,
-    logDetailOpen, selectedLogEntry, hasMore,
-    loadLogs, handleFilterChange, prevPage, nextPage,
-    handleCleanup, toggleExpand, openLogDetail, init,
+    logDetailOpen, selectedLogEntry,
+    loadLogs, prevPage, nextPage,
+    handleCleanup, toggleExpand, openLogDetail,
   }
 }

--- a/frontend/src/views/Logs.vue
+++ b/frontend/src/views/Logs.vue
@@ -194,49 +194,17 @@ const {
 } = useLogFilters()
 
 const TABLE_COL_COUNT = 13
-const PAGE_SIZE = 20
-const DEBOUNCE_MS = 300 // eslint-disable-line no-magic-numbers
+const DEBOUNCE_MS = 300
 
 const {
   logs, total, page, hasMore,
   cleanupDays, showCleanup, expandedRows, childLogs, childLoading,
   logDetailOpen, selectedLogEntry,
+  loadLogs, prevPage, nextPage,
   handleCleanup, toggleExpand, openLogDetail,
 } = useLogs()
 
-async function loadLogs() {
-  try {
-    const filterParams = buildFilterParams()
-    const res = await api.getLogs({
-      page: page.value,
-      limit: PAGE_SIZE,
-      view: 'grouped',
-      ...filterParams,
-    })
-    logs.value = res.data
-    total.value = res.total
-    expandedRows.value.clear()
-    childLogs.value = {}
-    childLoading.value = {}
-  } catch (e) {
-    console.error('Failed to load logs:', e)
-    toast.error('加载日志失败')
-  }
-}
-
-function prevPage() {
-  if (page.value > 1) {
-    page.value--
-    loadLogs()
-  }
-}
-
-function nextPage() {
-  page.value++
-  loadLogs()
-}
-
-const DEFAULT_RETENTION_DAYS = 3 // eslint-disable-line no-magic-numbers
+const DEFAULT_RETENTION_DAYS = 3
 const retentionDays = ref(DEFAULT_RETENTION_DAYS)
 const retentionSaving = ref(false)
 
@@ -267,13 +235,13 @@ watch(
   () => {
     page.value = 1
     if (filterTimer) clearTimeout(filterTimer)
-    filterTimer = setTimeout(() => loadLogs(), DEBOUNCE_MS)
+    filterTimer = setTimeout(() => loadLogs(buildFilterParams()), DEBOUNCE_MS)
   },
   { deep: true },
 )
 
 onMounted(() => {
-  loadLogs()
+  loadLogs(buildFilterParams())
   loadRetention()
 })
 </script>


### PR DESCRIPTION
## Summary
- **P0**: 统一 `useLogs` composable 的 `loadLogs()` 接受可选 `filterParams` 参数，消除 Logs.vue 中重复定义的 `loadLogs`/`prevPage`/`nextPage`
- **P1**: 导出 `MS_PER_SECOND`/`HTTP_ERROR_THRESHOLD` 共享常量，消除 types.ts 与 RequestOverviewPanel.vue 的重复
- **P1**: 为 `parseRequest`/`extractText` 添加运行时类型守卫，`api_type` 添加 includes 校验
- **P1**: `login`/`logout` 返回类型改为 `{ success: boolean }`，`getMappings` 标记 TODO
- **P3**: 移除无效 eslint-disable 注释，内联 style 改用 Tailwind 类

## Test plan
- [x] ESLint 零 warning（含 taste-lint 自定义规则）
- [x] vue-tsc 类型检查通过
- [x] 45 个测试文件全部通过（418 tests）
- [x] Pre-commit hook（ESLint + vue-tsc + 代码规范）全部通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)