### PR TITLE
feat: DB vacuum 优化 + 请求详情 UI 修复

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,56 +60,105 @@ npx llm-simple-router
 
 ### 3. 配置模型映射
 
-管理后台 > 模型映射页面。示例配置：
+管理后台 > 模型映射页面。
+
+**核心概念：** 客户端请求携带模型名 A，Router 根据映射规则将其替换为后端 Provider 支持的模型名 B，然后转发请求：
+
+```
+Claude Code (模型 A) → Router (A → B) → Provider API (模型 B)
+```
+
+只需在映射表中配置「客户端模型 = A，后端模型 = B，选择供应商」即可。
+
+#### Claude Code 默认模型名
+
+Claude Code 未设置环境变量时，默认使用以下模型名：`opus`、`sonnet`、`haiku`。如果后端是智谱 Coding Plan，映射配置如下：
 
 | 客户端模型 | 后端模型 | 供应商 | 时间窗口 |
 |-----------|---------|--------|---------|
-| sonnet | glm-5.1 | 智谱 | 全天 |
-| sonnet | kimi-for-coding | Moonshot | 14:00-18:00 |
+| opus | glm-5.1 | 智谱 Coding Plan | 全天 |
+| sonnet | glm-5.1 | 智谱 Coding Plan | 全天 |
+| haiku | glm-5-turbo | 智谱 Coding Plan | 全天 |
 
-客户端模型是指 Claude Code 实际请求的模型名（由 `ANTHROPIC_MODEL` 等环境变量决定）。
+也可以利用分时段功能实现高峰期自动切换：
+
+| 客户端模型 | 后端模型 | 供应商 | 时间窗口 |
+|-----------|---------|--------|---------|
+| sonnet | glm-5.1 | 智谱 Coding Plan | 00:00-14:00 |
+| sonnet | kimi-for-coding | Moonshot | 14:00-18:00 |
+| sonnet | glm-5.1 | 智谱 Coding Plan | 18:00-24:00 |
 
 ### 4. 配置 Claude Code
 
-在管理后台创建 Router API 密钥，然后选择一种方式配置：
+在管理后台创建 Router API 密钥，然后选择一种方式配置。**两种方式只需选其一。**
 
 **方式一：shell alias（推荐）**
+
+最小配置，Claude Code 使用默认模型名（opus / sonnet / haiku），Router 通过映射表转换为后端模型：
 
 ```bash
 alias clode='\
 export ANTHROPIC_AUTH_TOKEN="<your-router-key>" && \
 export ANTHROPIC_BASE_URL="http://127.0.0.1:9981" && \
-export ANTHROPIC_MODEL="<your-default-model>" && \
-export ANTHROPIC_DEFAULT_OPUS_MODEL="<your-opus-model>" && \
-export ANTHROPIC_DEFAULT_SONNET_MODEL="<your-sonnet-model>" && \
-export ANTHROPIC_DEFAULT_HAIKU_MODEL="<your-haiku-model>" && \
-export ANTHROPIC_SMALL_FAST_MODEL="<your-fast-model>" && \
 claude'
 ```
 
+也可以通过环境变量直接指定模型名，绕过 Router 映射：
+
+```bash
+alias clode='\
+export ANTHROPIC_AUTH_TOKEN="sk-router-xxxxxxxx" && \
+export ANTHROPIC_BASE_URL="http://192.168.1.111:9981" && \
+export ANTHROPIC_MODEL="glm-5" && \
+export ANTHROPIC_DEFAULT_OPUS_MODEL="glm-5.1" && \
+export ANTHROPIC_DEFAULT_SONNET_MODEL="glm-5" && \
+export ANTHROPIC_DEFAULT_HAIKU_MODEL="glm-5-turbo" && \
+export ANTHROPIC_SMALL_FAST_MODEL="glm-5-turbo" && \
+claude'
+```
+
+> 调试时可加参数：`claude --dangerously-skip-permissions --verbose --debug`，或设置 `export DEBUG=claude:*` 查看详细日志。
+
 **方式二：~/.claude/settings.json**
+
+在 `~/.claude/settings.json` 的 `env` 字段中配置，效果与 export 环境变量相同：
+
+最小配置：
 
 ```json
 {
   "env": {
     "ANTHROPIC_AUTH_TOKEN": "<your-router-key>",
-    "ANTHROPIC_BASE_URL": "http://127.0.0.1:9981",
-    "ANTHROPIC_MODEL": "<your-default-model>",
-    "ANTHROPIC_DEFAULT_OPUS_MODEL": "<your-opus-model>",
-    "ANTHROPIC_DEFAULT_SONNET_MODEL": "<your-sonnet-model>",
-    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "<your-haiku-model>",
-    "ANTHROPIC_SMALL_FAST_MODEL": "<your-fast-model>"
+    "ANTHROPIC_BASE_URL": "http://127.0.0.1:9981"
   }
 }
 ```
 
+覆盖模型名：
+
+```json
+{
+  "env": {
+    "ANTHROPIC_AUTH_TOKEN": "sk-router-xxxxxxxx",
+    "ANTHROPIC_BASE_URL": "http://192.168.1.111:9981",
+    "ANTHROPIC_MODEL": "glm-5",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL": "glm-5.1",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL": "glm-5",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "glm-5-turbo",
+    "ANTHROPIC_SMALL_FAST_MODEL": "glm-5-turbo"
+  }
+}
+```
+
+> settings.json 中的环境变量对所有项目生效。如果只想对当前项目生效，可放在 `.claude/settings.json`（项目根目录下）。
+
 ### 5. 使用
 
 ```bash
-# 方式一用户直接用 alias
+# 方式一（shell alias）
 clode
 
-# 方式二用户正常启动 claude
+# 方式二（settings.json）
 claude
 ```
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1678,7 +1678,7 @@
     },
     "node_modules/@vueuse/core": {
       "version": "14.2.1",
-      "resolved": "https://registry.npmmirror.com/@vueuse/core/-/core-14.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-14.2.1.tgz",
       "integrity": "sha512-3vwDzV+GDUNpdegRY6kzpLm4Igptq+GA0QkJ3W61Iv27YWwW/ufSlOfgQIpN6FZRMG0mkaz4gglJRtq5SeJyIQ==",
       "license": "MIT",
       "dependencies": {
@@ -5922,7 +5922,7 @@
     },
     "node_modules/reka-ui": {
       "version": "2.9.6",
-      "resolved": "https://registry.npmmirror.com/reka-ui/-/reka-ui-2.9.6.tgz",
+      "resolved": "https://registry.npmjs.org/reka-ui/-/reka-ui-2.9.6.tgz",
       "integrity": "sha512-K6bL457owpvWONc7hsjFxo3HDC9s6IzhRqShW0w9JSKelPGfRbkHD558UQTn/NH1cvrXVHygKyC7fExFmRketg==",
       "license": "MIT",
       "dependencies": {

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -58,6 +58,10 @@ const API = {
   USAGE_WINDOWS: '/usage/windows',
   USAGE_WEEKLY: '/usage/weekly',
   USAGE_MONTHLY: '/usage/monthly',
+  SETTINGS_DB_SIZE: '/settings/db-size',
+  SETTINGS_DB_SIZE_THRESHOLDS: '/settings/db-size-thresholds',
+  SETTINGS_EXPORT: '/settings/export',
+  SETTINGS_IMPORT: '/settings/import',
 } as const
 
 // --- Payload types ---
@@ -229,6 +233,23 @@ export interface DailyUsage {
   total_output_tokens: number
 }
 
+export interface DbSizeInfoResponse {
+  totalBytes: number;
+  logTableBytes: number;
+  logCount: number;
+  lastChecked: string | null;
+  thresholds: {
+    dbMaxSizeMb: number;
+    logTableMaxSizeMb: number;
+  };
+}
+
+export interface ConfigExportResponse {
+  version: number;
+  exportedAt: string;
+  data: Record<string, unknown[]>;
+}
+
 // --- Typed request helper ---
 // 解包 AxiosResponse.data，让调用方直接拿到类型化的响应体。
 
@@ -342,4 +363,10 @@ export const api = {
     request<DailyUsage[]>('get', API.USAGE_WEEKLY, undefined, { params }),
   getUsageMonthly: (params?: { router_key_id?: string }) =>
     request<DailyUsage[]>('get', API.USAGE_MONTHLY, undefined, { params }),
+
+  getDbSizeInfo: () => request<DbSizeInfoResponse>('get', API.SETTINGS_DB_SIZE),
+  setDbSizeThresholds: (data: { dbMaxSizeMb?: number; logTableMaxSizeMb?: number }) =>
+    request<{ dbMaxSizeMb: number; logTableMaxSizeMb: number }>('put', API.SETTINGS_DB_SIZE_THRESHOLDS, data),
+  exportConfig: () => request<ConfigExportResponse>('get', API.SETTINGS_EXPORT),
+  importConfig: (data: ConfigExportResponse) => request<Record<string, number>>('post', API.SETTINGS_IMPORT, data),
 }

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -51,6 +51,7 @@ const API = {
   MONITOR_CONCURRENCY: '/monitor/concurrency',
   MONITOR_RUNTIME: '/monitor/runtime',
   MONITOR_STREAM: '/monitor/stream',
+  MONITOR_REQUEST: '/monitor/request',
   RECOMMENDED_PROVIDERS: '/recommended/providers',
   RECOMMENDED_RETRY_RULES: '/recommended/retry-rules',
   RECOMMENDED_RELOAD: '/recommended/reload',
@@ -325,6 +326,7 @@ export const api = {
   getMonitorActive: () => request<ActiveRequest[]>('get', API.MONITOR_ACTIVE),
   getMonitorRecent: () => request<ActiveRequest[]>('get', API.MONITOR_RECENT),
   getMonitorStats: () => request<StatsSnapshot>('get', API.MONITOR_STATS),
+  getMonitorRequest: (id: string) => request<ActiveRequest>('get', `${API.MONITOR_REQUEST}/${id}`),
   getMonitorConcurrency: () => request<ProviderConcurrencySnapshot[]>('get', API.MONITOR_CONCURRENCY),
   getMonitorRuntime: () => request<RuntimeMetrics>('get', API.MONITOR_RUNTIME),
 

--- a/frontend/src/components/layout/Sidebar.vue
+++ b/frontend/src/components/layout/Sidebar.vue
@@ -49,6 +49,7 @@ import {
   Sparkles,
   FileText,
   Activity,
+  Settings,
   LogOut,
 } from 'lucide-vue-next'
 import { api } from '@/api/client'
@@ -73,6 +74,7 @@ const navItems: NavItem[] = [
   { path: '/proxy-enhancement', label: '代理增强（实验性）', icon: Sparkles },
   { path: '/monitor', label: '实时监控', icon: Activity },
   { path: '/logs', label: '请求日志', icon: FileText },
+  { path: '/settings', label: '系统设置', icon: Settings },
 ]
 
 const route = useRoute()

--- a/frontend/src/components/logs/types.ts
+++ b/frontend/src/components/logs/types.ts
@@ -28,4 +28,5 @@ export interface LogEntry {
   stop_reason: string | null
   metrics_complete: number
   stream_text_content: string | null
+  session_id: string | null
 }

--- a/frontend/src/components/request-detail/ContentBlockRenderer.vue
+++ b/frontend/src/components/request-detail/ContentBlockRenderer.vue
@@ -6,7 +6,7 @@
       <span class="text-xs font-medium">Reply</span>
     </div>
     <div class="px-2.5 py-2">
-      <pre class="text-xs overflow-y-auto whitespace-pre-wrap break-words max-h-60"><code>{{ content }}<span v-if="showCursor" class="inline-block w-1.5 h-3.5 dot-success animate-pulse ml-0.5 align-text-bottom" /></code></pre>
+      <pre class="text-xs overflow-y-auto whitespace-pre-wrap break-words"><code>{{ content }}<span v-if="showCursor" class="inline-block w-1.5 h-3.5 dot-success animate-pulse ml-0.5 align-text-bottom" /></code></pre>
     </div>
   </div>
 
@@ -23,7 +23,7 @@
     </CollapsibleTrigger>
     <CollapsibleContent>
       <div class="px-2.5 pb-2">
-        <pre class="text-xs rounded p-2 overflow-y-auto whitespace-pre-wrap break-words max-h-60" :class="contentClass"><code>{{ content || placeholder }}</code></pre>
+        <pre class="text-xs rounded p-2 overflow-y-auto whitespace-pre-wrap break-words" :class="contentClass"><code>{{ content || placeholder }}</code></pre>
       </div>
     </CollapsibleContent>
   </Collapsible>

--- a/frontend/src/components/request-detail/RequestDiffViewer.vue
+++ b/frontend/src/components/request-detail/RequestDiffViewer.vue
@@ -29,8 +29,11 @@
 
       <!-- Structured view -->
       <template v-else>
-        <div v-if="!upstreamParsed" class="text-[11px] text-muted-foreground py-4 text-center">
+        <div v-if="!upstreamParsed && !clientParsed" class="text-[11px] text-muted-foreground py-4 text-center">
           No request data available
+        </div>
+        <div v-if="!upstreamParsed && clientParsed" class="text-[11px] text-muted-foreground py-2 text-center">
+          请求进行中，上游请求内容将在完成后显示
         </div>
 
         <div v-else class="space-y-4">

--- a/frontend/src/components/request-detail/RequestDiffViewer.vue
+++ b/frontend/src/components/request-detail/RequestDiffViewer.vue
@@ -54,7 +54,7 @@
             <div class="text-[10px] uppercase tracking-wider text-muted-foreground font-medium mb-1">
               System
             </div>
-            <pre class="text-[11px] bg-muted/50 rounded-md px-2.5 py-2 overflow-y-auto whitespace-pre-wrap break-words max-h-40">{{ systemPrompt }}</pre>
+            <pre class="text-[11px] bg-muted/50 rounded-md border px-2.5 py-2 overflow-y-auto whitespace-pre-wrap break-words max-h-40">{{ systemPrompt }}</pre>
           </div>
 
           <!-- Messages -->
@@ -71,19 +71,26 @@
               >
                 <div class="flex items-center gap-1.5 mb-1">
                   <Badge
-                    class="text-[9px] px-1.5 py-0"
-                    :class="msg.role === 'user' ? 'badge-role-user' : msg.role === 'assistant' ? 'badge-role-assistant' : 'badge-role-thinking'"
+                    variant="outline"
+                    class="text-[9px] px-1.5 py-0 border-transparent"
+                    :class="msg.role === 'user' ? 'bg-role-user-bg text-role-user' : msg.role === 'assistant' ? 'bg-role-assistant-bg text-role-assistant' : 'bg-role-thinking-bg text-role-thinking'"
                   >
                     {{ msg.role }}
                   </Badge>
-                  <Badge v-if="msg.modified" class="badge-role-thinking text-[9px] px-1.5 py-0">
+                  <Badge v-if="msg.modified" variant="outline" class="bg-role-thinking-bg text-role-thinking text-[9px] px-1.5 py-0 border-transparent">
                     Modified
                   </Badge>
+                  <span v-if="msg.toolCalls.length > 0" class="text-[9px] text-muted-foreground">
+                    &rarr; {{ msg.toolCalls.join(', ') }}
+                  </span>
                 </div>
                 <div v-if="msg.modified && msg.removedText" class="diff-removed line-through mb-0.5">
                   {{ msg.removedText }}
                 </div>
-                <div class="text-foreground overflow-y-auto max-h-40">{{ msg.text }}</div>
+                <div v-if="msg.text" class="text-foreground overflow-y-auto max-h-40">{{ msg.text }}</div>
+                <div v-else-if="msg.toolResultCount > 0" class="text-muted-foreground text-[10px]">
+                  {{ msg.toolResultCount }} tool result(s)
+                </div>
               </div>
             </div>
           </div>
@@ -94,13 +101,32 @@
               Tools ({{ tools.length }})
             </div>
             <div class="space-y-1">
-              <div
-                v-for="(tool, i) in tools"
-                :key="i"
-                class="rounded-md border bg-background px-2.5 py-1.5 text-[11px]"
-              >
-                <Badge class="text-[9px] px-1.5 py-0 badge-role-tool">{{ tool.name }}</Badge>
-              </div>
+              <template v-for="(row, rowIdx) in toolRows" :key="rowIdx">
+                <div class="grid grid-cols-5 gap-1">
+                  <div
+                    v-for="(tool, colIdx) in row.tools"
+                    :key="colIdx"
+                    class="cursor-pointer rounded-md border px-1.5 py-1 text-[10px] truncate text-center transition-colors"
+                    :class="expandedToolIdx === row.startIdx + colIdx ? 'bg-role-tool-bg text-role-tool border-role-tool' : 'bg-background hover:bg-muted'"
+                    :title="tool.name"
+                    @click="expandedToolIdx = expandedToolIdx === row.startIdx + colIdx ? -1 : row.startIdx + colIdx"
+                  >
+                    {{ tool.name }}
+                  </div>
+                </div>
+                <div
+                  v-if="expandedToolIdx >= row.startIdx && expandedToolIdx < row.startIdx + row.tools.length"
+                  class="rounded-md border bg-background p-2.5"
+                >
+                  <div class="flex items-center gap-2 mb-1">
+                    <span class="text-[11px] font-semibold font-mono">{{ tools[expandedToolIdx].name }}</span>
+                  </div>
+                  <p v-if="tools[expandedToolIdx].description" class="text-[11px] text-muted-foreground">{{ tools[expandedToolIdx].description }}</p>
+                  <div v-if="tools[expandedToolIdx].params.length > 0" class="mt-1 flex flex-wrap gap-1">
+                    <Badge v-for="p in tools[expandedToolIdx].params" :key="p" variant="outline" class="text-[9px] px-1 py-0">{{ p }}</Badge>
+                  </div>
+                </div>
+              </template>
             </div>
           </div>
 
@@ -110,7 +136,7 @@
               Stream Options
             </div>
             <div class="flex items-center gap-2 text-[11px]">
-              <Badge class="badge-success text-[9px] px-1.5 py-0">Injected</Badge>
+              <Badge variant="outline" class="bg-success-light text-success-dark text-[9px] px-1.5 py-0 border-transparent">Injected</Badge>
               <code class="font-mono diff-added">{ "include_usage": true }</code>
             </div>
           </div>
@@ -232,6 +258,8 @@ interface MessageView {
   text: string
   removedText: string | null
   modified: boolean
+  toolCalls: string[]
+  toolResultCount: number
 }
 
 const messages = computed<MessageView[]>(() => {
@@ -243,18 +271,30 @@ const messages = computed<MessageView[]>(() => {
   for (let i = 0; i < upstreamMsgs.length; i++) {
     const upstreamMsg = upstreamMsgs[i]
     const role = String(upstreamMsg.role ?? 'unknown')
-    // 跳过 system 消息（已在 System 区展示）
     if (role === 'system') continue
+
     const upstreamText = extractText(upstreamMsg)
     const clientMsg = clientMsgs[i]
     const clientText = clientMsg ? extractText(clientMsg) : null
     const isModified = clientText !== null && upstreamText !== clientText
+
+    const content = upstreamMsg.content
+    const blocks = Array.isArray(content) ? content : []
+    const toolCalls = blocks
+      .filter((b: unknown) => typeof b === 'object' && b !== null && (b as Record<string, unknown>).type === 'tool_use')
+      .map((b: unknown) => (b as Record<string, unknown>).name as string)
+      .filter(Boolean)
+    const toolResultCount = blocks
+      .filter((b: unknown) => typeof b === 'object' && b !== null && (b as Record<string, unknown>).type === 'tool_result')
+      .length
 
     result.push({
       role,
       text: upstreamText,
       removedText: isModified ? clientText : null,
       modified: isModified,
+      toolCalls,
+      toolResultCount,
     })
   }
   return result
@@ -262,7 +302,21 @@ const messages = computed<MessageView[]>(() => {
 
 interface ToolView {
   name: string
+  description: string
+  params: string[]
 }
+
+const expandedToolIdx = ref(-1)
+
+const TOOLS_PER_ROW = 5
+
+const toolRows = computed(() => {
+  const rows: { tools: ToolView[]; startIdx: number }[] = []
+  for (let i = 0; i < tools.value.length; i += TOOLS_PER_ROW) {
+    rows.push({ tools: tools.value.slice(i, i + TOOLS_PER_ROW), startIdx: i })
+  }
+  return rows
+})
 
 const tools = computed<ToolView[]>(() => {
   const body = upstreamParsed.value?.body
@@ -271,7 +325,13 @@ const tools = computed<ToolView[]>(() => {
   if (!Array.isArray(rawTools)) return []
   return rawTools
     .filter(t => typeof t?.name === 'string')
-    .map(t => ({ name: t.name as string }))
+    .map(t => {
+      const desc = typeof t.description === 'string' ? t.description : ''
+      const schema = t.input_schema as Record<string, unknown> | undefined
+      const props = schema?.properties as Record<string, unknown> | undefined
+      const params = props ? Object.keys(props) : []
+      return { name: t.name as string, description: desc, params }
+    })
 })
 
 const streamOptionsInjected = computed(() => {

--- a/frontend/src/components/request-detail/RequestOverviewPanel.vue
+++ b/frontend/src/components/request-detail/RequestOverviewPanel.vue
@@ -3,7 +3,7 @@
     <!-- Row 1: model @ provider -->
     <div class="flex items-baseline gap-1 min-w-0">
       <span class="font-mono text-[11px] font-semibold truncate min-w-0">{{ overview.model }}</span>
-      <span v-if="overview.providerName" class="text-[10px] text-muted-foreground flex-shrink-0">@ {{ overview.providerName }}</span>
+      <span class="text-[10px] text-muted-foreground flex-shrink-0">@ {{ overview.providerName || 'unknown' }}</span>
     </div>
 
     <!-- Row 2: status + SSE + apiType -->

--- a/frontend/src/components/request-detail/RequestOverviewPanel.vue
+++ b/frontend/src/components/request-detail/RequestOverviewPanel.vue
@@ -8,15 +8,15 @@
 
     <!-- Row 2: status + SSE + apiType -->
     <div class="flex items-center gap-1.5">
-      <Badge v-if="statusColor === 'pending'" class="badge-pending">
-        <span class="w-1.5 h-1.5 rounded-full dot-pending animate-pulse" />
+      <Badge v-if="statusColor === 'pending'" variant="outline" class="border-warning/30 bg-warning-light text-warning-dark">
+        <span class="w-1.5 h-1.5 rounded-full bg-warning animate-pulse" />
         进行中
       </Badge>
-      <Badge v-else-if="statusColor === 'error'" class="badge-error">
+      <Badge v-else-if="statusColor === 'error'" variant="outline" class="border-danger/30 bg-danger-light text-danger-dark">
         {{ overview.statusCode ?? '失败' }}
       </Badge>
-      <Badge v-else class="badge-success">
-        <span class="w-1.5 h-1.5 rounded-full dot-success" />
+      <Badge v-else variant="outline" class="border-success/30 bg-success-light text-success-dark">
+        <span class="w-1.5 h-1.5 rounded-full bg-success" />
         已完成
       </Badge>
 

--- a/frontend/src/components/request-detail/UnifiedRequestDialog.vue
+++ b/frontend/src/components/request-detail/UnifiedRequestDialog.vue
@@ -41,8 +41,8 @@
 
           <!-- Right: Tabs -->
           <div class="flex-1 flex flex-col min-w-0 pl-3">
-            <Tabs v-model="activeTab">
-              <TabsList>
+            <Tabs v-model="activeTab" class="flex-1 flex flex-col min-h-0">
+              <TabsList class="flex-shrink-0">
                 <TabsTrigger value="response">响应内容</TabsTrigger>
                 <TabsTrigger value="request">请求内容</TabsTrigger>
               </TabsList>

--- a/frontend/src/components/request-detail/UnifiedRequestDialog.vue
+++ b/frontend/src/components/request-detail/UnifiedRequestDialog.vue
@@ -62,7 +62,7 @@
               </div>
 
               <!-- Request diff tab -->
-              <div v-if="activeTab === 'request'" class="flex-1 overflow-y-auto mt-2">
+              <div v-if="activeTab === 'request'" class="flex-1 min-h-0 mt-2">
                 <RequestDiffViewer :overview="overview" />
               </div>
             </Tabs>

--- a/frontend/src/components/request-detail/types.ts
+++ b/frontend/src/components/request-detail/types.ts
@@ -129,7 +129,7 @@ export function fromLogEntry(entry: LogEntry): UnifiedRequestOverview {
     apiType: entry.api_type === 'openai' || entry.api_type === 'anthropic' ? entry.api_type : 'openai',
     providerName: entry.provider_name,
     clientIp: undefined,
-    sessionId: null,
+    sessionId: entry.session_id ?? null,
     latencyMs: entry.latency_ms,
     ttftMs,
     inputTokens,

--- a/frontend/src/components/ui/progress/Progress.vue
+++ b/frontend/src/components/ui/progress/Progress.vue
@@ -1,0 +1,38 @@
+<script setup lang="ts">
+import type { ProgressRootProps } from 'reka-ui'
+import type { HTMLAttributes } from 'vue'
+import { reactiveOmit } from '@vueuse/core'
+import {
+  ProgressIndicator,
+  ProgressRoot,
+} from 'reka-ui'
+import { cn } from '@/lib/utils'
+
+const props = withDefaults(
+  defineProps<ProgressRootProps & { class?: HTMLAttributes['class'] }>(),
+  {
+    modelValue: 0,
+  },
+)
+
+const delegatedProps = reactiveOmit(props, 'class')
+</script>
+
+<template>
+  <ProgressRoot
+    data-slot="progress"
+    v-bind="delegatedProps"
+    :class="
+      cn(
+        'bg-muted h-1 rounded-full relative flex w-full items-center overflow-x-hidden',
+        props.class,
+      )
+    "
+  >
+    <ProgressIndicator
+      data-slot="progress-indicator"
+      class="bg-primary size-full flex-1 transition-all"
+      :style="`transform: translateX(-${100 - (props.modelValue ?? 0)}%);`"
+    />
+  </ProgressRoot>
+</template>

--- a/frontend/src/components/ui/progress/index.ts
+++ b/frontend/src/components/ui/progress/index.ts
@@ -1,0 +1,1 @@
+export { default as Progress } from './Progress.vue'

--- a/frontend/src/composables/useLogRetention.ts
+++ b/frontend/src/composables/useLogRetention.ts
@@ -1,0 +1,39 @@
+import { ref } from 'vue'
+import { toast } from 'vue-sonner'
+import { api } from '@/api/client'
+
+const DEFAULT_RETENTION_DAYS = 3
+
+export function useLogRetention() {
+  const retentionDays = ref(DEFAULT_RETENTION_DAYS)
+  const retentionSaving = ref(false)
+
+  async function saveRetention() {
+    retentionSaving.value = true
+    try {
+      const result = await api.setLogRetention(retentionDays.value)
+      retentionDays.value = result.days
+      toast.success('日志保留天数已更新')
+    } catch {
+      toast.error('更新保留天数失败')
+    } finally {
+      retentionSaving.value = false
+    }
+  }
+
+  async function loadRetention() {
+    try {
+      const { days } = await api.getLogRetention()
+      retentionDays.value = days
+    } catch {
+      toast.error('加载保留天数失败，使用默认值')
+    }
+  }
+
+  return {
+    retentionDays,
+    retentionSaving,
+    saveRetention,
+    loadRetention,
+  }
+}

--- a/frontend/src/composables/useLogs.ts
+++ b/frontend/src/composables/useLogs.ts
@@ -51,6 +51,9 @@ export function useLogs() {
     loadLogs()
   }
 
+  const cleanupResult = ref<number | null>(null)
+  const showCleanupResult = ref(false)
+
   async function handleCleanup() {
     try {
       const before = new Date(Date.now() - cleanupDays.value * MS_PER_DAY).toISOString()
@@ -58,7 +61,8 @@ export function useLogs() {
       showCleanup.value = false
       page.value = 1
       await loadLogs()
-      toast.success(`已清理 ${res.deleted} 条日志`)
+      cleanupResult.value = res.deleted
+      showCleanupResult.value = true
     } catch (e) {
       console.error('Failed to cleanup logs:', e)
       toast.error('清理日志失败')
@@ -100,6 +104,7 @@ export function useLogs() {
     logs, total, page, hasMore,
     cleanupDays, showCleanup, expandedRows, childLogs, childLoading,
     logDetailOpen, selectedLogEntry,
+    cleanupResult, showCleanupResult,
     loadLogs, prevPage, nextPage,
     handleCleanup, toggleExpand, openLogDetail,
   }

--- a/frontend/src/composables/useMonitorData.ts
+++ b/frontend/src/composables/useMonitorData.ts
@@ -124,10 +124,20 @@ export function useMonitorData() {
     try {
       // Pending 请求：从 tracker 内存获取 clientRequest（日志尚未写入 DB）
       if (req.status === 'pending') {
-        const trackerReq = await api.getMonitorRequest(requestId)
-        if (version !== loadVersion.value) return
-        logDetailData.value = {
-          clientRequest: trackerReq.clientRequest ?? undefined,
+        try {
+          const trackerReq = await api.getMonitorRequest(requestId)
+          if (version !== loadVersion.value) return
+          logDetailData.value = {
+            clientRequest: trackerReq.clientRequest ?? undefined,
+          }
+        } catch {
+          // 请求可能刚完成从 tracker 移除，回退到 DB 查询
+          if (version !== loadVersion.value) return
+          const log = await api.getLogDetail(requestId)
+          if (version !== loadVersion.value) return
+          logDetailData.value = log.client_request
+            ? { clientRequest: log.client_request }
+            : null
         }
         return
       }

--- a/frontend/src/composables/useMonitorData.ts
+++ b/frontend/src/composables/useMonitorData.ts
@@ -119,15 +119,23 @@ export function useMonitorData() {
       return
     }
     logDetailData.value = null
-    // 活跃请求暂无日志数据（日志在请求处理完成后才写入 DB）
-    if (req.status === 'pending') return
 
     nonStreamBodyLoading.value = true
     try {
+      // Pending 请求：从 tracker 内存获取 clientRequest（日志尚未写入 DB）
+      if (req.status === 'pending') {
+        const trackerReq = await api.getMonitorRequest(requestId)
+        if (version !== loadVersion.value) return
+        logDetailData.value = {
+          clientRequest: trackerReq.clientRequest ?? undefined,
+        }
+        return
+      }
+
+      // 已完成请求：从 DB 获取完整日志
       const log = await api.getLogDetail(requestId)
       if (version !== loadVersion.value) return
       // 从 upstream_response 提取 body（兼容 {statusCode, headers, body} 包装格式）
-      // 非流式请求的响应体在日志中，流式请求的响应体通过 SSE 实时推送
       let responseBody: string | undefined
       if (!req.isStream) {
         const raw = log.upstream_response

--- a/frontend/src/composables/useMonitorData.ts
+++ b/frontend/src/composables/useMonitorData.ts
@@ -130,8 +130,10 @@ export function useMonitorData() {
           logDetailData.value = {
             clientRequest: trackerReq.clientRequest ?? undefined,
           }
-        } catch {
-          // 请求可能刚完成从 tracker 移除，回退到 DB 查询
+        } catch (e: unknown) {
+          // 仅在 tracker 中请求不存在(404)时回退到 DB 查询
+          const status = (e as { response?: { status?: number } })?.response?.status
+          if (status !== 404) throw e // eslint-disable-line no-magic-numbers
           if (version !== loadVersion.value) return
           const log = await api.getLogDetail(requestId)
           if (version !== loadVersion.value) return

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -65,7 +65,7 @@ const router = createRouter({
     {
       path: '/settings',
       name: 'settings',
-      component: () => import('../views/Settings.vue'),
+      component: () => import('@/views/Settings.vue'),
       meta: { requiresAuth: true },
     },
   ],

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -62,6 +62,12 @@ const router = createRouter({
       component: () => import('@/views/Monitor.vue'),
       meta: { requiresAuth: true },
     },
+    {
+      path: '/settings',
+      name: 'settings',
+      component: () => import('../views/Settings.vue'),
+      meta: { requiresAuth: true },
+    },
   ],
 })
 

--- a/frontend/src/styles/components.css
+++ b/frontend/src/styles/components.css
@@ -1,17 +1,8 @@
 @layer components {
-  /* === 状态 Badge 颜色 === */
-  .badge-pending { background-color: var(--color-warning-light); color: var(--color-warning-dark); }
-  .badge-error { background-color: var(--color-danger-light); color: var(--color-danger-dark); }
-  .badge-success { background-color: var(--color-success-light); color: var(--color-success-dark); }
-
-  .dot-pending { background-color: var(--color-warning); }
+  /* === 状态色（仅用于非 Badge 元素） === */
   .dot-success { background-color: var(--color-success); }
 
-  /* === 角色色 === */
-  .badge-role-user { background-color: var(--color-role-user-bg); color: var(--color-role-user); }
-  .badge-role-assistant { background-color: var(--color-role-assistant-bg); color: var(--color-role-assistant); }
-  .badge-role-tool { background-color: var(--color-role-tool-bg); color: var(--color-role-tool); }
-  .badge-role-thinking { background-color: var(--color-role-thinking-bg); color: var(--color-role-thinking); }
+  /* === 角色色（已迁移至 Tailwind utility classes） === */
 
   /* === 内容块背景 === */
   .block-thinking { background-color: var(--color-role-thinking-bg); }

--- a/frontend/src/types/monitor.ts
+++ b/frontend/src/types/monitor.ts
@@ -27,6 +27,7 @@ export interface ActiveRequest {
   streamContent?: StreamContentSnapshot
   clientIp?: string
   sessionId?: string
+  clientRequest?: string
   completedAt?: number
 }
 

--- a/frontend/src/views/Logs.vue
+++ b/frontend/src/views/Logs.vue
@@ -166,6 +166,19 @@
         </DialogFooter>
       </DialogContent>
     </Dialog>
+
+    <!-- Cleanup result dialog -->
+    <AlertDialog v-model:open="showCleanupResult">
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>清理完成</AlertDialogTitle>
+          <AlertDialogDescription>已删除 {{ cleanupResult }} 条日志。</AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogAction @click="showCleanupResult = false">确定</AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
   </div>
 </template>
 
@@ -179,6 +192,7 @@ import { Label } from '@/components/ui/label'
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@/components/ui/select'
 import { Table, TableHeader, TableBody, TableRow, TableHead, TableCell } from '@/components/ui/table'
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog'
+import { AlertDialog, AlertDialogContent, AlertDialogHeader, AlertDialogTitle, AlertDialogDescription, AlertDialogFooter, AlertDialogAction } from '@/components/ui/alert-dialog'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Separator } from '@/components/ui/separator'
 import UnifiedRequestDialog from '@/components/request-detail/UnifiedRequestDialog.vue'
@@ -198,7 +212,8 @@ const DEBOUNCE_MS = 300
 
 const {
   logs, total, page, hasMore,
-  cleanupDays, showCleanup, expandedRows, childLogs, childLoading,
+  cleanupDays, showCleanup, cleanupResult, showCleanupResult,
+  expandedRows, childLogs, childLoading,
   logDetailOpen, selectedLogEntry,
   loadLogs, prevPage, nextPage,
   handleCleanup, toggleExpand, openLogDetail,

--- a/frontend/src/views/Logs.vue
+++ b/frontend/src/views/Logs.vue
@@ -183,9 +183,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, watch } from 'vue'
-import { toast } from 'vue-sonner'
-import { api } from '@/api/client'
+import { onMounted, watch } from 'vue'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -199,6 +197,7 @@ import UnifiedRequestDialog from '@/components/request-detail/UnifiedRequestDial
 import LogTableRow from '@/components/logs/LogTableRow.vue'
 import { useLogFilters } from '@/composables/useLogFilters'
 import { useLogs } from '@/composables/useLogs'
+import { useLogRetention } from '@/composables/useLogRetention'
 
 const {
   PERIODS, period, dateRange, dateRangeError,
@@ -219,30 +218,7 @@ const {
   handleCleanup, toggleExpand, openLogDetail,
 } = useLogs()
 
-const DEFAULT_RETENTION_DAYS = 3
-const retentionDays = ref(DEFAULT_RETENTION_DAYS)
-const retentionSaving = ref(false)
-
-async function saveRetention() {
-  retentionSaving.value = true
-  try {
-    await api.setLogRetention(retentionDays.value)
-    toast.success('保留天数已更新')
-  } catch {
-    toast.error('更新失败')
-  } finally {
-    retentionSaving.value = false
-  }
-}
-
-async function loadRetention() {
-  try {
-    const { days } = await api.getLogRetention()
-    retentionDays.value = days
-  } catch {
-    toast.error('加载保留天数失败，使用默认值')
-  }
-}
+const { retentionDays, retentionSaving, saveRetention, loadRetention } = useLogRetention()
 
 let filterTimer: ReturnType<typeof setTimeout> | null = null
 watch(

--- a/frontend/src/views/Settings.vue
+++ b/frontend/src/views/Settings.vue
@@ -1,4 +1,3 @@
-<!-- eslint-disable no-magic-numbers -->
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
 import { toast } from 'vue-sonner'
@@ -14,21 +13,39 @@ import {
 } from '@/components/ui/alert-dialog'
 import { Download, Upload, HardDrive } from 'lucide-vue-next'
 
+const BYTES_PER_MB = 1_048_576
+const KB_BASE = 1024
+const PERCENT_MAX = 100
+const JSON_INDENT = 2
+const DATE_SLICE_END = 10
+
+const RETENTION_MIN = 0
+const RETENTION_MAX = 90
+const SIZE_MB_MIN = 1
+const DEFAULT_RETENTION_DAYS = 3
+const DEFAULT_DB_MAX_SIZE_MB = 1024
+const DEFAULT_LOG_TABLE_MAX_SIZE_MB = 800
+
 const dbSizeInfo = ref<DbSizeInfoResponse | null>(null)
-const retentionDays = ref(3)
-const dbMaxSizeMb = ref(1024)
-const logTableMaxSizeMb = ref(800)
+const retentionDays = ref(DEFAULT_RETENTION_DAYS)
+const dbMaxSizeMb = ref(DEFAULT_DB_MAX_SIZE_MB)
+const logTableMaxSizeMb = ref(DEFAULT_LOG_TABLE_MAX_SIZE_MB)
 const loading = ref(false)
 const importing = ref(false)
 const importResult = ref<Record<string, number> | null>(null)
 const showImportDialog = ref(false)
 const pendingImportData = ref<ConfigExportResponse | null>(null)
+const fileInput = ref<HTMLInputElement>()
+
+const retentionError = ref('')
+const dbMaxSizeError = ref('')
+const logTableMaxSizeError = ref('')
 
 function formatBytes(bytes: number): string {
   if (bytes === 0) return '0 B'
   const units = ['B', 'KB', 'MB', 'GB']
-  const i = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1)
-  return `${(bytes / Math.pow(1024, i)).toFixed(1)} ${units[i]}`
+  const i = Math.min(Math.floor(Math.log(bytes) / Math.log(KB_BASE)), units.length - 1)
+  return `${(bytes / Math.pow(KB_BASE, i)).toFixed(1)} ${units[i]}`
 }
 
 async function loadSettings() {
@@ -51,7 +68,22 @@ async function loadSettings() {
   }
 }
 
+function validateRetention(): boolean {
+  retentionError.value = ''
+  const val = retentionDays.value
+  if (!Number.isInteger(val)) {
+    retentionError.value = '请输入整数'
+    return false
+  }
+  if (val < RETENTION_MIN || val > RETENTION_MAX) {
+    retentionError.value = `请输入 ${RETENTION_MIN}-${RETENTION_MAX} 之间的整数`
+    return false
+  }
+  return true
+}
+
 async function saveRetention() {
+  if (!validateRetention()) return
   try {
     const result = await api.setLogRetention(retentionDays.value)
     retentionDays.value = result.days
@@ -62,7 +94,27 @@ async function saveRetention() {
   }
 }
 
+function validateThresholds(): boolean {
+  dbMaxSizeError.value = ''
+  logTableMaxSizeError.value = ''
+  let valid = true
+  if (!Number.isFinite(dbMaxSizeMb.value) || dbMaxSizeMb.value < SIZE_MB_MIN) {
+    dbMaxSizeError.value = `请输入不小于 ${SIZE_MB_MIN} 的数值`
+    valid = false
+  }
+  if (!Number.isFinite(logTableMaxSizeMb.value) || logTableMaxSizeMb.value < SIZE_MB_MIN) {
+    logTableMaxSizeError.value = `请输入不小于 ${SIZE_MB_MIN} 的数值`
+    valid = false
+  }
+  if (valid && logTableMaxSizeMb.value > dbMaxSizeMb.value) {
+    logTableMaxSizeError.value = '日志表上限不应超过数据库上限'
+    valid = false
+  }
+  return valid
+}
+
 async function saveThresholds() {
+  if (!validateThresholds()) return
   try {
     const result = await api.setDbSizeThresholds({
       dbMaxSizeMb: dbMaxSizeMb.value,
@@ -81,11 +133,11 @@ async function saveThresholds() {
 async function handleExport() {
   try {
     const data = await api.exportConfig()
-    const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' })
+    const blob = new Blob([JSON.stringify(data, null, JSON_INDENT)], { type: 'application/json' })
     const url = URL.createObjectURL(blob)
     const a = document.createElement('a')
     a.href = url
-    a.download = `router-config-${new Date().toISOString().slice(0, 10)}.json`
+    a.download = `router-config-${new Date().toISOString().slice(0, DATE_SLICE_END)}.json`
     a.click()
     URL.revokeObjectURL(url)
     toast.success('配置已导出')
@@ -153,10 +205,12 @@ onMounted(loadSettings)
             id="retention-days"
             v-model.number="retentionDays"
             type="number"
-            :min="0"
-            :max="90"
+            :min="RETENTION_MIN"
+            :max="RETENTION_MAX"
             class="w-32"
+            @input="retentionError = ''"
           />
+          <p v-if="retentionError" class="text-sm text-destructive mt-1">{{ retentionError }}</p>
         </div>
         <Button size="sm" :disabled="loading" @click="saveRetention">保存</Button>
       </div>
@@ -179,7 +233,7 @@ onMounted(loadSettings)
             </span>
           </div>
           <Progress
-            :model-value="Math.min(100, (dbSizeInfo.totalBytes / (dbMaxSizeMb * 1048576)) * 100)"
+            :model-value="Math.min(PERCENT_MAX, (dbSizeInfo.totalBytes / (dbMaxSizeMb * BYTES_PER_MB)) * PERCENT_MAX)"
           />
         </div>
 
@@ -191,7 +245,7 @@ onMounted(loadSettings)
             </span>
           </div>
           <Progress
-            :model-value="Math.min(100, (dbSizeInfo.logTableBytes / (logTableMaxSizeMb * 1048576)) * 100)"
+            :model-value="Math.min(PERCENT_MAX, (dbSizeInfo.logTableBytes / (logTableMaxSizeMb * BYTES_PER_MB)) * PERCENT_MAX)"
           />
         </div>
 
@@ -203,11 +257,13 @@ onMounted(loadSettings)
       <div class="grid grid-cols-2 gap-4 pt-3 border-t">
         <div class="space-y-1">
           <Label for="db-max-size">数据库大小上限 (MB)</Label>
-          <Input id="db-max-size" v-model.number="dbMaxSizeMb" type="number" :min="1" />
+          <Input id="db-max-size" v-model.number="dbMaxSizeMb" type="number" :min="SIZE_MB_MIN" @input="dbMaxSizeError = ''" />
+          <p v-if="dbMaxSizeError" class="text-sm text-destructive mt-1">{{ dbMaxSizeError }}</p>
         </div>
         <div class="space-y-1">
           <Label for="log-max-size">日志表大小上限 (MB)</Label>
-          <Input id="log-max-size" v-model.number="logTableMaxSizeMb" type="number" :min="1" />
+          <Input id="log-max-size" v-model.number="logTableMaxSizeMb" type="number" :min="SIZE_MB_MIN" @input="logTableMaxSizeError = ''" />
+          <p v-if="logTableMaxSizeError" class="text-sm text-destructive mt-1">{{ logTableMaxSizeError }}</p>
         </div>
       </div>
       <Button size="sm" :disabled="loading" @click="saveThresholds">保存阈值</Button>
@@ -224,13 +280,11 @@ onMounted(loadSettings)
           导出配置
         </Button>
 
-        <label>
-          <Button variant="outline" size="sm" as="span" :disabled="loading">
-            <Upload class="mr-2 h-4 w-4" />
-            导入配置
-          </Button>
-          <input type="file" accept=".json" class="hidden" @change="handleFileSelect" />
-        </label>
+        <Button variant="outline" size="sm" :disabled="loading" @click="fileInput?.click()">
+          <Upload class="mr-2 h-4 w-4" />
+          导入配置
+        </Button>
+        <input ref="fileInput" type="file" accept=".json" class="hidden" @change="handleFileSelect" />
       </div>
 
       <div v-if="importResult" class="text-sm space-y-1 p-3 bg-muted rounded-md">

--- a/frontend/src/views/Settings.vue
+++ b/frontend/src/views/Settings.vue
@@ -3,7 +3,6 @@
 import { ref, onMounted } from 'vue'
 import { toast } from 'vue-sonner'
 import { api, type DbSizeInfoResponse, type ConfigExportResponse } from '@/api/client'
-import { Card, CardHeader, CardTitle, CardContent, CardDescription } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -140,117 +139,107 @@ onMounted(loadSettings)
 </script>
 
 <template>
-  <div class="space-y-6">
-    <h1 class="text-2xl font-bold">系统设置</h1>
+  <div class="p-6 space-y-6">
+    <h2 class="text-lg font-semibold text-foreground">系统设置</h2>
 
     <!-- Log Retention -->
-    <Card>
-      <CardHeader>
-        <CardTitle>日志保留策略</CardTitle>
-        <CardDescription>超过保留天数的日志将被自动清理</CardDescription>
-      </CardHeader>
-      <CardContent>
-        <div class="flex items-end gap-4">
-          <div class="space-y-2">
-            <Label for="retention-days">保留天数</Label>
-            <Input
-              id="retention-days"
-              v-model.number="retentionDays"
-              type="number"
-              :min="0"
-              :max="90"
-              class="w-32"
-            />
-          </div>
-          <Button :disabled="loading" @click="saveRetention">保存</Button>
+    <div class="bg-card rounded-lg border p-4 space-y-3">
+      <h3 class="font-medium text-sm text-foreground">日志保留策略</h3>
+      <p class="text-sm text-muted-foreground">超过保留天数的日志将被自动清理</p>
+      <div class="flex items-end gap-4">
+        <div class="space-y-1">
+          <Label for="retention-days">保留天数</Label>
+          <Input
+            id="retention-days"
+            v-model.number="retentionDays"
+            type="number"
+            :min="0"
+            :max="90"
+            class="w-32"
+          />
         </div>
-      </CardContent>
-    </Card>
+        <Button size="sm" :disabled="loading" @click="saveRetention">保存</Button>
+      </div>
+    </div>
 
     <!-- Storage Management -->
-    <Card>
-      <CardHeader>
-        <CardTitle class="flex items-center gap-2">
-          <HardDrive class="h-5 w-5" />
-          存储管理
-        </CardTitle>
-        <CardDescription>监控数据库大小并配置自动清理阈值</CardDescription>
-      </CardHeader>
-      <CardContent class="space-y-6">
-        <template v-if="dbSizeInfo">
-          <div class="space-y-2">
-            <div class="flex justify-between text-sm">
-              <span>数据库总大小</span>
-              <span class="text-muted-foreground">
-                {{ formatBytes(dbSizeInfo.totalBytes) }} / {{ dbMaxSizeMb }} MB
-              </span>
-            </div>
-            <Progress
-              :model-value="Math.min(100, (dbSizeInfo.totalBytes / (dbMaxSizeMb * 1048576)) * 100)"
-            />
-          </div>
+    <div class="bg-card rounded-lg border p-4 space-y-4">
+      <h3 class="font-medium text-sm text-foreground flex items-center gap-2">
+        <HardDrive class="h-4 w-4" />
+        存储管理
+      </h3>
+      <p class="text-sm text-muted-foreground">监控数据库大小并配置自动清理阈值</p>
 
-          <div class="space-y-2">
-            <div class="flex justify-between text-sm">
-              <span>请求日志大小 ({{ dbSizeInfo.logCount }} 条)</span>
-              <span class="text-muted-foreground">
-                {{ formatBytes(dbSizeInfo.logTableBytes) }} / {{ logTableMaxSizeMb }} MB
-              </span>
-            </div>
-            <Progress
-              :model-value="Math.min(100, (dbSizeInfo.logTableBytes / (logTableMaxSizeMb * 1048576)) * 100)"
-            />
+      <template v-if="dbSizeInfo">
+        <div class="space-y-1">
+          <div class="flex justify-between text-sm">
+            <span>数据库总大小</span>
+            <span class="text-muted-foreground">
+              {{ formatBytes(dbSizeInfo.totalBytes) }} / {{ dbMaxSizeMb }} MB
+            </span>
           </div>
-
-          <p v-if="dbSizeInfo.lastChecked" class="text-xs text-muted-foreground">
-            上次检查：{{ dbSizeInfo.lastChecked }}
-          </p>
-        </template>
-
-        <div class="grid grid-cols-2 gap-4 pt-4 border-t">
-          <div class="space-y-2">
-            <Label for="db-max-size">数据库大小上限 (MB)</Label>
-            <Input id="db-max-size" v-model.number="dbMaxSizeMb" type="number" :min="1" />
-          </div>
-          <div class="space-y-2">
-            <Label for="log-max-size">日志表大小上限 (MB)</Label>
-            <Input id="log-max-size" v-model.number="logTableMaxSizeMb" type="number" :min="1" />
-          </div>
+          <Progress
+            :model-value="Math.min(100, (dbSizeInfo.totalBytes / (dbMaxSizeMb * 1048576)) * 100)"
+          />
         </div>
-        <Button :disabled="loading" @click="saveThresholds">保存阈值</Button>
-      </CardContent>
-    </Card>
+
+        <div class="space-y-1">
+          <div class="flex justify-between text-sm">
+            <span>请求日志大小 ({{ dbSizeInfo.logCount }} 条)</span>
+            <span class="text-muted-foreground">
+              {{ formatBytes(dbSizeInfo.logTableBytes) }} / {{ logTableMaxSizeMb }} MB
+            </span>
+          </div>
+          <Progress
+            :model-value="Math.min(100, (dbSizeInfo.logTableBytes / (logTableMaxSizeMb * 1048576)) * 100)"
+          />
+        </div>
+
+        <p v-if="dbSizeInfo.lastChecked" class="text-xs text-muted-foreground">
+          上次检查：{{ dbSizeInfo.lastChecked }}
+        </p>
+      </template>
+
+      <div class="grid grid-cols-2 gap-4 pt-3 border-t">
+        <div class="space-y-1">
+          <Label for="db-max-size">数据库大小上限 (MB)</Label>
+          <Input id="db-max-size" v-model.number="dbMaxSizeMb" type="number" :min="1" />
+        </div>
+        <div class="space-y-1">
+          <Label for="log-max-size">日志表大小上限 (MB)</Label>
+          <Input id="log-max-size" v-model.number="logTableMaxSizeMb" type="number" :min="1" />
+        </div>
+      </div>
+      <Button size="sm" :disabled="loading" @click="saveThresholds">保存阈值</Button>
+    </div>
 
     <!-- Config Import/Export -->
-    <Card>
-      <CardHeader>
-        <CardTitle>配置导入导出</CardTitle>
-        <CardDescription>导出当前配置或从文件恢复</CardDescription>
-      </CardHeader>
-      <CardContent class="space-y-4">
-        <div class="flex gap-3">
-          <Button variant="outline" :disabled="loading" @click="handleExport">
-            <Download class="mr-2 h-4 w-4" />
-            导出配置
+    <div class="bg-card rounded-lg border p-4 space-y-3">
+      <h3 class="font-medium text-sm text-foreground">配置导入导出</h3>
+      <p class="text-sm text-muted-foreground">导出当前配置或从文件恢复</p>
+
+      <div class="flex gap-3">
+        <Button variant="outline" size="sm" :disabled="loading" @click="handleExport">
+          <Download class="mr-2 h-4 w-4" />
+          导出配置
+        </Button>
+
+        <label>
+          <Button variant="outline" size="sm" as="span" :disabled="loading">
+            <Upload class="mr-2 h-4 w-4" />
+            导入配置
           </Button>
+          <input type="file" accept=".json" class="hidden" @change="handleFileSelect" />
+        </label>
+      </div>
 
-          <label>
-            <Button variant="outline" as="span" :disabled="loading">
-              <Upload class="mr-2 h-4 w-4" />
-              导入配置
-            </Button>
-            <input type="file" accept=".json" class="hidden" @change="handleFileSelect" />
-          </label>
-        </div>
-
-        <div v-if="importResult" class="text-sm space-y-1 p-3 bg-muted rounded-md">
-          <p class="font-medium">导入完成：</p>
-          <p v-for="(count, table) in importResult" :key="table">
-            {{ table }}: {{ count }} 条
-          </p>
-        </div>
-      </CardContent>
-    </Card>
+      <div v-if="importResult" class="text-sm space-y-1 p-3 bg-muted rounded-md">
+        <p class="font-medium">导入完成：</p>
+        <p v-for="(count, table) in importResult" :key="table">
+          {{ table }}: {{ count }} 条
+        </p>
+      </div>
+    </div>
 
     <!-- Import confirmation dialog -->
     <AlertDialog v-model:open="showImportDialog">

--- a/frontend/src/views/Settings.vue
+++ b/frontend/src/views/Settings.vue
@@ -2,6 +2,7 @@
 import { ref, onMounted } from 'vue'
 import { toast } from 'vue-sonner'
 import { api, type DbSizeInfoResponse, type ConfigExportResponse } from '@/api/client'
+import { useLogRetention } from '@/composables/useLogRetention'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -22,12 +23,12 @@ const DATE_SLICE_END = 10
 const RETENTION_MIN = 0
 const RETENTION_MAX = 90
 const SIZE_MB_MIN = 1
-const DEFAULT_RETENTION_DAYS = 3
 const DEFAULT_DB_MAX_SIZE_MB = 1024
 const DEFAULT_LOG_TABLE_MAX_SIZE_MB = 800
 
+const { retentionDays, saveRetention } = useLogRetention()
+
 const dbSizeInfo = ref<DbSizeInfoResponse | null>(null)
-const retentionDays = ref(DEFAULT_RETENTION_DAYS)
 const dbMaxSizeMb = ref(DEFAULT_DB_MAX_SIZE_MB)
 const logTableMaxSizeMb = ref(DEFAULT_LOG_TABLE_MAX_SIZE_MB)
 const loading = ref(false)
@@ -82,16 +83,9 @@ function validateRetention(): boolean {
   return true
 }
 
-async function saveRetention() {
+async function handleSaveRetention() {
   if (!validateRetention()) return
-  try {
-    const result = await api.setLogRetention(retentionDays.value)
-    retentionDays.value = result.days
-    toast.success('日志保留天数已更新')
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  } catch (e: any) {
-    toast.error(e.response?.data?.error?.message || '更新失败')
-  }
+  await saveRetention()
 }
 
 function validateThresholds(): boolean {
@@ -212,7 +206,7 @@ onMounted(loadSettings)
           />
           <p v-if="retentionError" class="text-sm text-destructive mt-1">{{ retentionError }}</p>
         </div>
-        <Button size="sm" :disabled="loading" @click="saveRetention">保存</Button>
+        <Button size="sm" :disabled="loading" @click="handleSaveRetention">保存</Button>
       </div>
     </div>
 

--- a/frontend/src/views/Settings.vue
+++ b/frontend/src/views/Settings.vue
@@ -1,0 +1,274 @@
+<!-- eslint-disable no-magic-numbers -->
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { toast } from 'vue-sonner'
+import { api, type DbSizeInfoResponse, type ConfigExportResponse } from '@/api/client'
+import { Card, CardHeader, CardTitle, CardContent, CardDescription } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Progress } from '@/components/ui/progress'
+import {
+  AlertDialog, AlertDialogAction, AlertDialogCancel,
+  AlertDialogContent, AlertDialogDescription, AlertDialogFooter,
+  AlertDialogHeader, AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
+import { Download, Upload, HardDrive } from 'lucide-vue-next'
+
+const dbSizeInfo = ref<DbSizeInfoResponse | null>(null)
+const retentionDays = ref(3)
+const dbMaxSizeMb = ref(1024)
+const logTableMaxSizeMb = ref(800)
+const loading = ref(false)
+const importing = ref(false)
+const importResult = ref<Record<string, number> | null>(null)
+const showImportDialog = ref(false)
+const pendingImportData = ref<ConfigExportResponse | null>(null)
+
+function formatBytes(bytes: number): string {
+  if (bytes === 0) return '0 B'
+  const units = ['B', 'KB', 'MB', 'GB']
+  const i = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1)
+  return `${(bytes / Math.pow(1024, i)).toFixed(1)} ${units[i]}`
+}
+
+async function loadSettings() {
+  loading.value = true
+  try {
+    const [sizeInfo, retention] = await Promise.allSettled([
+      api.getDbSizeInfo(),
+      api.getLogRetention(),
+    ])
+    if (sizeInfo.status === 'fulfilled') {
+      dbSizeInfo.value = sizeInfo.value
+      dbMaxSizeMb.value = sizeInfo.value.thresholds.dbMaxSizeMb
+      logTableMaxSizeMb.value = sizeInfo.value.thresholds.logTableMaxSizeMb
+    }
+    if (retention.status === 'fulfilled') {
+      retentionDays.value = retention.value.days
+    }
+  } finally {
+    loading.value = false
+  }
+}
+
+async function saveRetention() {
+  try {
+    const result = await api.setLogRetention(retentionDays.value)
+    retentionDays.value = result.days
+    toast.success('日志保留天数已更新')
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } catch (e: any) {
+    toast.error(e.response?.data?.error?.message || '更新失败')
+  }
+}
+
+async function saveThresholds() {
+  try {
+    const result = await api.setDbSizeThresholds({
+      dbMaxSizeMb: dbMaxSizeMb.value,
+      logTableMaxSizeMb: logTableMaxSizeMb.value,
+    })
+    dbMaxSizeMb.value = result.dbMaxSizeMb
+    logTableMaxSizeMb.value = result.logTableMaxSizeMb
+    toast.success('存储阈值已更新')
+    await loadSettings()
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } catch (e: any) {
+    toast.error(e.response?.data?.error?.message || '更新失败')
+  }
+}
+
+async function handleExport() {
+  try {
+    const data = await api.exportConfig()
+    const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = `router-config-${new Date().toISOString().slice(0, 10)}.json`
+    a.click()
+    URL.revokeObjectURL(url)
+    toast.success('配置已导出')
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } catch (e: any) {
+    toast.error(e.response?.data?.error?.message || '导出失败')
+  }
+}
+
+function handleFileSelect(event: Event) {
+  const input = event.target as HTMLInputElement
+  const file = input.files?.[0]
+  if (!file) return
+  const reader = new FileReader()
+  reader.onload = () => {
+    try {
+      const data = JSON.parse(reader.result as string) as ConfigExportResponse
+      if (!data.version || data.version !== 1) {
+        toast.error('不支持的配置文件版本')
+        return
+      }
+      pendingImportData.value = data
+      showImportDialog.value = true
+    } catch {
+      toast.error('无效的 JSON 文件')
+    }
+  }
+  reader.readAsText(file)
+  input.value = ''
+}
+
+async function confirmImport() {
+  if (!pendingImportData.value) return
+  importing.value = true
+  try {
+    const result = await api.importConfig(pendingImportData.value)
+    importResult.value = result
+    showImportDialog.value = false
+    toast.success('配置已导入')
+    await loadSettings()
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } catch (e: any) {
+    toast.error(e.response?.data?.error?.message || '导入失败')
+  } finally {
+    importing.value = false
+    pendingImportData.value = null
+  }
+}
+
+onMounted(loadSettings)
+</script>
+
+<template>
+  <div class="space-y-6">
+    <h1 class="text-2xl font-bold">系统设置</h1>
+
+    <!-- Log Retention -->
+    <Card>
+      <CardHeader>
+        <CardTitle>日志保留策略</CardTitle>
+        <CardDescription>超过保留天数的日志将被自动清理</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div class="flex items-end gap-4">
+          <div class="space-y-2">
+            <Label for="retention-days">保留天数</Label>
+            <Input
+              id="retention-days"
+              v-model.number="retentionDays"
+              type="number"
+              :min="0"
+              :max="90"
+              class="w-32"
+            />
+          </div>
+          <Button :disabled="loading" @click="saveRetention">保存</Button>
+        </div>
+      </CardContent>
+    </Card>
+
+    <!-- Storage Management -->
+    <Card>
+      <CardHeader>
+        <CardTitle class="flex items-center gap-2">
+          <HardDrive class="h-5 w-5" />
+          存储管理
+        </CardTitle>
+        <CardDescription>监控数据库大小并配置自动清理阈值</CardDescription>
+      </CardHeader>
+      <CardContent class="space-y-6">
+        <template v-if="dbSizeInfo">
+          <div class="space-y-2">
+            <div class="flex justify-between text-sm">
+              <span>数据库总大小</span>
+              <span class="text-muted-foreground">
+                {{ formatBytes(dbSizeInfo.totalBytes) }} / {{ dbMaxSizeMb }} MB
+              </span>
+            </div>
+            <Progress
+              :model-value="Math.min(100, (dbSizeInfo.totalBytes / (dbMaxSizeMb * 1048576)) * 100)"
+            />
+          </div>
+
+          <div class="space-y-2">
+            <div class="flex justify-between text-sm">
+              <span>请求日志大小 ({{ dbSizeInfo.logCount }} 条)</span>
+              <span class="text-muted-foreground">
+                {{ formatBytes(dbSizeInfo.logTableBytes) }} / {{ logTableMaxSizeMb }} MB
+              </span>
+            </div>
+            <Progress
+              :model-value="Math.min(100, (dbSizeInfo.logTableBytes / (logTableMaxSizeMb * 1048576)) * 100)"
+            />
+          </div>
+
+          <p v-if="dbSizeInfo.lastChecked" class="text-xs text-muted-foreground">
+            上次检查：{{ dbSizeInfo.lastChecked }}
+          </p>
+        </template>
+
+        <div class="grid grid-cols-2 gap-4 pt-4 border-t">
+          <div class="space-y-2">
+            <Label for="db-max-size">数据库大小上限 (MB)</Label>
+            <Input id="db-max-size" v-model.number="dbMaxSizeMb" type="number" :min="1" />
+          </div>
+          <div class="space-y-2">
+            <Label for="log-max-size">日志表大小上限 (MB)</Label>
+            <Input id="log-max-size" v-model.number="logTableMaxSizeMb" type="number" :min="1" />
+          </div>
+        </div>
+        <Button :disabled="loading" @click="saveThresholds">保存阈值</Button>
+      </CardContent>
+    </Card>
+
+    <!-- Config Import/Export -->
+    <Card>
+      <CardHeader>
+        <CardTitle>配置导入导出</CardTitle>
+        <CardDescription>导出当前配置或从文件恢复</CardDescription>
+      </CardHeader>
+      <CardContent class="space-y-4">
+        <div class="flex gap-3">
+          <Button variant="outline" :disabled="loading" @click="handleExport">
+            <Download class="mr-2 h-4 w-4" />
+            导出配置
+          </Button>
+
+          <label>
+            <Button variant="outline" as="span" :disabled="loading">
+              <Upload class="mr-2 h-4 w-4" />
+              导入配置
+            </Button>
+            <input type="file" accept=".json" class="hidden" @change="handleFileSelect" />
+          </label>
+        </div>
+
+        <div v-if="importResult" class="text-sm space-y-1 p-3 bg-muted rounded-md">
+          <p class="font-medium">导入完成：</p>
+          <p v-for="(count, table) in importResult" :key="table">
+            {{ table }}: {{ count }} 条
+          </p>
+        </div>
+      </CardContent>
+    </Card>
+
+    <!-- Import confirmation dialog -->
+    <AlertDialog v-model:open="showImportDialog">
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>确认导入配置</AlertDialogTitle>
+          <AlertDialogDescription>
+            导入将覆盖当前的供应商、映射、密钥等配置。安全设置（密码、JWT）将保留不变。
+            此操作不可撤销。
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel :disabled="importing">取消</AlertDialogCancel>
+          <AlertDialogAction :disabled="importing" @click="confirmImport">
+            {{ importing ? '导入中...' : '确认导入' }}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  </div>
+</template>

--- a/scripts/vacuum-migrate.js
+++ b/scripts/vacuum-migrate.js
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+/**
+ * One-time script to switch existing database to auto_vacuum=INCREMENTAL mode.
+ * Requires VACUUM which locks the database for the duration.
+ * Run during a maintenance window.
+ *
+ * Usage: node scripts/vacuum-migrate.js [db-path]
+ * Default db-path: ~/.llm-simple-router/router.db
+ */
+import Database from "better-sqlite3";
+import { homedir } from "os";
+import { join } from "path";
+
+const dbPath = process.argv[2] || join(homedir(), ".llm-simple-router", "router.db");
+console.log(`Migrating database: ${dbPath}`);
+
+const db = new Database(dbPath);
+
+const [{ auto_vacuum }] = db.pragma("auto_vacuum");
+console.log(`Current auto_vacuum: ${auto_vacuum} (0=NONE, 1=FULL, 2=INCREMENTAL)`);
+
+if (auto_vacuum === 2) {
+  console.log("Already in INCREMENTAL mode. Checking if VACUUM is needed...");
+} else {
+  console.log("Setting auto_vacuum = INCREMENTAL...");
+  db.pragma("auto_vacuum = INCREMENTAL");
+}
+
+const [{ page_count: beforePages }] = db.pragma("page_count");
+console.log(`Pages before VACUUM: ${beforePages}`);
+console.log("Running VACUUM (this may take several minutes for large databases)...");
+
+const start = Date.now();
+db.exec("VACUUM");
+const elapsed = ((Date.now() - start) / 1000).toFixed(1);
+
+const [{ page_count: afterPages }] = db.pragma("page_count");
+console.log(`Pages after VACUUM: ${afterPages}`);
+console.log(`Freed ${beforePages - afterPages} pages (~${((beforePages - afterPages) * 4096 / 1024 / 1024).toFixed(1)} MB)`);
+console.log(`Completed in ${elapsed}s`);
+
+db.close();

--- a/scripts/vacuum-migrate.js
+++ b/scripts/vacuum-migrate.js
@@ -27,7 +27,8 @@ if (auto_vacuum === 2) {
 }
 
 const [{ page_count: beforePages }] = db.pragma("page_count");
-console.log(`Pages before VACUUM: ${beforePages}`);
+const [{ page_size: pageSize }] = db.pragma("page_size");
+console.log(`Pages before VACUUM: ${beforePages} (page size: ${pageSize})`);
 console.log("Running VACUUM (this may take several minutes for large databases)...");
 
 const start = Date.now();
@@ -36,7 +37,7 @@ const elapsed = ((Date.now() - start) / 1000).toFixed(1);
 
 const [{ page_count: afterPages }] = db.pragma("page_count");
 console.log(`Pages after VACUUM: ${afterPages}`);
-console.log(`Freed ${beforePages - afterPages} pages (~${((beforePages - afterPages) * 4096 / 1024 / 1024).toFixed(1)} MB)`);
+console.log(`Freed ${beforePages - afterPages} pages (~${((beforePages - afterPages) * pageSize / 1024 / 1024).toFixed(1)} MB)`);
 console.log(`Completed in ${elapsed}s`);
 
 db.close();

--- a/src/admin/monitor.ts
+++ b/src/admin/monitor.ts
@@ -33,5 +33,12 @@ export const adminMonitorRoutes: FastifyPluginCallback<MonitorRoutesOptions> = (
     });
   });
 
+  app.get("/admin/api/monitor/request/:id", async (request, reply) => {
+    const { id } = request.params as { id: string };
+    const req = tracker.getRequestById(id);
+    if (!req) return reply.status(404).send({ error: "Not found" });
+    return req;
+  });
+
   done();
 };

--- a/src/admin/monitor.ts
+++ b/src/admin/monitor.ts
@@ -1,5 +1,6 @@
 import { FastifyPluginCallback } from "fastify";
 import type { RequestTracker } from "../monitor/request-tracker.js";
+import { HTTP_NOT_FOUND } from "./constants.js";
 
 const HTTP_OK = 200;
 
@@ -36,7 +37,7 @@ export const adminMonitorRoutes: FastifyPluginCallback<MonitorRoutesOptions> = (
   app.get("/admin/api/monitor/request/:id", async (request, reply) => {
     const { id } = request.params as { id: string };
     const req = tracker.getRequestById(id);
-    if (!req) return reply.status(404).send({ error: "Not found" });
+    if (!req) return reply.status(HTTP_NOT_FOUND).send({ error: "Not found" });
     return req;
   });
 

--- a/src/admin/routes.ts
+++ b/src/admin/routes.ts
@@ -15,6 +15,7 @@ import { adminMonitorRoutes } from "./monitor.js";
 import { adminSettingsRoutes } from "./settings.js";
 import { adminRecommendedRoutes } from "./recommended.js";
 import { adminUsageRoutes } from "./usage.js";
+import { adminImportExportRoutes } from "./settings-import-export.js";
 import { RetryRuleMatcher } from "../proxy/retry-rules.js";
 import type { RequestTracker } from "../monitor/request-tracker.js";
 import { ProviderSemaphoreManager } from "../proxy/semaphore.js";
@@ -42,6 +43,7 @@ export const adminRoutes: FastifyPluginCallback<AdminRoutesOptions> = (app, opti
   app.register(adminProxyEnhancementRoutes, { db: options.db });
   app.register(adminMonitorRoutes, { tracker: options.tracker });
   app.register(adminSettingsRoutes, { db: options.db });
+  app.register(adminImportExportRoutes, { db: options.db, matcher: options.matcher, semaphoreManager: options.semaphoreManager });
   app.register(adminRecommendedRoutes, { db: options.db });
   app.register(adminUsageRoutes, { db: options.db });
   done();

--- a/src/admin/settings-import-export.ts
+++ b/src/admin/settings-import-export.ts
@@ -1,0 +1,102 @@
+import { FastifyPluginCallback } from "fastify";
+import Database from "better-sqlite3";
+
+interface ImportExportOptions {
+  db: Database.Database;
+}
+
+const CONFIG_TABLES = [
+  "providers",
+  "mapping_groups",
+  "retry_rules",
+  "router_keys",
+  "settings",
+  "session_model_states",
+];
+
+// settings 表按 key 列的值过滤，不覆盖本地安全敏感配置
+const PROTECTED_SETTING_KEYS = new Set(["admin_password_hash", "jwt_secret"]);
+
+const EXPORT_VERSION = 1;
+
+const ISO_DATE_LENGTH = 10;
+const BAD_REQUEST = 400;
+
+export const adminImportExportRoutes: FastifyPluginCallback<ImportExportOptions> = (app, options, done) => {
+  const { db } = options;
+
+  app.get("/admin/api/settings/export", async (_request, reply) => {
+    const data: Record<string, unknown[]> = {};
+    for (const table of CONFIG_TABLES) {
+      data[table] = db.prepare(`SELECT * FROM ${table}`).all();
+    }
+
+    const date = new Date().toISOString().slice(0, ISO_DATE_LENGTH);
+    reply.header("Content-Disposition", `attachment; filename="router-config-${date}.json"`);
+
+    return reply.send({
+      version: EXPORT_VERSION,
+      exportedAt: new Date().toISOString(),
+      data,
+    });
+  });
+
+  app.post("/admin/api/settings/import", async (request, reply) => {
+    const body = request.body as { version?: number; data?: Record<string, unknown[]> };
+    if (!body.version || body.version !== EXPORT_VERSION) {
+      return reply.code(BAD_REQUEST).send({ error: { message: `Unsupported version. Expected ${EXPORT_VERSION}.` } });
+    }
+    if (!body.data) {
+      return reply.code(BAD_REQUEST).send({ error: { message: "Missing data field" } });
+    }
+
+    const counts: Record<string, number> = {};
+    const importData = body.data;
+
+    db.transaction(() => {
+      // 临时关闭外键检查，避免删除顺序导致约束冲突
+      const prevFk = db.pragma("foreign_keys", { simple: true });
+      db.pragma("foreign_keys = OFF");
+
+      // 导入前先备份受保护配置，导入后恢复
+      const protectedRows = db
+        .prepare("SELECT * FROM settings WHERE key IN (?, ?)")
+        .all(...PROTECTED_SETTING_KEYS) as Record<string, unknown>[];
+
+      for (const table of CONFIG_TABLES) {
+        const rows = importData[table];
+        if (!Array.isArray(rows)) continue;
+
+        db.exec(`DELETE FROM ${table}`);
+
+        for (const row of rows) {
+          const entries = Object.entries(row as Record<string, unknown>);
+          if (table === "settings") {
+            // 跳过受保护配置（用本地值恢复）
+            const keyValue = entries.find(([k]) => k === "key")?.[1] as string | undefined;
+            if (keyValue && PROTECTED_SETTING_KEYS.has(keyValue)) {
+              continue;
+            }
+          }
+          const cols = entries.map(([k]) => k).join(", ");
+          const vals = entries.map(() => "?").join(", ");
+          db.prepare(`INSERT INTO ${table} (${cols}) VALUES (${vals})`).run(...entries.map(([, v]) => v));
+        }
+        counts[table] = rows.length;
+      }
+
+      // 恢复受保护配置
+      const upsertStmt = db.prepare("INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)");
+      for (const row of protectedRows) {
+        upsertStmt.run(row.key, row.value);
+      }
+
+      // 恢复外键设置
+      db.pragma(`foreign_keys = ${prevFk}`);
+    })();
+
+    return reply.send(counts);
+  });
+
+  done();
+};

--- a/src/admin/settings-import-export.ts
+++ b/src/admin/settings-import-export.ts
@@ -1,8 +1,14 @@
 import { FastifyPluginCallback } from "fastify";
 import Database from "better-sqlite3";
+import { RetryRuleMatcher } from "../proxy/retry-rules.js";
+import { ProviderSemaphoreManager } from "../proxy/semaphore.js";
+import { getAllProviders, PROVIDER_CONCURRENCY_DEFAULTS } from "../db/index.js";
+import { modelState } from "../proxy/model-state.js";
 
 interface ImportExportOptions {
   db: Database.Database;
+  matcher: RetryRuleMatcher | null;
+  semaphoreManager?: ProviderSemaphoreManager;
 }
 
 const CONFIG_TABLES = [
@@ -15,7 +21,7 @@ const CONFIG_TABLES = [
 ];
 
 // settings 表按 key 列的值过滤，不覆盖本地安全敏感配置
-const PROTECTED_SETTING_KEYS = new Set(["admin_password_hash", "jwt_secret"]);
+const PROTECTED_SETTING_KEYS = new Set(["admin_password_hash", "jwt_secret", "encryption_key"]);
 
 const EXPORT_VERSION = 1;
 
@@ -23,7 +29,7 @@ const ISO_DATE_LENGTH = 10;
 const BAD_REQUEST = 400;
 
 export const adminImportExportRoutes: FastifyPluginCallback<ImportExportOptions> = (app, options, done) => {
-  const { db } = options;
+  const { db, matcher, semaphoreManager } = options;
 
   app.get("/admin/api/settings/export", async (_request, reply) => {
     const data: Record<string, unknown[]> = {};
@@ -60,7 +66,7 @@ export const adminImportExportRoutes: FastifyPluginCallback<ImportExportOptions>
 
       // 导入前先备份受保护配置，导入后恢复
       const protectedRows = db
-        .prepare("SELECT * FROM settings WHERE key IN (?, ?)")
+        .prepare(`SELECT * FROM settings WHERE key IN (${[...PROTECTED_SETTING_KEYS].map(() => "?").join(", ")})`)
         .all(...PROTECTED_SETTING_KEYS) as Record<string, unknown>[];
 
       for (const table of CONFIG_TABLES) {
@@ -69,10 +75,16 @@ export const adminImportExportRoutes: FastifyPluginCallback<ImportExportOptions>
 
         db.exec(`DELETE FROM ${table}`);
 
+        // 用 PRAGMA table_info 获取合法列名，防止用户 JSON 注入非法列
+        const validCols = new Set(
+          (db.prepare(`PRAGMA table_info(${table})`).all() as { name: string }[]).map((c) => c.name)
+        );
+
         for (const row of rows) {
-          const entries = Object.entries(row as Record<string, unknown>);
+          const entries = Object.entries(row as Record<string, unknown>).filter(([k]) => validCols.has(k));
+          if (entries.length === 0) continue;
+
           if (table === "settings") {
-            // 跳过受保护配置（用本地值恢复）
             const keyValue = entries.find(([k]) => k === "key")?.[1] as string | undefined;
             if (keyValue && PROTECTED_SETTING_KEYS.has(keyValue)) {
               continue;
@@ -94,6 +106,25 @@ export const adminImportExportRoutes: FastifyPluginCallback<ImportExportOptions>
       // 恢复外键设置
       db.pragma(`foreign_keys = ${prevFk}`);
     })();
+
+    // 导入成功后刷新内存缓存
+    if (matcher) matcher.load(db);
+
+    if (semaphoreManager) {
+      // 清除旧的 semaphore 配置，按导入后的 providers 表重建
+      semaphoreManager.removeAll();
+      const providers = getAllProviders(db);
+      for (const p of providers) {
+        semaphoreManager.updateConfig(p.id, {
+          maxConcurrency: p.max_concurrency ?? PROVIDER_CONCURRENCY_DEFAULTS.max_concurrency,
+          queueTimeoutMs: p.queue_timeout_ms ?? PROVIDER_CONCURRENCY_DEFAULTS.queue_timeout_ms,
+          maxQueueSize: p.max_queue_size ?? PROVIDER_CONCURRENCY_DEFAULTS.max_queue_size,
+        });
+      }
+    }
+
+    // session_model_states 已通过 DB 导入，内存缓存会在读取时自然回填
+    modelState.clearAll();
 
     return reply.send(counts);
   });

--- a/src/admin/settings-import-export.ts
+++ b/src/admin/settings-import-export.ts
@@ -1,8 +1,11 @@
 import { FastifyPluginCallback } from "fastify";
 import Database from "better-sqlite3";
+import { createHash } from "crypto";
 import { RetryRuleMatcher } from "../proxy/retry-rules.js";
 import { ProviderSemaphoreManager } from "../proxy/semaphore.js";
 import { getAllProviders, PROVIDER_CONCURRENCY_DEFAULTS } from "../db/index.js";
+import { encrypt, decrypt } from "../utils/crypto.js";
+import { getSetting } from "../db/settings.js";
 import { modelState } from "../proxy/model-state.js";
 
 interface ImportExportOptions {
@@ -27,14 +30,35 @@ const EXPORT_VERSION = 1;
 
 const ISO_DATE_LENGTH = 10;
 const BAD_REQUEST = 400;
+const KEY_PREFIX_LENGTH = 8;
 
 export const adminImportExportRoutes: FastifyPluginCallback<ImportExportOptions> = (app, options, done) => {
   const { db, matcher, semaphoreManager } = options;
 
   app.get("/admin/api/settings/export", async (_request, reply) => {
+    const encryptionKey = getSetting(db, "encryption_key");
     const data: Record<string, unknown[]> = {};
     for (const table of CONFIG_TABLES) {
       data[table] = db.prepare(`SELECT * FROM ${table}`).all();
+    }
+
+    // 导出时解密敏感字段，确保跨实例可移植
+    if (encryptionKey) {
+      for (const row of (data.providers || []) as Record<string, unknown>[]) {
+        if (typeof row.api_key === "string" && row.api_key) {
+          try { row.api_key = decrypt(row.api_key, encryptionKey); } catch { /* eslint-disable-line taste/no-silent-catch -- 无法解密则保留原值 */ }
+        }
+      }
+      for (const row of (data.router_keys || []) as Record<string, unknown>[]) {
+        if (typeof row.key_encrypted === "string") {
+          try {
+            row.key = decrypt(row.key_encrypted, encryptionKey);
+            delete row.key_encrypted;
+            delete row.key_hash;
+            delete row.key_prefix;
+          } catch { /* eslint-disable-line taste/no-silent-catch -- 无法解密则保留加密数据 */ }
+        }
+      }
     }
 
     const date = new Date().toISOString().slice(0, ISO_DATE_LENGTH);
@@ -49,15 +73,33 @@ export const adminImportExportRoutes: FastifyPluginCallback<ImportExportOptions>
 
   app.post("/admin/api/settings/import", async (request, reply) => {
     const body = request.body as { version?: number; data?: Record<string, unknown[]> };
-    if (!body.version || body.version !== EXPORT_VERSION) {
+    if (typeof body.version !== "number" || body.version !== EXPORT_VERSION) {
       return reply.code(BAD_REQUEST).send({ error: { message: `Unsupported version. Expected ${EXPORT_VERSION}.` } });
     }
-    if (!body.data) {
-      return reply.code(BAD_REQUEST).send({ error: { message: "Missing data field" } });
+    if (!body.data || typeof body.data !== "object") {
+      return reply.code(BAD_REQUEST).send({ error: { message: "Missing or invalid data field" } });
     }
 
     const counts: Record<string, number> = {};
     const importData = body.data;
+    const encryptionKey = getSetting(db, "encryption_key");
+
+    // 导入时用本地密钥重新加密敏感字段
+    if (encryptionKey) {
+      for (const row of (importData.providers || []) as Record<string, unknown>[]) {
+        if (typeof row.api_key === "string" && row.api_key) {
+          row.api_key = encrypt(row.api_key, encryptionKey);
+        }
+      }
+      for (const row of (importData.router_keys || []) as Record<string, unknown>[]) {
+        if (typeof row.key === "string") {
+          row.key_hash = createHash("sha256").update(row.key).digest("hex");
+          row.key_prefix = row.key.slice(0, KEY_PREFIX_LENGTH);
+          row.key_encrypted = encrypt(row.key, encryptionKey);
+          delete row.key;
+        }
+      }
+    }
 
     db.transaction(() => {
       // 临时关闭外键检查，避免删除顺序导致约束冲突

--- a/src/admin/settings.ts
+++ b/src/admin/settings.ts
@@ -1,6 +1,11 @@
 import { FastifyPluginCallback } from "fastify";
 import Database from "better-sqlite3";
-import { getLogRetentionDays, setLogRetentionDays } from "../db/settings.js";
+import {
+  getLogRetentionDays, setLogRetentionDays,
+  getDbMaxSizeMb, setDbMaxSizeMb,
+  getLogTableMaxSizeMb, setLogTableMaxSizeMb,
+  getSetting,
+} from "../db/settings.js";
 
 interface SettingsOptions {
   db: Database.Database;
@@ -21,6 +26,38 @@ export const adminSettingsRoutes: FastifyPluginCallback<SettingsOptions> = (app,
     }
     setLogRetentionDays(db, days);
     return { days };
+  });
+
+  app.get("/admin/api/settings/db-size", async () => {
+    const raw = getSetting(db, "db_size_info");
+    const sizeInfo = raw ? JSON.parse(raw) : { totalBytes: 0, logTableBytes: 0, logCount: 0, lastChecked: null };
+    return {
+      ...sizeInfo,
+      thresholds: {
+        dbMaxSizeMb: getDbMaxSizeMb(db),
+        logTableMaxSizeMb: getLogTableMaxSizeMb(db),
+      },
+    };
+  });
+
+  app.put("/admin/api/settings/db-size-thresholds", async (request) => {
+    const body = request.body as { dbMaxSizeMb?: number; logTableMaxSizeMb?: number };
+    if (body.dbMaxSizeMb !== undefined) {
+      if (!Number.isFinite(body.dbMaxSizeMb) || body.dbMaxSizeMb < 1) {
+        throw { statusCode: 400, message: "dbMaxSizeMb must be a positive number" };
+      }
+      setDbMaxSizeMb(db, Math.round(body.dbMaxSizeMb));
+    }
+    if (body.logTableMaxSizeMb !== undefined) {
+      if (!Number.isFinite(body.logTableMaxSizeMb) || body.logTableMaxSizeMb < 1) {
+        throw { statusCode: 400, message: "logTableMaxSizeMb must be a positive number" };
+      }
+      setLogTableMaxSizeMb(db, Math.round(body.logTableMaxSizeMb));
+    }
+    return {
+      dbMaxSizeMb: getDbMaxSizeMb(db),
+      logTableMaxSizeMb: getLogTableMaxSizeMb(db),
+    };
   });
 
   done();

--- a/src/admin/settings.ts
+++ b/src/admin/settings.ts
@@ -29,8 +29,12 @@ export const adminSettingsRoutes: FastifyPluginCallback<SettingsOptions> = (app,
   });
 
   app.get("/admin/api/settings/db-size", async () => {
+    const DEFAULT_SIZE_INFO = { totalBytes: 0, logTableBytes: 0, logCount: 0, lastChecked: null };
     const raw = getSetting(db, "db_size_info");
-    const sizeInfo = raw ? JSON.parse(raw) : { totalBytes: 0, logTableBytes: 0, logCount: 0, lastChecked: null };
+    let sizeInfo = DEFAULT_SIZE_INFO;
+    if (raw) {
+      try { sizeInfo = JSON.parse(raw); } catch { /* eslint-disable-line taste/no-silent-catch -- 损坏的缓存值，回退默认 */ }
+    }
     return {
       ...sizeInfo,
       thresholds: {

--- a/src/admin/settings.ts
+++ b/src/admin/settings.ts
@@ -15,7 +15,8 @@ export const adminSettingsRoutes: FastifyPluginCallback<SettingsOptions> = (app,
 
   app.put("/admin/api/settings/log-retention", async (request) => {
     const { days } = request.body as { days: number };
-    if (!Number.isInteger(days) || days < 0 || days > 90) {
+    const MAX_LOG_RETENTION_DAYS = 90;
+    if (!Number.isInteger(days) || days < 0 || days > MAX_LOG_RETENTION_DAYS) {
       throw { statusCode: 400, message: "days must be integer 0-90" };
     }
     setLogRetentionDays(db, days);

--- a/src/db/db-size-monitor.ts
+++ b/src/db/db-size-monitor.ts
@@ -25,8 +25,7 @@ export function collectDbSizeInfo(db: Database.Database, dbPath: string): DbSize
   if (dbPath !== ":memory:") {
     try {
       totalBytes = statSync(dbPath).size;
-    } catch {
-      // DB 文件可能尚未创建（CI 内存测试、首次启动等）
+    } catch { // eslint-disable-line taste/no-silent-catch -- DB 文件可能尚未创建（CI 内存测试、首次启动等）
     }
   }
   const logTableBytes = estimateLogTableSize(db);
@@ -73,7 +72,8 @@ export function scheduleDbSizeMonitor(
 ): DbSizeMonitorHandle {
   const intervalMs = options.intervalMs ?? DEFAULT_INTERVAL_MS;
   let running = false;
-  let timer: ReturnType<typeof setInterval> | null = null;
+  let initialTimer: ReturnType<typeof setTimeout> | null = null;
+  let intervalTimer: ReturnType<typeof setInterval> | null = null;
 
   const doCheck = () => {
     if (running) return;
@@ -86,19 +86,22 @@ export function scheduleDbSizeMonitor(
       };
       const deleted = runSizeBasedCleanup(db, dbPath, thresholds);
       if (deleted > 0) options.log.info(`Size-based cleanup: deleted ${deleted} log records`);
-    } catch {
-      // DB 可能已关闭（测试清理、进程关闭等），静默忽略
+    } catch (e) {
+      // DB 可能已关闭（测试清理、进程关闭等）
+      options.log.info(`Size monitor check skipped: ${e instanceof Error ? e.message : String(e)}`);
     } finally {
       running = false;
     }
   };
 
-  collectDbSizeInfo(db, dbPath);
+  // 推迟到下一个事件循环 tick，避免阻塞服务器启动（与 log-cleaner 保持一致）
+  initialTimer = setTimeout(doCheck, 0);
 
-  timer = setInterval(doCheck, intervalMs);
+  intervalTimer = setInterval(doCheck, intervalMs);
   return {
     stop: () => {
-      if (timer) { clearInterval(timer); timer = null; }
+      if (initialTimer) { clearTimeout(initialTimer); initialTimer = null; }
+      if (intervalTimer) { clearInterval(intervalTimer); intervalTimer = null; }
     },
   };
 }

--- a/src/db/db-size-monitor.ts
+++ b/src/db/db-size-monitor.ts
@@ -1,0 +1,96 @@
+import { statSync } from "fs";
+import Database from "better-sqlite3";
+import { setSetting, getDbMaxSizeMb, getLogTableMaxSizeMb } from "./settings.js";
+import { estimateLogTableSize, deleteOldestLogs, getLogCount } from "./logs.js";
+
+const BYTES_PER_MB = 1_048_576;
+const DEFAULT_INTERVAL_MS = 1_800_000; // 30 分钟
+const CLEANUP_TARGET_RATIO = 0.8;
+const DEFAULT_ROW_BYTES = 500;
+
+export interface DbSizeInfo {
+  totalBytes: number;
+  logTableBytes: number;
+  logCount: number;
+  lastChecked: string;
+}
+
+export interface SizeThresholds {
+  dbMaxSizeMb: number;
+  logTableMaxSizeMb: number;
+}
+
+export function collectDbSizeInfo(db: Database.Database, dbPath: string): DbSizeInfo {
+  const totalBytes = dbPath === ":memory:" ? 0 : statSync(dbPath).size;
+  const logTableBytes = estimateLogTableSize(db);
+  const logCount = getLogCount(db);
+  const info: DbSizeInfo = {
+    totalBytes,
+    logTableBytes,
+    logCount,
+    lastChecked: new Date().toISOString(),
+  };
+  setSetting(db, "db_size_info", JSON.stringify(info));
+  return info;
+}
+
+export function runSizeBasedCleanup(
+  db: Database.Database,
+  dbPath: string,
+  thresholds: SizeThresholds,
+): number {
+  const info = collectDbSizeInfo(db, dbPath);
+  const logOverThreshold = info.logTableBytes > thresholds.logTableMaxSizeMb * BYTES_PER_MB;
+  const dbOverThreshold = info.totalBytes > thresholds.dbMaxSizeMb * BYTES_PER_MB;
+
+  if (!logOverThreshold && !dbOverThreshold) return 0;
+
+  const targetBytes = thresholds.logTableMaxSizeMb * BYTES_PER_MB * CLEANUP_TARGET_RATIO;
+  const avgRowBytes = info.logCount > 0 ? info.logTableBytes / info.logCount : DEFAULT_ROW_BYTES;
+  const keepCount = Math.max(0, Math.floor(targetBytes / avgRowBytes));
+
+  return deleteOldestLogs(db, keepCount);
+}
+
+export interface DbSizeMonitorHandle {
+  stop: () => void;
+}
+
+export function scheduleDbSizeMonitor(
+  db: Database.Database,
+  dbPath: string,
+  options: {
+    intervalMs?: number;
+    dbMaxSizeMb?: number;
+    logTableMaxSizeMb?: number;
+    log: { info: (msg: string) => void };
+  },
+): DbSizeMonitorHandle {
+  const intervalMs = options.intervalMs ?? DEFAULT_INTERVAL_MS;
+  let running = false;
+  let timer: ReturnType<typeof setInterval> | null = null;
+
+  const doCheck = () => {
+    if (running) return;
+    running = true;
+    try {
+      const thresholds: SizeThresholds = {
+        dbMaxSizeMb: options.dbMaxSizeMb ?? getDbMaxSizeMb(db),
+        logTableMaxSizeMb: options.logTableMaxSizeMb ?? getLogTableMaxSizeMb(db),
+      };
+      const deleted = runSizeBasedCleanup(db, dbPath, thresholds);
+      if (deleted > 0) options.log.info(`Size-based cleanup: deleted ${deleted} log records`);
+    } finally {
+      running = false;
+    }
+  };
+
+  collectDbSizeInfo(db, dbPath);
+
+  timer = setInterval(doCheck, intervalMs);
+  return {
+    stop: () => {
+      if (timer) { clearInterval(timer); timer = null; }
+    },
+  };
+}

--- a/src/db/db-size-monitor.ts
+++ b/src/db/db-size-monitor.ts
@@ -21,7 +21,14 @@ export interface SizeThresholds {
 }
 
 export function collectDbSizeInfo(db: Database.Database, dbPath: string): DbSizeInfo {
-  const totalBytes = dbPath === ":memory:" ? 0 : statSync(dbPath).size;
+  let totalBytes = 0;
+  if (dbPath !== ":memory:") {
+    try {
+      totalBytes = statSync(dbPath).size;
+    } catch {
+      // DB 文件可能尚未创建（CI 内存测试、首次启动等）
+    }
+  }
   const logTableBytes = estimateLogTableSize(db);
   const logCount = getLogCount(db);
   const info: DbSizeInfo = {

--- a/src/db/db-size-monitor.ts
+++ b/src/db/db-size-monitor.ts
@@ -86,6 +86,8 @@ export function scheduleDbSizeMonitor(
       };
       const deleted = runSizeBasedCleanup(db, dbPath, thresholds);
       if (deleted > 0) options.log.info(`Size-based cleanup: deleted ${deleted} log records`);
+    } catch {
+      // DB 可能已关闭（测试清理、进程关闭等），静默忽略
     } finally {
       running = false;
     }

--- a/src/db/db-size-monitor.ts
+++ b/src/db/db-size-monitor.ts
@@ -61,8 +61,6 @@ export function scheduleDbSizeMonitor(
   dbPath: string,
   options: {
     intervalMs?: number;
-    dbMaxSizeMb?: number;
-    logTableMaxSizeMb?: number;
     log: { info: (msg: string) => void };
   },
 ): DbSizeMonitorHandle {
@@ -74,9 +72,10 @@ export function scheduleDbSizeMonitor(
     if (running) return;
     running = true;
     try {
+      // 每次检查时从 DB 读取最新阈值，而非使用启动时的缓存值
       const thresholds: SizeThresholds = {
-        dbMaxSizeMb: options.dbMaxSizeMb ?? getDbMaxSizeMb(db),
-        logTableMaxSizeMb: options.logTableMaxSizeMb ?? getLogTableMaxSizeMb(db),
+        dbMaxSizeMb: getDbMaxSizeMb(db),
+        logTableMaxSizeMb: getLogTableMaxSizeMb(db),
       };
       const deleted = runSizeBasedCleanup(db, dbPath, thresholds);
       if (deleted > 0) options.log.info(`Size-based cleanup: deleted ${deleted} log records`);

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -119,6 +119,9 @@ export {
   updateLogMetrics,
   updateLogStreamContent,
   backfillMetricsFromRequestMetrics,
+  estimateLogTableSize,
+  deleteOldestLogs,
+  getLogCount,
 } from "./logs.js";
 export type { RequestLog, RequestLogGroupedRow, RequestLogListRow } from "./logs.js";
 
@@ -140,6 +143,10 @@ export { getStats } from "./stats.js";
 export type { Stats, StatsPeriod } from "./stats.js";
 
 export { getSetting, setSetting, isInitialized } from "./settings.js";
+export {
+  getDbMaxSizeMb, setDbMaxSizeMb,
+  getLogTableMaxSizeMb, setLogTableMaxSizeMb,
+} from "./settings.js";
 
 export {
   getSessionStates,
@@ -158,3 +165,10 @@ export {
   getWindowUsage,
 } from "./usage-windows.js";
 export type { UsageWindow, WindowUsage } from "./usage-windows.js";
+
+export {
+  collectDbSizeInfo,
+  runSizeBasedCleanup,
+  scheduleDbSizeMonitor,
+} from "./db-size-monitor.js";
+export type { DbSizeInfo, SizeThresholds, DbSizeMonitorHandle } from "./db-size-monitor.js";

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -20,6 +20,7 @@ export function initDatabase(dbPath: string): Database.Database {
 
   const db = new Database(dbPath);
   db.pragma("journal_mode = WAL");
+  db.pragma("auto_vacuum = INCREMENTAL");
   db.pragma("foreign_keys = ON");
 
   db.exec(`

--- a/src/db/log-cleaner.ts
+++ b/src/db/log-cleaner.ts
@@ -23,7 +23,8 @@ export function scheduleLogCleanup(
   log: { info: (msg: string) => void },
 ): LogCleanupHandle {
   let cleaning = false;
-  let timer: ReturnType<typeof setInterval> | null = null;
+  let initialTimer: ReturnType<typeof setTimeout> | null = null;
+  let intervalTimer: ReturnType<typeof setInterval> | null = null;
 
   const doCleanup = () => {
     if (cleaning) return;
@@ -31,20 +32,23 @@ export function scheduleLogCleanup(
     try {
       const deleted = runLogCleanup(db);
       if (deleted > 0) log.info(`Log cleanup: deleted ${deleted} records`);
+    } catch {
+      // DB 可能已关闭（测试清理、进程关闭等），静默忽略
     } finally {
       cleaning = false;
     }
   };
 
   // 推迟到下一个事件循环 tick，避免阻塞服务器启动
-  setTimeout(doCleanup, 0);
+  initialTimer = setTimeout(doCleanup, 0);
 
   // 定时执行
-  timer = setInterval(doCleanup, CLEANUP_INTERVAL_MS);
+  intervalTimer = setInterval(doCleanup, CLEANUP_INTERVAL_MS);
 
   return {
     stop: () => {
-      if (timer) { clearInterval(timer); timer = null; }
+      if (initialTimer) { clearTimeout(initialTimer); initialTimer = null; }
+      if (intervalTimer) { clearInterval(intervalTimer); intervalTimer = null; }
     },
   };
 }

--- a/src/db/log-cleaner.ts
+++ b/src/db/log-cleaner.ts
@@ -36,8 +36,8 @@ export function scheduleLogCleanup(
     }
   };
 
-  // 启动时立即执行一次
-  doCleanup();
+  // 推迟到下一个事件循环 tick，避免阻塞服务器启动
+  setTimeout(doCleanup, 0);
 
   // 定时执行
   timer = setInterval(doCleanup, CLEANUP_INTERVAL_MS);

--- a/src/db/log-cleaner.ts
+++ b/src/db/log-cleaner.ts
@@ -32,8 +32,9 @@ export function scheduleLogCleanup(
     try {
       const deleted = runLogCleanup(db);
       if (deleted > 0) log.info(`Log cleanup: deleted ${deleted} records`);
-    } catch {
-      // DB 可能已关闭（测试清理、进程关闭等），静默忽略
+    } catch (e) {
+      // DB 可能已关闭（测试清理、进程关闭等）
+      log.info(`Log cleanup skipped: ${e instanceof Error ? e.message : String(e)}`);
     } finally {
       cleaning = false;
     }

--- a/src/db/logs.ts
+++ b/src/db/logs.ts
@@ -238,21 +238,33 @@ export function estimateLogTableSize(db: Database.Database): number {
   return row.size;
 }
 
-/** 删除最旧的日志，保留 keepCount 条，返回实际删除条数 */
+const DELETE_BATCH_SIZE = 1000;
+
+/** 删除最旧的日志，保留 keepCount 条，返回实际删除条数。分批删除避免长时间锁表 */
 export function deleteOldestLogs(db: Database.Database, keepCount: number): number {
   const total = (db.prepare("SELECT count(*) as c FROM request_logs").get() as { c: number }).c;
   const toDelete = Math.max(0, total - keepCount);
   if (toDelete === 0) return 0;
-  const result = db.prepare(`
+
+  let totalDeleted = 0;
+  const stmt = db.prepare(`
     DELETE FROM request_logs
-    WHERE id IN (
-      SELECT id FROM request_logs ORDER BY created_at ASC LIMIT ?
+    WHERE rowid IN (
+      SELECT rowid FROM request_logs ORDER BY created_at ASC LIMIT ?
     )
-  `).run(toDelete);
-  if (result.changes > 0) {
+  `);
+
+  while (totalDeleted < toDelete) {
+    const batchSize = Math.min(DELETE_BATCH_SIZE, toDelete - totalDeleted);
+    const result = stmt.run(batchSize);
+    totalDeleted += result.changes;
+    if (result.changes < batchSize) break;
+  }
+
+  if (totalDeleted > 0) {
     db.pragma("incremental_vacuum");
   }
-  return result.changes;
+  return totalDeleted;
 }
 
 /** 获取 request_logs 总行数 */

--- a/src/db/logs.ts
+++ b/src/db/logs.ts
@@ -43,7 +43,7 @@ const LOG_LIST_SELECT = `rl.id, rl.api_type, rl.model, rl.provider_id, rl.status
             rl.is_stream, rl.error_message, rl.created_at, rl.is_retry, rl.is_failover, rl.original_request_id, rl.original_model,
             CASE WHEN rl.provider_id = 'router' THEN rl.upstream_request ELSE NULL END AS upstream_request,
             rl.input_tokens, rl.output_tokens, rl.cache_read_tokens, rl.ttft_ms, rl.tokens_per_second, rl.stop_reason,
-            rl.backend_model, rl.metrics_complete,
+            rl.backend_model, rl.metrics_complete, rl.session_id,
             COALESCE(p.name, rl.provider_id) AS provider_name`;
 const LOG_LIST_JOIN = `LEFT JOIN providers p ON p.id = rl.provider_id`;
 
@@ -65,6 +65,7 @@ export interface RequestLogInsert {
   original_request_id?: string | null;
   router_key_id?: string | null;
   original_model?: string | null;
+  session_id?: string | null;
 }
 
 export function insertRequestLog(
@@ -74,8 +75,8 @@ export function insertRequestLog(
   db.prepare(
     `INSERT INTO request_logs (id, api_type, model, provider_id, status_code, latency_ms,
       is_stream, error_message, created_at, client_request, upstream_request, upstream_response,
-      is_retry, is_failover, original_request_id, router_key_id, original_model)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      is_retry, is_failover, original_request_id, router_key_id, original_model, session_id)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
     log.id, log.api_type, log.model, log.provider_id, log.status_code,
     log.latency_ms, log.is_stream, log.error_message, log.created_at,
@@ -83,6 +84,7 @@ export function insertRequestLog(
     log.upstream_response ?? null,
     log.is_retry ?? 0, log.is_failover ?? 0, log.original_request_id ?? null,
     log.router_key_id ?? null, log.original_model ?? null,
+    log.session_id ?? null,
   );
 }
 

--- a/src/db/logs.ts
+++ b/src/db/logs.ts
@@ -222,6 +222,41 @@ export function deleteLogsBefore(db: Database.Database, beforeDate: string): num
   return changes;
 }
 
+/** 估算 request_logs 表占用字节数 */
+export function estimateLogTableSize(db: Database.Database): number {
+  const row = db.prepare(`
+    SELECT COALESCE(SUM(
+      length(client_request) + length(upstream_request) +
+      length(upstream_response) + length(stream_text_content) +
+      length(error_message) + 500
+    ), 0) as size
+    FROM request_logs
+  `).get() as { size: number };
+  return row.size;
+}
+
+/** 删除最旧的日志，保留 keepCount 条，返回实际删除条数 */
+export function deleteOldestLogs(db: Database.Database, keepCount: number): number {
+  const total = (db.prepare("SELECT count(*) as c FROM request_logs").get() as { c: number }).c;
+  const toDelete = Math.max(0, total - keepCount);
+  if (toDelete === 0) return 0;
+  const result = db.prepare(`
+    DELETE FROM request_logs
+    WHERE id IN (
+      SELECT id FROM request_logs ORDER BY created_at ASC LIMIT ?
+    )
+  `).run(toDelete);
+  if (result.changes > 0) {
+    db.pragma("incremental_vacuum(100)");
+  }
+  return result.changes;
+}
+
+/** 获取 request_logs 总行数 */
+export function getLogCount(db: Database.Database): number {
+  return (db.prepare("SELECT count(*) as c FROM request_logs").get() as { c: number }).c;
+}
+
 /** 查询某条日志的子请求（retry/failover 关联），上限 100 条 */
 export function getRequestLogChildren(
   db: Database.Database,

--- a/src/db/logs.ts
+++ b/src/db/logs.ts
@@ -222,16 +222,19 @@ export function deleteLogsBefore(db: Database.Database, beforeDate: string): num
   return changes;
 }
 
+/** 每行元数据（数字列+索引）的估算字节数 */
+const ROW_METADATA_BYTES = 500;
+
 /** 估算 request_logs 表占用字节数 */
 export function estimateLogTableSize(db: Database.Database): number {
   const row = db.prepare(`
     SELECT COALESCE(SUM(
-      length(client_request) + length(upstream_request) +
-      length(upstream_response) + length(stream_text_content) +
-      length(error_message) + 500
+      COALESCE(length(client_request), 0) + COALESCE(length(upstream_request), 0) +
+      COALESCE(length(upstream_response), 0) + COALESCE(length(stream_text_content), 0) +
+      COALESCE(length(error_message), 0) + ?
     ), 0) as size
     FROM request_logs
-  `).get() as { size: number };
+  `).get(ROW_METADATA_BYTES) as { size: number };
   return row.size;
 }
 

--- a/src/db/logs.ts
+++ b/src/db/logs.ts
@@ -28,6 +28,7 @@ export interface RequestLog {
   backend_model: string | null;
   metrics_complete: number;
   stream_text_content: string | null;
+  session_id: string | null;
 }
 
 /** 列表查询扩展字段：JOIN providers 获得 provider_name */

--- a/src/db/logs.ts
+++ b/src/db/logs.ts
@@ -217,7 +217,7 @@ export function backfillMetricsFromRequestMetrics(db: Database.Database): number
 export function deleteLogsBefore(db: Database.Database, beforeDate: string): number {
   const changes = db.prepare("DELETE FROM request_logs WHERE created_at < ?").run(beforeDate).changes;
   if (changes > 0) {
-    db.pragma("incremental_vacuum(100)");
+    db.pragma("incremental_vacuum");
   }
   return changes;
 }
@@ -250,7 +250,7 @@ export function deleteOldestLogs(db: Database.Database, keepCount: number): numb
     )
   `).run(toDelete);
   if (result.changes > 0) {
-    db.pragma("incremental_vacuum(100)");
+    db.pragma("incremental_vacuum");
   }
   return result.changes;
 }

--- a/src/db/logs.ts
+++ b/src/db/logs.ts
@@ -160,8 +160,12 @@ export function getRequestLogs(
   return { data, total };
 }
 
-export function getRequestLogById(db: Database.Database, id: string): RequestLog | undefined {
-  return db.prepare("SELECT * FROM request_logs WHERE id = ?").get(id) as RequestLog | undefined;
+export function getRequestLogById(db: Database.Database, id: string): RequestLogListRow | undefined {
+  return db.prepare(
+    `SELECT rl.*, COALESCE(p.name, rl.provider_id) AS provider_name
+     FROM request_logs rl LEFT JOIN providers p ON p.id = rl.provider_id
+     WHERE rl.id = ?`,
+  ).get(id) as RequestLogListRow | undefined;
 }
 
 type MetricsUpdate = {

--- a/src/db/logs.ts
+++ b/src/db/logs.ts
@@ -212,7 +212,11 @@ export function backfillMetricsFromRequestMetrics(db: Database.Database): number
 }
 
 export function deleteLogsBefore(db: Database.Database, beforeDate: string): number {
-  return db.prepare("DELETE FROM request_logs WHERE created_at < ?").run(beforeDate).changes;
+  const changes = db.prepare("DELETE FROM request_logs WHERE created_at < ?").run(beforeDate).changes;
+  if (changes > 0) {
+    db.pragma("incremental_vacuum(100)");
+  }
+  return changes;
 }
 
 /** 查询某条日志的子请求（retry/failover 关联），上限 100 条 */

--- a/src/db/migrations/022_add_session_id_and_incremental_vacuum.sql
+++ b/src/db/migrations/022_add_session_id_and_incremental_vacuum.sql
@@ -1,2 +1,5 @@
 ALTER TABLE request_logs ADD COLUMN session_id TEXT;
+
+-- NOTE: PRAGMA auto_vacuum only takes effect after VACUUM for existing databases.
+-- Run scripts/vacuum-migrate.js for existing deployments.
 PRAGMA auto_vacuum = 2;

--- a/src/db/migrations/022_add_session_id_and_incremental_vacuum.sql
+++ b/src/db/migrations/022_add_session_id_and_incremental_vacuum.sql
@@ -1,0 +1,2 @@
+ALTER TABLE request_logs ADD COLUMN session_id TEXT;
+PRAGMA auto_vacuum = 2;

--- a/src/db/settings.ts
+++ b/src/db/settings.ts
@@ -22,3 +22,24 @@ export function getLogRetentionDays(db: Database.Database): number {
 export function setLogRetentionDays(db: Database.Database, days: number): void {
   setSetting(db, "log_retention_days", String(days));
 }
+
+const DEFAULT_DB_MAX_SIZE_MB = 1024;
+const DEFAULT_LOG_TABLE_MAX_SIZE_MB = 800;
+
+export function getDbMaxSizeMb(db: Database.Database): number {
+  const val = getSetting(db, "db_max_size_mb");
+  return val ? parseInt(val, 10) : DEFAULT_DB_MAX_SIZE_MB;
+}
+
+export function setDbMaxSizeMb(db: Database.Database, mb: number): void {
+  setSetting(db, "db_max_size_mb", String(mb));
+}
+
+export function getLogTableMaxSizeMb(db: Database.Database): number {
+  const val = getSetting(db, "log_table_max_size_mb");
+  return val ? parseInt(val, 10) : DEFAULT_LOG_TABLE_MAX_SIZE_MB;
+}
+
+export function setLogTableMaxSizeMb(db: Database.Database, mb: number): void {
+  setSetting(db, "log_table_max_size_mb", String(mb));
+}

--- a/src/db/settings.ts
+++ b/src/db/settings.ts
@@ -15,7 +15,8 @@ export function isInitialized(db: Database.Database): boolean {
 
 export function getLogRetentionDays(db: Database.Database): number {
   const val = getSetting(db, "log_retention_days");
-  return val ? parseInt(val, 10) : 3;
+  const DEFAULT_LOG_RETENTION_DAYS = 3;
+  return val ? parseInt(val, 10) : DEFAULT_LOG_RETENTION_DAYS;
 }
 
 export function setLogRetentionDays(db: Database.Database, days: number): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,8 @@ import { RequestTracker } from "./monitor/request-tracker.js";
 import { modelState } from "./proxy/model-state.js";
 import { UsageWindowTracker } from "./proxy/usage-window-tracker.js";
 import { scheduleLogCleanup } from "./db/log-cleaner.js";
+import { scheduleDbSizeMonitor } from "./db/db-size-monitor.js";
+import { getDbMaxSizeMb, getLogTableMaxSizeMb } from "./db/settings.js";
 import fastifyStatic from "@fastify/static";
 import Database from "better-sqlite3";
 
@@ -227,12 +229,19 @@ export async function buildApp(
 
   const logCleanup = scheduleLogCleanup(db, app.log);
 
+  const dbSizeMonitor = scheduleDbSizeMonitor(db, config.DB_PATH, {
+    dbMaxSizeMb: getDbMaxSizeMb(db),
+    logTableMaxSizeMb: getLogTableMaxSizeMb(db),
+    log: app.log,
+  });
+
   return {
     app,
     db,
     usageWindowTracker,
     close: async () => {
       logCleanup.stop();
+      dbSizeMonitor.stop();
       tracker.stopPushInterval();
       await app.close();
       db.close();

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,7 +38,6 @@ import { modelState } from "./proxy/model-state.js";
 import { UsageWindowTracker } from "./proxy/usage-window-tracker.js";
 import { scheduleLogCleanup } from "./db/log-cleaner.js";
 import { scheduleDbSizeMonitor } from "./db/db-size-monitor.js";
-import { getDbMaxSizeMb, getLogTableMaxSizeMb } from "./db/settings.js";
 import fastifyStatic from "@fastify/static";
 import Database from "better-sqlite3";
 
@@ -230,8 +229,6 @@ export async function buildApp(
   const logCleanup = scheduleLogCleanup(db, app.log);
 
   const dbSizeMonitor = scheduleDbSizeMonitor(db, config.DB_PATH, {
-    dbMaxSizeMb: getDbMaxSizeMb(db),
-    logTableMaxSizeMb: getLogTableMaxSizeMb(db),
     log: app.log,
   });
 

--- a/src/metrics/metrics-extractor.ts
+++ b/src/metrics/metrics-extractor.ts
@@ -152,7 +152,7 @@ export class MetricsExtractor {
       const msg = parsed as AnthropicMessageDelta;
       this.outputTokens = msg.usage?.output_tokens ?? null;
       // 第三方 Anthropic 兼容 API（如 OpenRouter、智谱）可能将 input_tokens 放在 message_delta 而非 message_start
-      if (!this.inputTokens && msg.usage?.input_tokens) {
+      if (this.inputTokens === null && msg.usage?.input_tokens) {
         this.inputTokens = msg.usage.input_tokens;
       }
       this.stopReason = msg.delta?.stop_reason ?? null;

--- a/src/metrics/metrics-extractor.ts
+++ b/src/metrics/metrics-extractor.ts
@@ -33,7 +33,7 @@ interface AnthropicContentBlockDelta {
 interface AnthropicMessageDelta {
   type: string;
   delta?: { stop_reason?: string };
-  usage?: { output_tokens?: number };
+  usage?: { output_tokens?: number; input_tokens?: number };
 }
 
 interface OpenAIChoice {
@@ -151,6 +151,10 @@ export class MetricsExtractor {
     } else if (type === "message_delta") {
       const msg = parsed as AnthropicMessageDelta;
       this.outputTokens = msg.usage?.output_tokens ?? null;
+      // 第三方 Anthropic 兼容 API（如 OpenRouter、智谱）可能将 input_tokens 放在 message_delta 而非 message_start
+      if (!this.inputTokens && msg.usage?.input_tokens) {
+        this.inputTokens = msg.usage.input_tokens;
+      }
       this.stopReason = msg.delta?.stop_reason ?? null;
       this.streamEndTime = Date.now();
     } else if (type === "message_stop") {

--- a/src/monitor/request-tracker.ts
+++ b/src/monitor/request-tracker.ts
@@ -198,6 +198,11 @@ export class RequestTracker {
     return this.activeMap.get(id) ?? this.recentCompleted.find((r) => r.id === id);
   }
 
+  /** Public alias for API endpoint use — returns full request data including clientRequest */
+  getRequestById(id: string): ActiveRequest | undefined {
+    return this.activeMap.get(id) ?? this.recentCompleted.find((r) => r.id === id);
+  }
+
   // --- Stats / monitoring ---
 
   getStats(): StatsSnapshot {
@@ -270,7 +275,16 @@ export class RequestTracker {
   }
 
   broadcast(event: string, data: unknown): void {
-    const msg = `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+    // Strip clientRequest from periodic broadcasts to reduce bandwidth;
+    // full data available on-demand via getRequestById / API endpoint
+    let payload = data;
+    if (event === "request_update" && Array.isArray(data)) {
+      payload = data.map(req => {
+        const { clientRequest: _, ...rest } = req as ActiveRequest;
+        return rest;
+      });
+    }
+    const msg = `event: ${event}\ndata: ${JSON.stringify(payload)}\n\n`;
     const clientCount = this.clients.size;
     let sentCount = 0;
     for (const client of this.clients) {

--- a/src/monitor/request-tracker.ts
+++ b/src/monitor/request-tracker.ts
@@ -200,7 +200,7 @@ export class RequestTracker {
 
   /** Public alias for API endpoint use — returns full request data including clientRequest */
   getRequestById(id: string): ActiveRequest | undefined {
-    return this.activeMap.get(id) ?? this.recentCompleted.find((r) => r.id === id);
+    return this.get(id);
   }
 
   // --- Stats / monitoring ---
@@ -275,8 +275,8 @@ export class RequestTracker {
   }
 
   broadcast(event: string, data: unknown): void {
-    // Strip clientRequest from periodic broadcasts to reduce bandwidth;
-    // full data available on-demand via getRequestById / API endpoint
+    // Strip clientRequest from broadcasts to reduce bandwidth;
+    // full data available on-demand via API endpoint
     let payload = data;
     if (event === "request_update" && Array.isArray(data)) {
       payload = data.map((req: ActiveRequest) => {
@@ -284,6 +284,10 @@ export class RequestTracker {
         delete copy.clientRequest;
         return copy;
       });
+    } else if (event === "request_complete" && data && typeof data === "object") {
+      const copy = { ...(data as ActiveRequest) };
+      delete copy.clientRequest;
+      payload = copy;
     }
     const msg = `event: ${event}\ndata: ${JSON.stringify(payload)}\n\n`;
     const clientCount = this.clients.size;

--- a/src/monitor/request-tracker.ts
+++ b/src/monitor/request-tracker.ts
@@ -279,9 +279,10 @@ export class RequestTracker {
     // full data available on-demand via getRequestById / API endpoint
     let payload = data;
     if (event === "request_update" && Array.isArray(data)) {
-      payload = data.map(req => {
-        const { clientRequest: _, ...rest } = req as ActiveRequest;
-        return rest;
+      payload = data.map((req: ActiveRequest) => {
+        const copy = { ...req };
+        delete copy.clientRequest;
+        return copy;
       });
     }
     const msg = `event: ${event}\ndata: ${JSON.stringify(payload)}\n\n`;

--- a/src/monitor/types.ts
+++ b/src/monitor/types.ts
@@ -30,6 +30,7 @@ export interface ActiveRequest {
   streamContent?: StreamContentSnapshot;
   clientIp?: string;
   sessionId?: string;
+  clientRequest?: string;
   completedAt?: number;
 }
 

--- a/src/proxy/log-helpers.ts
+++ b/src/proxy/log-helpers.ts
@@ -28,6 +28,7 @@ export interface RequestLogParams extends LogRetryMeta {
   upHdrs: Record<string, string>;
   routerKeyId?: string | null;
   originalModel?: string | null;
+  sessionId?: string | null;
 }
 
 /** 插入成功请求日志，供 openai/anthropic 插件共享 */
@@ -37,7 +38,8 @@ export function insertSuccessLog(
 ): void {
   const { id: logId, apiType, model, provider, isStream, startTime,
     clientReq, upstreamReq, status, respBody, upHdrs,
-    isRetry = false, isFailover = false, originalRequestId = null, routerKeyId = null, originalModel = null } = params;
+    isRetry = false, isFailover = false, originalRequestId = null, routerKeyId = null, originalModel = null,
+    sessionId = null } = params;
 
   insertRequestLog(db, {
     id: logId, api_type: apiType, model, provider_id: provider.id,
@@ -48,6 +50,7 @@ export function insertSuccessLog(
     upstream_response: JSON.stringify({ statusCode: status, headers: upHdrs, body: respBody }),
     is_retry: isRetry ? 1 : 0, is_failover: isFailover ? 1 : 0, original_request_id: originalRequestId,
     router_key_id: routerKeyId, original_model: originalModel,
+    session_id: sessionId,
   });
 }
 
@@ -65,13 +68,15 @@ export interface RejectedLogParams extends LogRetryMeta {
   clientHeaders: RawHeaders;
   providerId?: string | null;
   originalModel?: string | null;
+  sessionId?: string | null;
 }
 
 /** Log a request rejected before reaching upstream */
 export function insertRejectedLog(params: RejectedLogParams): void {
   const { db, logId, apiType, model, statusCode, errorMessage,
     startTime, isStream, routerKeyId, originalBody, clientHeaders,
-    providerId = null, isFailover = false, originalRequestId = null, originalModel = null } = params;
+    providerId = null, isFailover = false, originalRequestId = null, originalModel = null,
+    sessionId = null } = params;
 
   insertRequestLog(db, {
     id: logId,
@@ -88,5 +93,6 @@ export function insertRejectedLog(params: RejectedLogParams): void {
     original_request_id: originalRequestId,
     router_key_id: routerKeyId,
     original_model: originalModel,
+    session_id: sessionId,
   });
 }

--- a/src/proxy/model-state.ts
+++ b/src/proxy/model-state.ts
@@ -25,6 +25,11 @@ export class ModelStateManager {
     this.db = db;
   }
 
+  /** 清空所有内存缓存（导入配置后调用） */
+  clearAll(): void {
+    this.store.clear();
+  }
+
   /** 构造内存 Map 的 key：有 sessionId 时用复合键 */
   buildKey(routerKeyId: string | null, sessionId?: string): string {
     if (sessionId) {

--- a/src/proxy/orchestrator.ts
+++ b/src/proxy/orchestrator.ts
@@ -28,6 +28,8 @@ export interface OrchestratorConfig {
   trackerId?: string;
   /** Claude Code 的 session ID，从 x-claude-code-session-id 请求头获取 */
   sessionId?: string;
+  /** 客户端请求的 JSON 字符串（headers + body），用于 Monitor 实时查看 */
+  clientRequest?: string;
 }
 
 export interface HandleContext {
@@ -113,6 +115,7 @@ export class ProxyOrchestrator {
       attempts: [],
       clientIp: request.ip,
       sessionId: config.sessionId,
+      clientRequest: config.clientRequest,
     };
   }
 

--- a/src/proxy/proxy-handler.ts
+++ b/src/proxy/proxy-handler.ts
@@ -251,10 +251,14 @@ export async function handleProxyRequest(
       collectTransportMetrics(deps.db, apiType, resilienceResult.result, isStream, lastLogId, provider.id, resolved.backend_model, request);
 
       // 流式请求：将 tracker 中累积的内容持久化到日志
-      // 优先写 textContent（纯文本），若为空但 blocks 存在则序列化为 JSON
+      // blocks 含非 text 类型时（thinking/tool_use）必须序列化为 JSON 以保留结构
       if (isStream && deps.tracker) {
         const sc = deps.tracker.get(logId)?.streamContent;
-        const content = sc?.textContent || serializeBlocksForStorage(sc?.blocks, apiType);
+        const blocks = sc?.blocks;
+        const hasStructured = blocks && blocks.length > 0 && blocks.some(b => b.type !== "text");
+        const content = hasStructured
+          ? serializeBlocksForStorage(blocks, apiType)
+          : (sc?.textContent || "");
         if (content) updateLogStreamContent(deps.db, lastLogId, content);
       }
 

--- a/src/proxy/proxy-handler.ts
+++ b/src/proxy/proxy-handler.ts
@@ -58,7 +58,7 @@ export async function handleProxyRequest(
   const sessionId = (request.headers as RawHeaders)["x-claude-code-session-id"] as string | undefined;
   const { effectiveModel, originalModel, interceptResponse } = applyEnhancement(deps.db, request, clientModel, sessionId);
 
-  if (interceptResponse) return handleIntercept(deps.db, apiType, request, reply, interceptResponse, clientModel);
+  if (interceptResponse) return handleIntercept(deps.db, apiType, request, reply, interceptResponse, clientModel, sessionId);
 
   const group = getMappingGroup(deps.db, effectiveModel);
   const isFailover = group?.strategy === "failover";
@@ -86,7 +86,7 @@ export async function handleProxyRequest(
           db: deps.db, logId, apiType, model: effectiveModel, statusCode: e.statusCode,
           errorMessage: `All failover targets exhausted (${excludeTargets.length} attempted)`,
           startTime, isStream, routerKeyId, originalBody, clientHeaders: cliHdrs, originalModel,
-          isFailover: true, originalRequestId: rootLogId,
+          isFailover: true, originalRequestId: rootLogId, sessionId,
         });
         return reply.status(e.statusCode).send(e.body);
       }
@@ -95,7 +95,7 @@ export async function handleProxyRequest(
         db: deps.db, logId, apiType, model: effectiveModel, statusCode: e.statusCode,
         errorMessage: `No mapping found for model '${effectiveModel}'`, startTime, isStream,
         routerKeyId, originalBody, clientHeaders: cliHdrs, originalModel,
-        isFailover: isFailoverIteration, originalRequestId: isFailoverIteration ? rootLogId : null,
+        isFailover: isFailoverIteration, originalRequestId: isFailoverIteration ? rootLogId : null, sessionId,
       });
       return reply.status(e.statusCode).send(e.body);
     }
@@ -111,7 +111,7 @@ export async function handleProxyRequest(
               db: deps.db, logId, apiType, model: effectiveModel, statusCode: e.statusCode,
               errorMessage: `Model '${resolved.backend_model}' not allowed`, startTime, isStream, routerKeyId,
               originalBody, clientHeaders: cliHdrs, providerId: resolved.provider_id, originalModel,
-              isFailover: isFailoverIteration, originalRequestId: isFailoverIteration ? rootLogId : null,
+              isFailover: isFailoverIteration, originalRequestId: isFailoverIteration ? rootLogId : null, sessionId,
             });
             return reply.status(e.statusCode).send(e.body);
           }
@@ -126,7 +126,7 @@ export async function handleProxyRequest(
         db: deps.db, logId, apiType, model: effectiveModel, statusCode: e.statusCode,
         errorMessage: `Provider '${resolved.provider_id}' unavailable`, startTime, isStream, routerKeyId,
         originalBody, clientHeaders: cliHdrs, providerId: resolved.provider_id, originalModel,
-        isFailover: isFailoverIteration, originalRequestId: isFailoverIteration ? rootLogId : null,
+        isFailover: isFailoverIteration, originalRequestId: isFailoverIteration ? rootLogId : null, sessionId,
       });
       return reply.status(e.statusCode).send(e.body);
     }
@@ -136,7 +136,7 @@ export async function handleProxyRequest(
         db: deps.db, logId, apiType, model: effectiveModel, statusCode: e.statusCode,
         errorMessage: `API type mismatch: expected '${apiType}'`, startTime, isStream, routerKeyId,
         originalBody, clientHeaders: cliHdrs, providerId: resolved.provider_id, originalModel,
-        isFailover: isFailoverIteration, originalRequestId: isFailoverIteration ? rootLogId : null,
+        isFailover: isFailoverIteration, originalRequestId: isFailoverIteration ? rootLogId : null, sessionId,
       });
       return reply.status(e.statusCode).send(e.body);
     }
@@ -219,7 +219,7 @@ export async function handleProxyRequest(
         deps.db,
         {
           apiType, model: effectiveModel, providerId: provider.id, isStream,
-          clientReq, upstreamReqBase, logId, routerKeyId, originalModel,
+          clientReq, upstreamReqBase, logId, routerKeyId, originalModel, sessionId,
           failover: { isFailoverIteration, rootLogId: rootLogId! },
         },
         resilienceResult.attempts, resilienceResult.result, startTime,
@@ -268,7 +268,7 @@ export async function handleProxyRequest(
           errorMessage: `Concurrency queue full for provider '${provider.id}'`,
           startTime, isStream, routerKeyId, originalBody, clientHeaders: cliHdrs,
           providerId: provider.id, originalModel,
-          isFailover: isFailoverIteration, originalRequestId: isFailoverIteration ? rootLogId : null,
+          isFailover: isFailoverIteration, originalRequestId: isFailoverIteration ? rootLogId : null, sessionId,
         });
         return reply.status(err.statusCode).send(err.body);
       }
@@ -279,7 +279,7 @@ export async function handleProxyRequest(
           errorMessage: `Concurrency wait timeout for provider '${provider.id}' (${e.timeoutMs}ms)`,
           startTime, isStream, routerKeyId, originalBody, clientHeaders: cliHdrs,
           providerId: provider.id, originalModel,
-          isFailover: isFailoverIteration, originalRequestId: isFailoverIteration ? rootLogId : null,
+          isFailover: isFailoverIteration, originalRequestId: isFailoverIteration ? rootLogId : null, sessionId,
         });
         return reply.status(err.statusCode).send(err.body);
       }
@@ -292,6 +292,7 @@ export async function handleProxyRequest(
         client_request: clientReq, upstream_request: upstreamReqBase,
         is_failover: isFailoverIteration ? 1 : 0, original_request_id: isFailoverIteration ? rootLogId : null,
         router_key_id: routerKeyId, original_model: originalModel,
+        session_id: sessionId,
       });
       const err = errors.upstreamConnectionFailed();
       return reply.status(err.statusCode).send(err.body);

--- a/src/proxy/proxy-handler.ts
+++ b/src/proxy/proxy-handler.ts
@@ -212,7 +212,7 @@ export async function handleProxyRequest(
     try {
       const resilienceResult = await deps.orchestrator.handle(
         request, reply, apiType,
-        { resolved, provider, clientModel: effectiveModel, isStream, trackerId: logId, sessionId },
+        { resolved, provider, clientModel: effectiveModel, isStream, trackerId: logId, sessionId, clientRequest: clientReq },
         { retryMaxAttempts: deps.retryMaxAttempts, retryBaseDelayMs: deps.retryBaseDelayMs, isFailover, ruleMatcher: deps.matcher, transportFn },
       );
       const lastLogId = logResilienceResult(

--- a/src/proxy/proxy-handler.ts
+++ b/src/proxy/proxy-handler.ts
@@ -53,7 +53,7 @@ function serializeBlocksForStorage(blocks: ContentBlock[] | undefined, apiType: 
       if (b.type === "thinking") return { type: "thinking", thinking: b.content };
       if (b.type === "tool_use") {
         let input = {};
-        try { input = JSON.parse(b.content || "{}"); } catch { /* keep empty */ }
+        try { input = JSON.parse(b.content || "{}"); } catch { /* eslint-disable-line taste/no-silent-catch -- tool_use content 非合法 JSON 时保留空对象 */ }
         return { type: "tool_use", name: b.name ?? "", input };
       }
       return { type: "text", text: b.content };
@@ -252,6 +252,7 @@ export async function handleProxyRequest(
 
       // 流式请求：将 tracker 中累积的内容持久化到日志
       // blocks 含非 text 类型时（thinking/tool_use）必须序列化为 JSON 以保留结构
+      // 注意：tracker 在原 logId 下累积内容，lastLogId 可能因 resilience 重试而指向不同记录
       if (isStream && deps.tracker) {
         const sc = deps.tracker.get(logId)?.streamContent;
         const blocks = sc?.blocks;

--- a/src/proxy/proxy-handler.ts
+++ b/src/proxy/proxy-handler.ts
@@ -43,6 +43,27 @@ export interface RouteHandlerDeps {
 const STREAM_CONTENT_MAX_RAW = 131072;
 const STREAM_CONTENT_MAX_TEXT = 65536;
 
+import type { ContentBlock } from "../monitor/types.js";
+
+/** 将 tracker blocks 序列化为前端 tryDirectParse 可解析的 JSON */
+function serializeBlocksForStorage(blocks: ContentBlock[] | undefined, apiType: "openai" | "anthropic"): string {
+  if (!blocks || blocks.length === 0) return "";
+  if (apiType === "anthropic") {
+    const content = blocks.map(b => {
+      if (b.type === "thinking") return { type: "thinking", thinking: b.content };
+      if (b.type === "tool_use") {
+        let input = {};
+        try { input = JSON.parse(b.content || "{}"); } catch { /* keep empty */ }
+        return { type: "tool_use", name: b.name ?? "", input };
+      }
+      return { type: "text", text: b.content };
+    });
+    return JSON.stringify({ content });
+  }
+  const text = blocks.filter(b => b.type === "text").map(b => b.content).join("");
+  return JSON.stringify({ choices: [{ message: { content: text } }] });
+}
+
 function toStreamMetrics(m: MetricsResult) {
   return {
     inputTokens: m.input_tokens,
@@ -229,12 +250,12 @@ export async function handleProxyRequest(
       );
       collectTransportMetrics(deps.db, apiType, resilienceResult.result, isStream, lastLogId, provider.id, resolved.backend_model, request);
 
-      // 流式请求：将 tracker 中累积的文本内容持久化到日志
-      // 注意：tracker 在原 logId 下累积内容，但 logResilienceResult 可能因重试生成新 lastLogId
+      // 流式请求：将 tracker 中累积的内容持久化到日志
+      // 优先写 textContent（纯文本），若为空但 blocks 存在则序列化为 JSON
       if (isStream && deps.tracker) {
-        const req = deps.tracker.get(logId);
-        const text = req?.streamContent?.textContent;
-        if (text) updateLogStreamContent(deps.db, lastLogId, text);
+        const sc = deps.tracker.get(logId)?.streamContent;
+        const content = sc?.textContent || serializeBlocksForStorage(sc?.blocks, apiType);
+        if (content) updateLogStreamContent(deps.db, lastLogId, content);
       }
 
       // Failover: 单 provider 内重试已耗尽但仍失败，尝试下一个 target

--- a/src/proxy/proxy-handler.ts
+++ b/src/proxy/proxy-handler.ts
@@ -19,6 +19,7 @@ import { UPSTREAM_SUCCESS, ProviderSwitchNeeded } from "./types.js";
 import type { RawHeaders, TransportResult } from "./types.js";
 import { SSEMetricsTransform } from "../metrics/sse-metrics-transform.js";
 import { MetricsExtractor } from "../metrics/metrics-extractor.js";
+import type { MetricsResult } from "../metrics/metrics-extractor.js";
 import { updateLogStreamContent } from "../db/index.js";
 import { callNonStream, callStream } from "./transport.js";
 import { insertRejectedLog } from "./log-helpers.js";
@@ -39,8 +40,20 @@ export interface RouteHandlerDeps {
   orchestrator: ProxyOrchestrator;
 }
 
-const STREAM_CONTENT_MAX_RAW = 8192;
-const STREAM_CONTENT_MAX_TEXT = 4096;
+const STREAM_CONTENT_MAX_RAW = 131072;
+const STREAM_CONTENT_MAX_TEXT = 65536;
+
+function toStreamMetrics(m: MetricsResult) {
+  return {
+    inputTokens: m.input_tokens,
+    outputTokens: m.output_tokens,
+    cacheReadTokens: m.cache_read_tokens,
+    ttftMs: m.ttft_ms,
+    tokensPerSecond: m.tokens_per_second,
+    stopReason: m.stop_reason,
+    isComplete: m.is_complete === 1,
+  };
+}
 
 export async function handleProxyRequest(
   request: FastifyRequest,
@@ -160,14 +173,7 @@ export async function handleProxyRequest(
       if (isStream) {
         const metricsTransform = new SSEMetricsTransform(apiType, startTime, {
           onMetrics: (m) => {
-            deps.tracker?.update(logId, {
-              streamMetrics: {
-                inputTokens: m.input_tokens, outputTokens: m.output_tokens,
-                cacheReadTokens: m.cache_read_tokens,
-                ttftMs: m.ttft_ms, tokensPerSecond: m.tokens_per_second,
-                stopReason: m.stop_reason, isComplete: m.is_complete === 1,
-              },
-            });
+            deps.tracker?.update(logId, { streamMetrics: toStreamMetrics(m) });
           },
           onChunk: (rawLine) => {
             deps.tracker?.appendStreamChunk(logId, rawLine, apiType, STREAM_CONTENT_MAX_RAW, STREAM_CONTENT_MAX_TEXT);
@@ -176,24 +182,21 @@ export async function handleProxyRequest(
         const checkEarlyError = deps.matcher
           ? (data: string) => deps.matcher!.test(UPSTREAM_SUCCESS, data)
           : undefined;
-        return callStream(
+        const streamResult = await callStream(
           provider, apiKey, body, cliHdrs, reply, deps.streamTimeoutMs,
           upstreamPath, buildUpstreamHeaders, metricsTransform, checkEarlyError,
         );
+        const m = (streamResult.kind === "stream_success" || streamResult.kind === "stream_abort")
+          ? streamResult.metrics : undefined;
+        if (m) deps.tracker?.update(logId, { streamMetrics: toStreamMetrics(m) });
+        return streamResult;
       }
       const result = await callNonStream(provider, apiKey, body, cliHdrs, upstreamPath, buildUpstreamHeaders);
       // 非流式请求：从响应体提取指标并更新 tracker
       if (result.kind === "success") {
         const mr = MetricsExtractor.fromNonStreamResponse(apiType, result.body);
         if (mr) {
-          deps.tracker?.update(logId, {
-            streamMetrics: {
-              inputTokens: mr.input_tokens, outputTokens: mr.output_tokens,
-              cacheReadTokens: mr.cache_read_tokens,
-              ttftMs: mr.ttft_ms, tokensPerSecond: mr.tokens_per_second,
-              stopReason: mr.stop_reason, isComplete: mr.is_complete === 1,
-            },
-          });
+          deps.tracker?.update(logId, { streamMetrics: toStreamMetrics(mr) });
         }
       }
       // 非流式响应注入模型信息标签（模型映射场景）
@@ -227,8 +230,9 @@ export async function handleProxyRequest(
       collectTransportMetrics(deps.db, apiType, resilienceResult.result, isStream, lastLogId, provider.id, resolved.backend_model, request);
 
       // 流式请求：将 tracker 中累积的文本内容持久化到日志
+      // 注意：tracker 在原 logId 下累积内容，但 logResilienceResult 可能因重试生成新 lastLogId
       if (isStream && deps.tracker) {
-        const req = deps.tracker.get(lastLogId);
+        const req = deps.tracker.get(logId);
         const text = req?.streamContent?.textContent;
         if (text) updateLogStreamContent(deps.db, lastLogId, text);
       }

--- a/src/proxy/proxy-logging.ts
+++ b/src/proxy/proxy-logging.ts
@@ -38,6 +38,7 @@ export function handleIntercept(
   reply: import("fastify").FastifyReply,
   interceptResponse: { statusCode: number; body: unknown; meta?: unknown },
   clientModel: string,
+  sessionId?: string,
 ): import("fastify").FastifyReply {
   const logId = randomUUID();
   const isStream = (request.body as Record<string, unknown>).stream === true;
@@ -52,6 +53,7 @@ export function handleIntercept(
     upstream_response: JSON.stringify({ statusCode: interceptResponse.statusCode, body: respBody }),
     is_retry: 0, is_failover: 0, original_request_id: null,
     router_key_id: request.routerKey?.id ?? null, original_model: null,
+    session_id: sessionId,
   });
   return reply.status(interceptResponse.statusCode).send(interceptResponse.body);
 }
@@ -70,6 +72,7 @@ export function logResilienceResult(
     logId: string;
     routerKeyId: string | null;
     originalModel: string | null;
+    sessionId?: string | null;
     failover?: FailoverContext;
   },
   attempts: ResilienceAttempt[],
@@ -97,6 +100,7 @@ export function logResilienceResult(
         is_retry: isOriginal ? 0 : 1, is_failover: isFailoverLog ? 1 : 0,
         original_request_id: parentId,
         router_key_id: params.routerKeyId, original_model: params.originalModel,
+        session_id: params.sessionId,
       });
     } else if (attempt.statusCode !== UPSTREAM_SUCCESS) {
       insertRequestLog(db, {
@@ -110,6 +114,7 @@ export function logResilienceResult(
         is_retry: isOriginal ? 0 : 1, is_failover: isFailoverLog ? 1 : 0,
         original_request_id: parentId,
         router_key_id: params.routerKeyId, original_model: params.originalModel,
+        session_id: params.sessionId,
       });
     } else {
       const upHdrs = (result.kind === "stream_success" || result.kind === "stream_abort")
@@ -126,6 +131,7 @@ export function logResilienceResult(
         isRetry: !isOriginal, isFailover: isFailoverLog,
         originalRequestId: parentId,
         routerKeyId: params.routerKeyId, originalModel: params.originalModel,
+        sessionId: params.sessionId,
       });
       lastSuccessLogId = attemptLogId;
     }

--- a/src/proxy/semaphore.ts
+++ b/src/proxy/semaphore.ts
@@ -185,4 +185,15 @@ export class ProviderSemaphoreManager {
     }
     this.entries.delete(providerId);
   }
+
+  /** 清除所有 provider 的信号量配置（导入配置后调用） */
+  removeAll(): void {
+    for (const [, entry] of this.entries) {
+      for (const e of entry.queue) {
+        if (e.timer) clearTimeout(e.timer);
+        e.reject(new Error("Provider removed"));
+      }
+    }
+    this.entries.clear();
+  }
 }

--- a/tests/admin-import-export.test.ts
+++ b/tests/admin-import-export.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { FastifyInstance } from "fastify";
+import { buildApp } from "../src/index.js";
+import { initDatabase } from "../src/db/index.js";
+import { setSetting } from "../src/db/settings.js";
+import { hashPassword } from "../src/utils/password.js";
+
+const TEST_ENCRYPTION_KEY = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+function makeConfig() {
+  return {
+    PORT: 9981,
+    DB_PATH: ":memory:",
+    LOG_LEVEL: "silent",
+    TZ: "Asia/Shanghai",
+    STREAM_TIMEOUT_MS: 5000,
+    RETRY_MAX_ATTEMPTS: 0,
+    RETRY_BASE_DELAY_MS: 0,
+  };
+}
+
+async function login(app: FastifyInstance): Promise<string> {
+  const res = await app.inject({
+    method: "POST",
+    url: "/admin/api/login",
+    payload: { password: "test-admin-pass" },
+  });
+  const match = (res.headers["set-cookie"] as string).match(/admin_token=([^;]+)/);
+  return `admin_token=${match![1]}`;
+}
+
+function seedSettings(db: ReturnType<typeof initDatabase>) {
+  setSetting(db, "encryption_key", TEST_ENCRYPTION_KEY);
+  setSetting(db, "jwt_secret", "test-jwt-secret-for-testing");
+  setSetting(db, "admin_password_hash", hashPassword("test-admin-pass"));
+  setSetting(db, "initialized", "true");
+  setSetting(db, "log_retention_days", "3");
+}
+
+describe("Config Import/Export API", () => {
+  let app: FastifyInstance;
+  let db: ReturnType<typeof initDatabase>;
+  let close: () => Promise<void>;
+  let cookie: string;
+
+  beforeEach(async () => {
+    db = initDatabase(":memory:");
+    seedSettings(db);
+    const result = await buildApp({ config: makeConfig() as any, db });
+    app = result.app;
+    close = result.close;
+    cookie = await login(app);
+  });
+
+  afterEach(async () => {
+    await close();
+  });
+
+  describe("GET /admin/api/settings/export", () => {
+    it("returns valid JSON export with version field", async () => {
+      const res = await app.inject({
+        method: "GET",
+        url: "/admin/api/settings/export",
+        headers: { cookie },
+      });
+      expect(res.statusCode).toBe(200);
+      expect(res.headers["content-disposition"]).toContain("router-config-");
+      const body = res.json();
+      expect(body.version).toBe(1);
+      expect(body.exportedAt).toBeTruthy();
+      expect(body.data).toHaveProperty("providers");
+      expect(body.data).toHaveProperty("settings");
+    });
+
+    it("does not export request_logs or request_metrics", async () => {
+      const res = await app.inject({
+        method: "GET",
+        url: "/admin/api/settings/export",
+        headers: { cookie },
+      });
+      const body = res.json();
+      expect(body.data).not.toHaveProperty("request_logs");
+      expect(body.data).not.toHaveProperty("request_metrics");
+    });
+  });
+
+  describe("POST /admin/api/settings/import", () => {
+    it("imports config and returns counts", async () => {
+      const exportRes = await app.inject({
+        method: "GET",
+        url: "/admin/api/settings/export",
+        headers: { cookie },
+      });
+      const exportData = exportRes.json();
+
+      const importRes = await app.inject({
+        method: "POST",
+        url: "/admin/api/settings/import",
+        payload: exportData,
+        headers: { cookie, "content-type": "application/json" },
+      });
+      expect(importRes.statusCode).toBe(200);
+      const result = importRes.json();
+      expect(result).toHaveProperty("providers");
+      expect(result).toHaveProperty("settings");
+    });
+
+    it("rejects missing version", async () => {
+      const res = await app.inject({
+        method: "POST",
+        url: "/admin/api/settings/import",
+        payload: { data: {} },
+        headers: { cookie, "content-type": "application/json" },
+      });
+      expect(res.statusCode).toBe(400);
+    });
+
+    it("rejects wrong version", async () => {
+      const res = await app.inject({
+        method: "POST",
+        url: "/admin/api/settings/import",
+        payload: { version: 99, data: {} },
+        headers: { cookie, "content-type": "application/json" },
+      });
+      expect(res.statusCode).toBe(400);
+    });
+
+    it("rejects missing data field", async () => {
+      const res = await app.inject({
+        method: "POST",
+        url: "/admin/api/settings/import",
+        payload: { version: 1 },
+        headers: { cookie, "content-type": "application/json" },
+      });
+      expect(res.statusCode).toBe(400);
+    });
+
+    it("preserves local admin_password_hash and jwt_secret on import", async () => {
+      const exportRes = await app.inject({
+        method: "GET",
+        url: "/admin/api/settings/export",
+        headers: { cookie },
+      });
+      const exportData = exportRes.json();
+      // 篡改导出数据中的密码和 JWT 密钥
+      exportData.data.settings = exportData.data.settings.map((s: any) =>
+        s.key === "admin_password_hash"
+          ? { ...s, value: "tampered-password-hash" }
+          : s.key === "jwt_secret"
+            ? { ...s, value: "tampered-jwt" }
+            : s,
+      );
+
+      await app.inject({
+        method: "POST",
+        url: "/admin/api/settings/import",
+        payload: exportData,
+        headers: { cookie, "content-type": "application/json" },
+      });
+
+      // 原密码仍然能登录
+      const loginRes = await app.inject({
+        method: "POST",
+        url: "/admin/api/login",
+        payload: { password: "test-admin-pass" },
+      });
+      expect(loginRes.statusCode).toBe(200);
+    });
+
+    it("preserves local log_retention_days value from export", async () => {
+      const exportRes = await app.inject({
+        method: "GET",
+        url: "/admin/api/settings/export",
+        headers: { cookie },
+      });
+      const exportData = exportRes.json();
+      // 修改非受保护配置项
+      exportData.data.settings = exportData.data.settings.map((s: any) =>
+        s.key === "log_retention_days" ? { ...s, value: "7" } : s,
+      );
+
+      await app.inject({
+        method: "POST",
+        url: "/admin/api/settings/import",
+        payload: exportData,
+        headers: { cookie, "content-type": "application/json" },
+      });
+
+      // 再次导出验证值已更新
+      const reExportRes = await app.inject({
+        method: "GET",
+        url: "/admin/api/settings/export",
+        headers: { cookie },
+      });
+      const reExportData = reExportRes.json();
+      const logRetention = reExportData.data.settings.find((s: any) => s.key === "log_retention_days");
+      expect(logRetention.value).toBe("7");
+    });
+  });
+});

--- a/tests/admin-import-export.test.ts
+++ b/tests/admin-import-export.test.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { FastifyInstance } from "fastify";
+import { createHash } from "crypto";
 import { buildApp } from "../src/index.js";
 import { initDatabase } from "../src/db/index.js";
 import { setSetting } from "../src/db/settings.js";
 import { hashPassword } from "../src/utils/password.js";
+import { encrypt, decrypt } from "../src/utils/crypto.js";
 
 const TEST_ENCRYPTION_KEY = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
 
@@ -82,6 +84,45 @@ describe("Config Import/Export API", () => {
       expect(body.data).not.toHaveProperty("request_logs");
       expect(body.data).not.toHaveProperty("request_metrics");
     });
+
+    it("decrypts provider api_key to plaintext", async () => {
+      const plainApiKey = "sk-test-plaintext-key-12345";
+      const encryptedApiKey = encrypt(plainApiKey, TEST_ENCRYPTION_KEY);
+      db.prepare(
+        "INSERT INTO providers (id, name, api_type, base_url, api_key, is_active, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
+      ).run("test-p-id", "Test Provider", "openai", "https://api.test.com", encryptedApiKey, 1, new Date().toISOString(), new Date().toISOString());
+
+      const res = await app.inject({
+        method: "GET",
+        url: "/admin/api/settings/export",
+        headers: { cookie },
+      });
+      const body = res.json();
+      const provider = body.data.providers.find((p: any) => p.id === "test-p-id");
+      expect(provider.api_key).toBe(plainApiKey);
+    });
+
+    it("decrypts router_keys and replaces key_encrypted with plaintext key", async () => {
+      const plainKey = "sk-router-testkey1234567890abcdef";
+      const keyEncrypted = encrypt(plainKey, TEST_ENCRYPTION_KEY);
+      const keyHash = createHash("sha256").update(plainKey).digest("hex");
+      const keyPrefix = plainKey.slice(0, 8);
+      db.prepare(
+        "INSERT INTO router_keys (id, name, key_hash, key_prefix, key_encrypted, is_active) VALUES (?, ?, ?, ?, ?, ?)"
+      ).run("test-rk-id", "Test Key", keyHash, keyPrefix, keyEncrypted, 1);
+
+      const res = await app.inject({
+        method: "GET",
+        url: "/admin/api/settings/export",
+        headers: { cookie },
+      });
+      const body = res.json();
+      const rk = body.data.router_keys.find((k: any) => k.id === "test-rk-id");
+      expect(rk.key).toBe(plainKey);
+      expect(rk).not.toHaveProperty("key_encrypted");
+      expect(rk).not.toHaveProperty("key_hash");
+      expect(rk).not.toHaveProperty("key_prefix");
+    });
   });
 
   describe("POST /admin/api/settings/import", () => {
@@ -133,6 +174,59 @@ describe("Config Import/Export API", () => {
         headers: { cookie, "content-type": "application/json" },
       });
       expect(res.statusCode).toBe(400);
+    });
+
+    it("re-encrypts provider api_key with local key on import", async () => {
+      const plainApiKey = "sk-import-test-key";
+      const now = new Date().toISOString();
+      const exportData = {
+        version: 1,
+        data: {
+          providers: [{
+            id: "import-p-id", name: "Import Provider", api_type: "openai",
+            base_url: "https://api.test.com", api_key: plainApiKey,
+            is_active: 1, created_at: now, updated_at: now,
+          }],
+        },
+      };
+
+      await app.inject({
+        method: "POST",
+        url: "/admin/api/settings/import",
+        payload: exportData,
+        headers: { cookie, "content-type": "application/json" },
+      });
+
+      const row = db.prepare("SELECT api_key FROM providers WHERE id = ?").get("import-p-id") as { api_key: string };
+      expect(row.api_key).not.toBe(plainApiKey);
+      expect(decrypt(row.api_key, TEST_ENCRYPTION_KEY)).toBe(plainApiKey);
+    });
+
+    it("re-encrypts router_key from plaintext key on import", async () => {
+      const plainKey = "sk-router-import-key-abcdef";
+      const now = new Date().toISOString();
+      const exportData = {
+        version: 1,
+        data: {
+          router_keys: [{
+            id: "import-rk-id", name: "Import Key", key: plainKey, is_active: 1,
+            allowed_models: null, created_at: now, updated_at: now,
+          }],
+        },
+      };
+
+      await app.inject({
+        method: "POST",
+        url: "/admin/api/settings/import",
+        payload: exportData,
+        headers: { cookie, "content-type": "application/json" },
+      });
+
+      const row = db.prepare("SELECT * FROM router_keys WHERE id = ?").get("import-rk-id") as Record<string, any>;
+      expect(row.key_encrypted).toBeTruthy();
+      expect(decrypt(row.key_encrypted, TEST_ENCRYPTION_KEY)).toBe(plainKey);
+      expect(row.key_hash).toBe(createHash("sha256").update(plainKey).digest("hex"));
+      expect(row.key_prefix).toBe(plainKey.slice(0, 8));
     });
 
     it("preserves local admin_password_hash and jwt_secret on import", async () => {

--- a/tests/admin-monitor.test.ts
+++ b/tests/admin-monitor.test.ts
@@ -139,4 +139,13 @@ describe("Admin Monitor API", () => {
       expect(res.statusCode).toBe(401);
     }
   });
+
+  it("GET /admin/api/monitor/request/:id returns 404 for unknown id", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: "/admin/api/monitor/request/nonexistent-id",
+      headers: { cookie },
+    });
+    expect(res.statusCode).toBe(404);
+  });
 });

--- a/tests/admin-settings.test.ts
+++ b/tests/admin-settings.test.ts
@@ -113,4 +113,37 @@ describe("Admin Settings API", () => {
     expect(res.statusCode).toBe(200);
     expect(res.json()).toEqual({ days: 0 });
   });
+
+  it("GET /settings/db-size returns defaults", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: "/admin/api/settings/db-size",
+      headers: { cookie },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.thresholds.dbMaxSizeMb).toBe(1024);
+    expect(body.thresholds.logTableMaxSizeMb).toBe(800);
+  });
+
+  it("PUT /settings/db-size-thresholds updates values", async () => {
+    const putRes = await app.inject({
+      method: "PUT",
+      url: "/admin/api/settings/db-size-thresholds",
+      payload: { dbMaxSizeMb: 2048, logTableMaxSizeMb: 1600 },
+      headers: { cookie },
+    });
+    expect(putRes.statusCode).toBe(200);
+    expect(putRes.json()).toEqual({ dbMaxSizeMb: 2048, logTableMaxSizeMb: 1600 });
+  });
+
+  it("PUT /settings/db-size-thresholds rejects invalid values", async () => {
+    const res = await app.inject({
+      method: "PUT",
+      url: "/admin/api/settings/db-size-thresholds",
+      payload: { dbMaxSizeMb: -1 },
+      headers: { cookie },
+    });
+    expect(res.statusCode).toBe(400);
+  });
 });

--- a/tests/db-size-monitor.test.ts
+++ b/tests/db-size-monitor.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { initDatabase } from "../src/db/index.js";
+import { setSetting } from "../src/db/settings.js";
+import { insertRequestLog } from "../src/db/logs.js";
+import {
+  collectDbSizeInfo,
+  runSizeBasedCleanup,
+  scheduleDbSizeMonitor,
+} from "../src/db/db-size-monitor.js";
+
+describe("DbSizeMonitor", () => {
+  let db: ReturnType<typeof initDatabase>;
+
+  beforeEach(() => {
+    db = initDatabase(":memory:");
+    setSetting(db, "encryption_key", "a".repeat(64));
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  function seedLog(id: string, bodySize: number, createdAt?: string) {
+    const body = "x".repeat(bodySize);
+    insertRequestLog(db, {
+      id,
+      api_type: "openai",
+      model: "test-model",
+      provider_id: null,
+      status_code: 200,
+      latency_ms: 100,
+      is_stream: 0,
+      error_message: null,
+      created_at: createdAt ?? new Date().toISOString(),
+      client_request: body,
+      upstream_request: null,
+      upstream_response: null,
+    });
+  }
+
+  describe("collectDbSizeInfo", () => {
+    it("returns zero log size for empty database", () => {
+      const info = collectDbSizeInfo(db, ":memory:");
+      expect(info.logTableBytes).toBe(0);
+      expect(info.logCount).toBe(0);
+      expect(info.totalBytes).toBe(0);
+    });
+
+    it("estimates log table size with records", () => {
+      seedLog("log-1", 1000);
+      seedLog("log-2", 2000);
+      const info = collectDbSizeInfo(db, ":memory:");
+      expect(info.logCount).toBe(2);
+      expect(info.logTableBytes).toBeGreaterThanOrEqual(3000);
+    });
+  });
+
+  describe("runSizeBasedCleanup", () => {
+    it("does nothing when under threshold", () => {
+      seedLog("log-1", 100);
+      const deleted = runSizeBasedCleanup(db, ":memory:", {
+        dbMaxSizeMb: 1024,
+        logTableMaxSizeMb: 800,
+      });
+      expect(deleted).toBe(0);
+    });
+
+    it("deletes oldest logs when over threshold", () => {
+      for (let i = 0; i < 5; i++) {
+        const ts = new Date(Date.now() - (5 - i) * 60000).toISOString();
+        seedLog(`log-${i}`, 500, ts);
+      }
+      const deleted = runSizeBasedCleanup(db, ":memory:", {
+        dbMaxSizeMb: 1024,
+        logTableMaxSizeMb: 0,
+      });
+      expect(deleted).toBeGreaterThan(0);
+    });
+  });
+
+  describe("scheduleDbSizeMonitor", () => {
+    it("returns a handle with stop function", () => {
+      const handle = scheduleDbSizeMonitor(db, ":memory:", {
+        intervalMs: 60000,
+        log: { info: vi.fn() },
+      });
+      expect(handle.stop).toBeTypeOf("function");
+      handle.stop();
+    });
+  });
+});

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -39,7 +39,7 @@ describe("initDatabase", () => {
       .prepare("SELECT name FROM migrations")
       .all() as { name: string }[];
 
-    expect(rows.length).toBe(21);
+    expect(rows.length).toBe(22);
     expect(rows[0].name).toBe("001_init.sql");
     expect(rows[1].name).toBe("002_add_request_response_body.sql");
     expect(rows[2].name).toBe("003_add_full_request_chain_log.sql");
@@ -114,6 +114,19 @@ describe("initDatabase", () => {
       .get("map-1") as any;
     expect(row.client_model).toBe("gpt-4");
     expect(row.backend_model).toBe("gpt-4-turbo");
+  });
+
+  it("creates request_logs with session_id column", () => {
+    db = initDatabase(":memory:");
+    const info = db.pragma("table_info(request_logs)") as { name: string }[];
+    const columnNames = info.map(c => c.name);
+    expect(columnNames).toContain("session_id");
+  });
+
+  it("sets auto_vacuum to INCREMENTAL (2)", () => {
+    db = initDatabase(":memory:");
+    const [{ auto_vacuum }] = db.pragma("auto_vacuum") as { auto_vacuum: number }[];
+    expect(auto_vacuum).toBe(2);
   });
 
   it("should enforce UNIQUE on client_model", () => {

--- a/tests/log-cleaner.test.ts
+++ b/tests/log-cleaner.test.ts
@@ -43,4 +43,20 @@ describe("LogCleaner", () => {
     insertLog("old", 30);
     expect(runLogCleanup(db)).toBe(0);
   });
+
+  it("runs incremental_vacuum after deleting logs", () => {
+    setLogRetentionDays(db, 3);
+    insertLog("old", 5);
+    insertLog("recent", 1);
+    const beforePages = (db.pragma("page_count") as { page_count: number }[])[0].page_count;
+    runLogCleanup(db);
+    const afterPages = (db.pragma("page_count") as { page_count: number }[])[0].page_count;
+    expect(afterPages).toBeLessThanOrEqual(beforePages);
+  });
+
+  it("does not run incremental_vacuum when no logs deleted", () => {
+    setLogRetentionDays(db, 3);
+    insertLog("recent", 1);
+    expect(() => runLogCleanup(db)).not.toThrow();
+  });
 });

--- a/tests/metrics-extractor.test.ts
+++ b/tests/metrics-extractor.test.ts
@@ -141,6 +141,79 @@ describe("MetricsExtractor - Anthropic streaming", () => {
     expect(metrics.ttft_ms).not.toBeNull();
   });
 
+  it("should fallback input_tokens from message_delta when message_start has no usage (third-party compatible API)", () => {
+    const extractor = new MetricsExtractor("anthropic", MOCK_NOW);
+
+    // message_start 不带 usage（第三方 API 可能如此）
+    extractor.processEvent(
+      makeEvent("message_start", JSON.stringify({
+        type: "message_start",
+        message: {},
+      })),
+    );
+
+    expect(extractor.getMetrics().input_tokens).toBeNull();
+
+    // content_block_delta 触发 TTFT
+    vi.advanceTimersByTime(100);
+    extractor.processEvent(
+      makeEvent("content_block_delta", JSON.stringify({
+        type: "content_block_delta",
+        delta: { type: "text_delta", text: "Hi" },
+      })),
+    );
+
+    // message_delta 同时携带 output_tokens 和 input_tokens（OpenRouter/智谱 模式）
+    vi.advanceTimersByTime(200);
+    extractor.processEvent(
+      makeEvent("message_delta", JSON.stringify({
+        type: "message_delta",
+        delta: { stop_reason: "end_turn" },
+        usage: { output_tokens: 30, input_tokens: 500 },
+      })),
+    );
+
+    extractor.processEvent(
+      makeEvent("message_stop", JSON.stringify({ type: "message_stop" })),
+    );
+
+    const metrics = extractor.getMetrics();
+    expect(metrics.input_tokens).toBe(500);
+    expect(metrics.output_tokens).toBe(30);
+    expect(metrics.stop_reason).toBe("end_turn");
+    expect(metrics.is_complete).toBe(1);
+  });
+
+  it("should not override input_tokens from message_start when message_delta also has input_tokens", () => {
+    const extractor = new MetricsExtractor("anthropic", MOCK_NOW);
+
+    extractor.processEvent(
+      makeEvent("message_start", JSON.stringify({
+        type: "message_start",
+        message: { usage: { input_tokens: 800 } },
+      })),
+    );
+
+    vi.advanceTimersByTime(100);
+    extractor.processEvent(
+      makeEvent("content_block_delta", JSON.stringify({
+        type: "content_block_delta",
+        delta: { type: "text_delta", text: "Hi" },
+      })),
+    );
+
+    extractor.processEvent(
+      makeEvent("message_delta", JSON.stringify({
+        type: "message_delta",
+        delta: { stop_reason: "end_turn" },
+        usage: { output_tokens: 20, input_tokens: 999 },
+      })),
+    );
+
+    // message_start 的值优先，不被 message_delta 覆盖
+    expect(extractor.getMetrics().input_tokens).toBe(800);
+  });
+
   it("should set ttft_ms=null when stream interrupted before any content", () => {
     const extractor = new MetricsExtractor("anthropic", MOCK_NOW);
 

--- a/tests/metrics.test.ts
+++ b/tests/metrics.test.ts
@@ -29,7 +29,7 @@ describe("request_metrics migration and insertMetrics", () => {
       .prepare("SELECT name FROM migrations")
       .all() as { name: string }[];
 
-    expect(rows).toHaveLength(21);
+    expect(rows).toHaveLength(22);
     expect(rows[5].name).toBe("006_create_request_metrics.sql");
     expect(rows[6].name).toBe("007_add_retry_fields.sql");
     expect(rows[7].name).toBe("008_create_router_keys.sql");

--- a/tests/recommended.test.ts
+++ b/tests/recommended.test.ts
@@ -76,17 +76,19 @@ describe('recommended API endpoints', () => {
   let app: FastifyInstance
   let db: Database.Database
   let cookie: string
+  let close: () => Promise<void>
 
   beforeEach(async () => {
     db = initDatabase(':memory:')
     seedAuthSettings(db)
     const result = await buildApp({ db })
     app = result.app
+    close = result.close
     cookie = await login(app)
   })
 
   afterEach(async () => {
-    await app.close()
+    await close()
   })
 
   it('GET /recommended/providers returns preset list', async () => {


### PR DESCRIPTION
## Summary

- **DB Vacuum 优化**: `auto_vacuum = INCREMENTAL` + `incremental_vacuum` 日志清理后回收空间；新增 `vacuum-migrate.js` 脚本供已有大库一次性迁移
- **Session ID**: 全栈传递 `x-claude-code-session-id`，从 proxy-handler → log-helpers → DB → 前端请求详情展示
- **Pending 请求内容**: ActiveRequest 内存存储 clientRequest，新增 `GET /monitor/request/:id` API，前端 pending 时从内存获取请求内容
- **Storage Monitor**: 新增 DB 大小监控 + 阈值清理（DbSizeMonitor），Settings 页面可视化存储使用情况
- **配置导入导出**: Admin Settings 支持 JSON 格式的配置导入导出（providers, mappings, retry_rules, router_keys, settings）
- **Metrics 修复**: 第三方 Anthropic 兼容 API（智谱/OpenRouter）从 `message_delta` 回退提取 `input_tokens`；修复流式请求 SSE 广播时序问题（最终指标在 `request_complete` 事件中完整推送）
- **流式响应内容序列化**: 修复 thinking/tool_use/text 三类 stream block 的持久化——thinking-only 响应不再丢失内容块，structured response（含 tool_use）的 thinking 和 text 块也会被完整写入 DB；请求详情面板中 provider 名称正确回显
- **前端 UI**: 新增 Settings 页面（存储监控 + 配置管理），请求详情面板改进（pending 提示、session_id 展示、角色 Badge 迁移至 Tailwind utility classes）

## Code Review 修复清单

本次 PR 在 code review 后修复了以下问题：

### Critical
- **SQL 注入防护**: `settings-import-export` 用 `PRAGMA table_info` 白名单过滤用户 JSON 中的列名
- **导入后内存刷新**: import 完成后自动刷新 RetryRuleMatcher、SemaphoreManager、ModelStateManager 缓存
- **encryption_key 保护**: 加入 `PROTECTED_SETTING_KEYS`，防止导入覆盖导致已加密数据不可解密

### Major
- **DbSizeMonitor 阈值**: 每次 check 从 DB 读取最新值，Admin API 修改后即时生效
- **deleteOldestLogs 性能**: 分批删除（1000/batch），使用 `rowid` 替代 `id` 子查询
- **Settings.vue 表单校验**: 为 retentionDays/dbMaxSizeMb/logTableMaxSizeMb 添加内联校验 + 错误提示
- **Settings.vue 组件规范**: 原生 `<label>` + `<input>` 改为 Button + ref 触发方式
- **useMonitorData catch**: 仅在 404 时降级到 DB 查询，401/网络错误正常抛出

### Minor
- **metrics-extractor**: `!this.inputTokens` → `this.inputTokens === null`，防止 `input_tokens=0` 误触发 fallback
- **LogCleaner**: 启动清理延迟到下一个 tick，避免阻塞服务启动
- **Magic numbers**: 提取 `BYTES_PER_MB`/`KB_BASE` 等命名常量，移除文件级 eslint-disable
- **Router path**: Settings 导入路径统一使用 `@/views/` 别名
- **Migration 注释**: 说明 `auto_vacuum=2` 对已有数据库需运行 `vacuum-migrate.js`
- **CSS cleanup**: 移除未使用的 badge CSS 类，角色色迁移至 Tailwind utilities
- **Stream block 持久化**: thinking-only 响应的 `client_response` 不再为空；structured response 的 `thinking`/`text` 块在 `tool_use` 存在时也完整写入；`provider_name` 在日志详情中正确回显

## Test plan

- [x] 441 个测试全部通过（`npm test`）
- [x] TypeScript 编译零错误（`npx tsc --noEmit`）
- [x] ESLint 零错误零警告
- [x] Pre-commit hook 全部通过（ESLint + vue-tsc + vue_rules_checker）
- [ ] 手动验证：Settings 页面数值输入校验
- [ ] 手动验证：配置导入导出功能
- [ ] 手动验证：流式请求监控面板 token 指标展示
- [ ] 手动验证：智谱 API 的 input_tokens 回退解析

🤖 Generated with [Claude Code](https://claude.com/claude-code)