### PR TITLE
feat: add provider auto-update script and fix DeepSeek api_type

### DIFF
--- a/docs/provider/doc_url.json
+++ b/docs/provider/doc_url.json
@@ -1,114 +1,310 @@
 {
-  "DeepSeek": {
-    "provider-api": {
-      "doc_url": "https://api-docs.deepseek.com/",
-      "pricing_url": "https://api-docs.deepseek.com/quick_start/pricing",
-      "note": "仅 API 模式；baseUrl: https://api.deepseek.com (OpenAI 格式) / https://api.deepseek.com/anthropic (Anthropic 格式)；deepseek-chat/deepseek-reasoner 将废弃，对应 deepseek-v4-flash/deepseek-v4-pro"
-    }
-  },
-  "百度千帆": {
-    "provider-api": {
-      "doc_url": "https://cloud.baidu.com/doc/WENXINWORKSHOP/s/7ltgucw50",
-      "pricing_url": "https://cloud.baidu.com/doc/WENXINWORKSHOP/s/Slfmc9dds",
-      "note": "仅 API 模式；baseUrl: https://qianfan.baidubce.com/v2；支持 OpenAI 兼容格式"
-    }
-  },
-  "科大讯飞": {
-    "provider-api": {
-      "doc_url": "https://www.xfyun.cn/doc/spark/%E6%8E%A5%E5%8F%A3%E8%AF%B4%E6%98%8E.html",
-      "pricing_url": "https://www.xfyun.cn/doc/spark/%E6%8E%A5%E5%8F%A3%E8%AF%B4%E6%98%8E.html",
-      "note": "仅 API 模式；baseUrl: https://spark-api-open.xf-yun.com/v1；支持 OpenAI 兼容格式"
-    }
-  },
-  "硅基流动": {
-    "provider-api": {
-      "doc_url": "https://docs.siliconflow.cn/",
-      "pricing_url": "https://siliconflow.cn/pricing",
-      "note": "仅 API 模式；baseUrl: https://api.siliconflow.cn/v1；聚合多家开源模型"
-    }
-  },
-  "智谱": {
-    "provider-api": {
-      "doc_url": "https://open.bigmodel.cn/dev/api",
-      "pricing_url": "https://open.bigmodel.cn/pricing",
-      "note": "API 模式 (OpenAI 格式)；baseUrl: https://open.bigmodel.cn/api/paas/v4"
+  "deepseek": {
+    "group": "DeepSeek",
+    "plan": "Anthropic",
+    "apiType": "anthropic",
+    "baseUrl": "https://api.deepseek.com/anthropic",
+    "urls": {
+      "overview": "https://api-docs.deepseek.com/",
+      "models": "https://api-docs.deepseek.com/quick_start/pricing",
+      "api_reference": "https://api-docs.deepseek.com/api/create-chat-completion",
+      "pricing": "https://api-docs.deepseek.com/quick_start/pricing",
+      "integration": null,
+      "changelog": null
     },
-    "provider-coding-plan": {
-      "doc_url": "https://open.bigmodel.cn/dev/api/anthropic",
-      "pricing_url": "https://open.bigmodel.cn/pricing",
-      "note": "Coding Plan (Anthropic 格式)；baseUrl: https://open.bigmodel.cn/api/anthropic；面向编码场景，模型如 glm-5.1/glm-5/glm-4.7"
-    }
+    "pages": [],
+    "note": "deepseek-chat/reasoner 将于 2026/07/24 废弃，对应 deepseek-v4-flash/v4-pro"
   },
-  "KIMI": {
-    "provider-api": {
-      "doc_url": "https://platform.moonshot.cn/docs",
-      "pricing_url": "https://platform.moonshot.cn/docs/pricing/chat",
-      "note": "API 模式 (OpenAI 格式)；baseUrl: https://api.moonshot.cn；模型如 kimi-k2.6/kimi-k2.5/moonshot-v1-128k"
+  "deepseek-openai": {
+    "group": "DeepSeek",
+    "plan": "OpenAI",
+    "apiType": "openai",
+    "baseUrl": "https://api.deepseek.com",
+    "urls": {
+      "overview": "https://api-docs.deepseek.com/",
+      "models": "https://api-docs.deepseek.com/quick_start/pricing",
+      "api_reference": "https://api-docs.deepseek.com/api/create-chat-completion",
+      "pricing": "https://api-docs.deepseek.com/quick_start/pricing",
+      "integration": null,
+      "changelog": null
     },
-    "provider-coding-plan": {
-      "doc_url": "https://platform.moonshot.cn/docs/coding",
-      "pricing_url": "https://platform.moonshot.cn/docs/pricing/chat",
-      "note": "Coding Plan (Anthropic 格式)；baseUrl: https://api.kimi.com/coding；面向编码场景，模型如 kimi-for-coding/kimi-k2.5"
-    }
+    "pages": [],
+    "note": "OpenAI 兼容格式接入"
   },
-  "Minimax": {
-    "provider-api": {
-      "doc_url": "https://platform.minimaxi.com/docs/guides/models-intro",
-      "pricing_url": "https://platform.minimaxi.com/docs/pricing/overview",
-      "note": "API 模式 (OpenAI 格式)；baseUrl: https://api.minimax.chat；模型如 MiniMax-M2.7/M2.5/M2.1"
+  "qianfan": {
+    "group": "百度千帆",
+    "plan": "API",
+    "apiType": "openai",
+    "baseUrl": "https://qianfan.baidubce.com/v2",
+    "urls": {
+      "overview": "https://cloud.baidu.com/doc/WENXINWORKSHOP/s/7ltgucw50",
+      "models": "https://cloud.baidu.com/doc/qianfan/s/rmh4stp0j",
+      "api_reference": "https://cloud.baidu.com/doc/WENXINWORKSHOP/s/7ltgucw50",
+      "pricing": "https://cloud.baidu.com/doc/WENXINWORKSHOP/s/Slfmc9dds",
+      "integration": null,
+      "changelog": null
     },
-    "provider-token-plan": {
-      "doc_url": "https://platform.minimaxi.com/docs/pricing/overview",
-      "pricing_url": "https://platform.minimaxi.com/subscribe/token-plan",
-      "note": "Token Plan (Anthropic 格式)；baseUrl: https://api.minimaxi.com/anthropic；按 Token 计费，模型如 MiniMax-M2.7"
-    }
+    "pages": [],
+    "note": "OpenAI 兼容格式；当前配置模型几乎全部过时（ernie-4.0/3.5 系列），应更新为 ernie-5.0/4.5-turbo 系列"
   },
-  "火山引擎": {
-    "provider-api": {
-      "doc_url": "https://www.volcengine.com/docs/82379/1099455",
-      "pricing_url": "https://www.volcengine.com/docs/82379/1099455",
-      "note": "API 模式 (OpenAI 格式)；baseUrl: https://ark.cn-beijing.volces.com/api/v3；模型如 doubao-seed 系列"
+  "iflytek-spark": {
+    "group": "科大讯飞",
+    "plan": "API",
+    "apiType": "openai",
+    "baseUrl": "https://spark-api-open.xf-yun.com/v1",
+    "urls": {
+      "overview": "https://www.xfyun.cn/doc/spark/%E6%8E%A5%E5%8F%A3%E8%AF%B4%E6%98%8E.html",
+      "models": "https://www.xfyun.cn/doc/spark/%E6%8E%A5%E5%8F%A3%E8%AF%B4%E6%98%8E.html",
+      "api_reference": "https://www.xfyun.cn/doc/spark/%E6%8E%A5%E5%8F%A3%E8%AF%B4%E6%98%8E.html",
+      "pricing": "https://www.xfyun.cn/doc/spark/%E6%8E%A5%E5%8F%A3%E8%AF%B4%E6%98%8E.html",
+      "integration": null,
+      "changelog": null
     },
-    "provider-coding-plan": {
-      "doc_url": "https://www.volcengine.com/docs/82379/1399568",
-      "pricing_url": "https://www.volcengine.com/docs/82379/1399568",
-      "note": "Coding Plan (Anthropic 格式)；baseUrl: https://ark.cn-beijing.volces.com/api/compatible；聚合多模型如 ark-code/doubao-seed/kimi-k2.5"
-    }
+    "pages": [],
+    "note": "HTTP API 仅 6 个 domain 参数；Max 套餐将于 2026/03 下线，升级为 Ultra"
   },
-  "阿里云": {
-    "provider-api": {
-      "doc_url": "https://help.aliyun.com/zh/model-studio/",
-      "pricing_url": "https://help.aliyun.com/zh/model-studio/models",
-      "note": "API 模式 (OpenAI 兼容)；baseUrl: https://dashscope.aliyuncs.com/compatible-mode；百炼 Model Studio 平台"
+  "siliconflow": {
+    "group": "硅基流动",
+    "plan": "API",
+    "apiType": "openai",
+    "baseUrl": "https://api.siliconflow.cn/v1",
+    "urls": {
+      "overview": "https://docs.siliconflow.cn/",
+      "models": "https://docs.siliconflow.cn/api-reference/models",
+      "api_reference": "https://docs.siliconflow.cn/api-reference/chat-completions/chat-completions",
+      "pricing": "https://siliconflow.cn/pricing",
+      "integration": null,
+      "changelog": null
     },
-    "provider-coding-plan": {
-      "doc_url": "https://help.aliyun.com/zh/model-studio/qwen-api-reference/",
-      "pricing_url": "https://help.aliyun.com/zh/model-studio/models",
-      "note": "Coding Plan (Anthropic 格式)；baseUrl: https://coding.dashscope.aliyuncs.com/apps/anthropic；聚合多模型如 qwen3-coder/kimi-k2.5/glm-5"
-    }
+    "pages": [],
+    "note": "聚合多家开源模型；模型列表通过动态加载的模型广场展示"
   },
-  "腾讯云": {
-    "provider-api": {
-      "doc_url": "https://cloud.tencent.com/document/product/1729",
-      "pricing_url": "https://cloud.tencent.com/document/product/1729/111033",
-      "note": "API 模式 (OpenAI 格式)；baseUrl: https://api.hunyuan.cloud.tencent.com；混元大模型系列"
+  "zhipu": {
+    "group": "智谱",
+    "plan": "API",
+    "apiType": "openai",
+    "baseUrl": "https://open.bigmodel.cn/api/paas/v4",
+    "urls": {
+      "overview": "https://open.bigmodel.cn/dev/api",
+      "models": "https://open.bigmodel.cn/dev/api",
+      "api_reference": "https://open.bigmodel.cn/dev/api",
+      "pricing": "https://open.bigmodel.cn/pricing",
+      "integration": null,
+      "changelog": null
     },
-    "provider-coding-plan": {
-      "doc_url": "https://cloud.tencent.com/document/product/1729/111033",
-      "pricing_url": "https://cloud.tencent.com/document/product/1729/111033",
-      "note": "Coding Plan (Anthropic 格式)；baseUrl: https://api.lkeap.cloud.tencent.com/coding/anthropic；聚合多模型如 tc-code/hunyuan-2.0"
-    }
+    "pages": [],
+    "note": "OpenAI 兼容格式"
   },
-  "阶跃星辰": {
-    "provider-api": {
-      "doc_url": "https://platform.stepfun.com/docs",
-      "pricing_url": "https://platform.stepfun.com/docs",
-      "note": "API 模式 (OpenAI 格式)；baseUrl: https://api.stepfun.com；模型如 step-3.5-flash/step-3/step-2"
+  "zhipu-coding-plan": {
+    "group": "智谱",
+    "plan": "Coding Plan",
+    "apiType": "anthropic",
+    "baseUrl": "https://open.bigmodel.cn/api/anthropic",
+    "urls": {
+      "overview": "https://open.bigmodel.cn/dev/api/anthropic",
+      "models": "https://open.bigmodel.cn/dev/api/anthropic",
+      "api_reference": "https://open.bigmodel.cn/dev/api/anthropic",
+      "pricing": "https://open.bigmodel.cn/pricing",
+      "integration": null,
+      "changelog": null
     },
-    "provider-coding-plan": {
-      "doc_url": "https://platform.stepfun.com/docs",
-      "pricing_url": "https://platform.stepfun.com/docs",
-      "note": "Step Plan (Anthropic 格式)；baseUrl: https://api.stepfun.com/step_plan；面向编码场景，模型如 step-3.5-flash 系列"
-    }
+    "pages": [],
+    "note": "Coding Plan (Anthropic 格式)；面向编码场景"
+  },
+  "kimi": {
+    "group": "KIMI",
+    "plan": "API",
+    "apiType": "openai",
+    "baseUrl": "https://api.moonshot.cn",
+    "urls": {
+      "overview": "https://platform.moonshot.cn/docs",
+      "models": "https://platform.moonshot.cn/docs/models",
+      "api_reference": "https://platform.moonshot.cn/docs/api/chat",
+      "pricing": "https://platform.moonshot.cn/docs/pricing/chat",
+      "integration": null,
+      "changelog": null
+    },
+    "pages": [],
+    "note": "kimi-k2 系列将于 2026/05/25 下线"
+  },
+  "kimi-coding-plan": {
+    "group": "KIMI",
+    "plan": "Coding Plan",
+    "apiType": "anthropic",
+    "baseUrl": "https://api.kimi.com/coding",
+    "urls": {
+      "overview": "https://platform.moonshot.cn/docs/coding",
+      "models": "https://platform.moonshot.cn/docs/coding",
+      "api_reference": "https://platform.moonshot.cn/docs/coding",
+      "pricing": "https://platform.moonshot.cn/docs/pricing/chat",
+      "integration": null,
+      "changelog": null
+    },
+    "pages": [],
+    "note": "Coding Plan (Anthropic 格式)；面向编码场景"
+  },
+  "minimax": {
+    "group": "Minimax",
+    "plan": "API",
+    "apiType": "openai",
+    "baseUrl": "https://api.minimax.chat",
+    "urls": {
+      "overview": "https://platform.minimaxi.com/docs/guides/models-intro",
+      "models": "https://platform.minimaxi.com/docs/guides/models-intro",
+      "api_reference": "https://platform.minimaxi.com/docs/api-reference/api-overview",
+      "pricing": "https://platform.minimaxi.com/docs/pricing/overview",
+      "integration": null,
+      "changelog": null
+    },
+    "pages": [],
+    "note": "OpenAI 兼容格式；M2.1/M2 已标记为历史模型"
+  },
+  "minimax-token-plan": {
+    "group": "Minimax",
+    "plan": "Token Plan",
+    "apiType": "anthropic",
+    "baseUrl": "https://api.minimaxi.com/anthropic",
+    "urls": {
+      "overview": "https://platform.minimaxi.com/docs/guides/models-intro",
+      "models": null,
+      "api_reference": "https://platform.minimaxi.com/docs/api-reference/api-overview",
+      "pricing": "https://platform.minimaxi.com/docs/pricing/overview",
+      "integration": null,
+      "changelog": null
+    },
+    "pages": [
+      { "id": "token-plan-intro", "url": "https://platform.minimaxi.com/docs/token-plan/intro", "purpose": "plan-overview" },
+      { "id": "token-plan-claude-code", "url": "https://platform.minimaxi.com/docs/token-plan/claude-code", "purpose": "integration" },
+      { "id": "token-plan-quickstart", "url": "https://platform.minimaxi.com/docs/token-plan/quickstart", "purpose": "models-list" }
+    ],
+    "note": "Token Plan (Anthropic 格式)；按 Token 计费；highspeed 版本模型需从 quickstart 页获取"
+  },
+  "volcengine": {
+    "group": "火山引擎",
+    "plan": "API",
+    "apiType": "openai",
+    "baseUrl": "https://ark.cn-beijing.volces.com/api/v3",
+    "urls": {
+      "overview": "https://www.volcengine.com/docs/82379/1099455",
+      "models": "https://www.volcengine.com/docs/82379/1099455",
+      "api_reference": "https://www.volcengine.com/docs/82379/1099455",
+      "pricing": "https://www.volcengine.com/docs/82379/1099455",
+      "integration": null,
+      "changelog": null
+    },
+    "pages": [],
+    "note": "OpenAI 兼容格式；doubao-seed 系列"
+  },
+  "volcengine-coding-plan": {
+    "group": "火山引擎",
+    "plan": "Coding Plan",
+    "apiType": "anthropic",
+    "baseUrl": "https://ark.cn-beijing.volces.com/api/compatible",
+    "urls": {
+      "overview": "https://www.volcengine.com/docs/82379/1399568",
+      "models": "https://www.volcengine.com/docs/82379/1399568",
+      "api_reference": "https://www.volcengine.com/docs/82379/1399568",
+      "pricing": "https://www.volcengine.com/docs/82379/1399568",
+      "integration": null,
+      "changelog": null
+    },
+    "pages": [],
+    "note": "Coding Plan (Anthropic 格式)；聚合 ark-code/doubao-seed/kimi-k2.5/glm 等模型"
+  },
+  "aliyun": {
+    "group": "阿里云",
+    "plan": "API",
+    "apiType": "openai",
+    "baseUrl": "https://dashscope.aliyuncs.com/compatible-mode",
+    "urls": {
+      "overview": "https://help.aliyun.com/zh/model-studio/",
+      "models": "https://help.aliyun.com/zh/model-studio/models",
+      "api_reference": "https://help.aliyun.com/zh/model-studio/developer-reference/use-qwen-by-calling-api",
+      "pricing": "https://help.aliyun.com/zh/model-studio/models",
+      "integration": null,
+      "changelog": null
+    },
+    "pages": [],
+    "note": "百炼 Model Studio；OpenAI 兼容格式"
+  },
+  "aliyun-coding-plan": {
+    "group": "阿里云",
+    "plan": "Coding Plan",
+    "apiType": "anthropic",
+    "baseUrl": "https://coding.dashscope.aliyuncs.com/apps/anthropic",
+    "urls": {
+      "overview": "https://help.aliyun.com/zh/model-studio/coding-plan",
+      "models": "https://help.aliyun.com/zh/model-studio/coding-plan",
+      "api_reference": "https://help.aliyun.com/zh/model-studio/coding-plan",
+      "pricing": "https://help.aliyun.com/zh/model-studio/coding-plan",
+      "integration": null,
+      "changelog": null
+    },
+    "pages": [],
+    "note": "Coding Plan (Anthropic 格式)；聚合 qwen3-coder/kimi-k2.5/glm-5 等"
+  },
+  "tencent": {
+    "group": "腾讯云",
+    "plan": "API",
+    "apiType": "openai",
+    "baseUrl": "https://api.hunyuan.cloud.tencent.com",
+    "urls": {
+      "overview": "https://cloud.tencent.com/document/product/1729",
+      "models": "https://cloud.tencent.com/document/product/1729",
+      "api_reference": "https://cloud.tencent.com/document/product/1729",
+      "pricing": "https://cloud.tencent.com/document/product/1729/111033",
+      "integration": null,
+      "changelog": null
+    },
+    "pages": [],
+    "note": "混元大模型系列；OpenAI 兼容格式"
+  },
+  "tencent-coding-plan": {
+    "group": "腾讯云",
+    "plan": "Coding Plan",
+    "apiType": "anthropic",
+    "baseUrl": "https://api.lkeap.cloud.tencent.com/coding/anthropic",
+    "urls": {
+      "overview": "https://cloud.tencent.com/document/product/1772/128947",
+      "models": "https://cloud.tencent.com/document/product/1772/128947",
+      "api_reference": "https://cloud.tencent.com/document/product/1772/128947",
+      "pricing": "https://cloud.tencent.com/document/product/1772/128947",
+      "integration": null,
+      "changelog": null
+    },
+    "pages": [],
+    "note": "Coding Plan (Anthropic 格式)；hunyuan-t1/turbos 标注即将下线"
+  },
+  "stepfun": {
+    "group": "阶跃星辰",
+    "plan": "API",
+    "apiType": "openai",
+    "baseUrl": "https://api.stepfun.com",
+    "urls": {
+      "overview": "https://platform.stepfun.com/docs/zh/guides/models",
+      "models": "https://platform.stepfun.com/docs/zh/guides/models",
+      "api_reference": "https://platform.stepfun.com/docs/zh/api/chat-completion",
+      "pricing": "https://platform.stepfun.com/docs/zh/guides/models",
+      "integration": null,
+      "changelog": null
+    },
+    "pages": [],
+    "note": "OpenAI 兼容格式"
+  },
+  "stepfun-step-plan": {
+    "group": "阶跃星辰",
+    "plan": "Step Plan",
+    "apiType": "anthropic",
+    "baseUrl": "https://api.stepfun.com/step_plan",
+    "urls": {
+      "overview": "https://platform.stepfun.com/docs/zh/guides/models",
+      "models": "https://platform.stepfun.com/docs/zh/guides/models",
+      "api_reference": "https://platform.stepfun.com/docs/zh/guides/models",
+      "pricing": "https://platform.stepfun.com/docs/zh/guides/models",
+      "integration": null,
+      "changelog": null
+    },
+    "pages": [],
+    "note": "Step Plan (Anthropic 格式)；面向编码场景"
   }
 }

--- a/scripts/prompts/update-provider-config.md
+++ b/scripts/prompts/update-provider-config.md
@@ -1,0 +1,50 @@
+# LLM 供应商配置更新任务
+
+你是一个 LLM 供应商配置维护助手。请根据文档 URL 更新供应商的模型列表。
+
+## 当前 recommended-providers.json
+
+```json
+// CURRENT_PROVIDERS
+{{CURRENT_PROVIDERS}}
+```
+
+## 当前 doc_url.json
+
+```json
+// CURRENT_DOC_URLS
+{{CURRENT_DOC_URLS}}
+```
+
+## 你的任务
+
+对每个供应商 preset：
+
+1. **抓取文档**：用 WebSearch 和 fetch_markdown 工具访问 urls 中的链接，获取最新模型信息
+2. **更新模型列表**：对比当前 models 数组，添加新模型、标记废弃模型（排在最后加 ` (deprecated)` 后缀）
+3. **补充 URL**：如果发现 urls 中有 null 字段对应的实际页面，补充上去
+
+## 规则
+
+- 不要删除任何 preset，不要修改 presetName / baseUrl / apiType
+- 模型名使用供应商文档中的精确标识符
+- 不确定是否废弃的模型保留不动
+- 不要虚构 URL，找不到的保持 null
+
+## 输出格式
+
+输出两个 JSON 代码块，带标记注释：
+
+### 文件 1: recommended-providers.json
+
+````json
+// OUTPUT_PROVIDERS
+[当前数组的更新版本]
+````
+
+### 文件 2: doc_url.json
+
+````json
+// OUTPUT_DOC_URLS
+{当前对象的更新版本}
+````

--- a/scripts/update-provider-docs.mjs
+++ b/scripts/update-provider-docs.mjs
@@ -1,0 +1,240 @@
+#!/usr/bin/env node
+
+/**
+ * 供应商文档自动更新脚本
+ *
+ * 流程：构建提示词 → claude -p 无头模式 → 解析输出 → 验证 → 差异检测 → 提交 PR
+ *
+ * 用法：node scripts/update-provider-docs.mjs
+ * 前置：claude CLI、gh CLI 已安装并登录
+ */
+
+import { execSync, spawn } from 'node:child_process'
+import { readFileSync, writeFileSync, unlinkSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const CONFIG_PATH = resolve(ROOT, 'config/recommended-providers.json')
+const DOC_URL_PATH = resolve(ROOT, 'docs/provider/doc_url.json')
+const PROMPT_PATH = resolve(ROOT, 'scripts/prompts/update-provider-config.md')
+const BRANCH_PREFIX = 'chore/update-provider-docs'
+const TARGET_BRANCH = 'develop'
+const CLAUDE_TIMEOUT_MS = 600_000
+
+function abort(msg) {
+  console.error(`\n✗ ${msg}`)
+  process.exit(1)
+}
+
+// ── 前置检查 ──────────────────────────────────────
+
+function checkPrerequisites() {
+  for (const cmd of ['claude', 'gh', 'git']) {
+    try { execSync(`which ${cmd}`, { stdio: 'pipe' }) }
+    catch { abort(`缺少命令行工具: ${cmd}`) }
+  }
+  const status = execSync('git status --porcelain', { cwd: ROOT, encoding: 'utf-8' })
+  if (status.trim()) abort('工作树不干净，请先提交或暂存更改')
+}
+
+// ── 分支管理 ──────────────────────────────────────
+
+function createBranch() {
+  const ts = new Date().toISOString().slice(0, 10).replace(/-/g, '')
+  const branch = `${BRANCH_PREFIX}-${ts}`
+  execSync(`git fetch origin ${TARGET_BRANCH}`, { cwd: ROOT, stdio: 'pipe' })
+  try {
+    execSync(`git checkout -b ${branch} origin/${TARGET_BRANCH}`, { cwd: ROOT, stdio: 'pipe' })
+  } catch {
+    const suffix = new Date().toISOString().slice(11, 13) + new Date().toISOString().slice(14, 16)
+    const retry = `${branch}-${suffix}`
+    execSync(`git checkout -b ${retry} origin/${TARGET_BRANCH}`, { cwd: ROOT, stdio: 'pipe' })
+    return retry
+  }
+  return branch
+}
+
+function cleanup(branch) {
+  try {
+    execSync(`git checkout ${TARGET_BRANCH}`, { cwd: ROOT, stdio: 'pipe' })
+    execSync(`git branch -D ${branch}`, { cwd: ROOT, stdio: 'pipe' })
+  } catch { /* best effort */ }
+}
+
+// ── 构建提示词 ──────────────────────────────────────
+
+function buildPrompt(providers, docUrls) {
+  const template = readFileSync(PROMPT_PATH, 'utf-8')
+  return template
+    .replace('{{CURRENT_PROVIDERS}}', JSON.stringify(providers, null, 2))
+    .replace('{{CURRENT_DOC_URLS}}', JSON.stringify(docUrls, null, 2))
+}
+
+// ── 调用 Claude CLI ──────────────────────────────────
+
+async function callClaude(prompt) {
+  const tmpFile = resolve(ROOT, `.tmp-claude-prompt-${Date.now()}.md`)
+  writeFileSync(tmpFile, prompt)
+
+  try {
+    return await new Promise((resolve, reject) => {
+      const child = spawn('claude', ['-p', '--dangerously-skip-permissions'], {
+        cwd: ROOT,
+        stdio: ['pipe', 'pipe', 'pipe'],
+        env: { ...process.env },
+      })
+
+      let stdout = '', stderr = ''
+      child.stdout.on('data', d => { stdout += d })
+      child.stderr.on('data', d => { stderr += d })
+
+      const timer = setTimeout(() => {
+        child.kill('SIGTERM')
+        reject(new Error('claude -p 超时 (10min)'))
+      }, CLAUDE_TIMEOUT_MS)
+
+      child.on('close', code => {
+        clearTimeout(timer)
+        code === 0 ? resolve(stdout) : reject(new Error(`claude 退出码 ${code}: ${stderr.slice(0, 500)}`))
+      })
+
+      child.stdin.write(prompt)
+      child.stdin.end()
+    })
+  } finally {
+    try { unlinkSync(tmpFile) } catch { /* */ }
+  }
+}
+
+// ── 输出解析 ──────────────────────────────────────
+
+function extractJsonBlock(output, marker) {
+  const tagged = new RegExp('```json\\s*\\n//\\s*' + marker + '\\s*\\n([\\s\\S]*?)```')
+  const m = output.match(tagged)
+  if (m) return m[1].trim()
+
+  const blocks = [...output.matchAll(/```json\s*\n([\s\S]*?)```/g)].map(b => b[1].trim())
+  if (marker === 'OUTPUT_PROVIDERS') {
+    return blocks.find(b => b.startsWith('[')) || null
+  }
+  return blocks.find(b => b.startsWith('{') && b.includes('"urls"')) || null
+}
+
+function parseOutput(output) {
+  const providersRaw = extractJsonBlock(output, 'OUTPUT_PROVIDERS')
+  const docUrlsRaw = extractJsonBlock(output, 'OUTPUT_DOC_URLS')
+
+  if (!providersRaw && !docUrlsRaw) {
+    const debugPath = `/tmp/provider-update-raw-${Date.now()}.txt`
+    writeFileSync(debugPath, output)
+    abort(`无法从 Claude 输出中提取 JSON，原始输出已保存到 ${debugPath}`)
+  }
+
+  return {
+    providers: providersRaw ? JSON.parse(providersRaw) : null,
+    docUrls: docUrlsRaw ? JSON.parse(docUrlsRaw) : null,
+  }
+}
+
+// ── 验证 ──────────────────────────────────────────
+
+function validateProviders(data) {
+  if (!Array.isArray(data)) abort('providers 必须是数组')
+  for (const group of data) {
+    if (!group.group || !Array.isArray(group.presets)) abort(`无效的 group: ${JSON.stringify(group).slice(0, 80)}`)
+    for (const p of group.presets) {
+      if (!p.presetName || !p.baseUrl || !p.models || !p.apiType)
+        abort(`无效的 preset: ${JSON.stringify(p).slice(0, 80)}`)
+    }
+  }
+}
+
+function validateDocUrls(data) {
+  if (typeof data !== 'object' || data === null) abort('doc_urls 必须是对象')
+  for (const [key, val] of Object.entries(data)) {
+    if (!val.group || !val.urls) abort(`无效的 doc_url 条目: ${key}`)
+  }
+}
+
+// ── 提交与 PR ──────────────────────────────────────
+
+function commitAndPR(branch, providersChanged, docUrlsChanged) {
+  const files = []
+  if (providersChanged) files.push(CONFIG_PATH)
+  if (docUrlsChanged) files.push(DOC_URL_PATH)
+
+  execSync(`git add ${files.join(' ')}`, { cwd: ROOT })
+  const date = new Date().toISOString().slice(0, 10)
+  execSync(`git commit -m "chore: update provider docs and models ${date} [automated]"`, { cwd: ROOT })
+  execSync(`git push -u origin ${branch}`, { cwd: ROOT })
+
+  const body = [
+    'Automated provider documentation and model list update.',
+    '',
+    '## Changes',
+    `- ${providersChanged ? 'Models updated' : 'Models unchanged'}`,
+    `- ${docUrlsChanged ? 'Doc URLs updated' : 'Doc URLs unchanged'}`,
+    '',
+    'Generated by `scripts/update-provider-docs.mjs`',
+  ].join('\n')
+
+  execSync(
+    `gh pr create --base ${TARGET_BRANCH} --title "chore: update provider docs and models ${date}" --body ${JSON.stringify(body)}`,
+    { cwd: ROOT, encoding: 'utf-8' },
+  )
+  console.log(`PR created on branch ${branch}`)
+}
+
+// ── 主流程 ──────────────────────────────────────
+
+async function main() {
+  console.log('1. 前置检查...')
+  checkPrerequisites()
+
+  console.log('2. 加载配置...')
+  const currentProviders = JSON.parse(readFileSync(CONFIG_PATH, 'utf-8'))
+  const currentDocUrls = JSON.parse(readFileSync(DOC_URL_PATH, 'utf-8'))
+
+  console.log('3. 创建分支...')
+  const branch = createBranch()
+
+  try {
+    console.log('4. 构建提示词...')
+    const prompt = buildPrompt(currentProviders, currentDocUrls)
+
+    console.log('5. 调用 Claude CLI (可能需要几分钟)...')
+    const output = await callClaude(prompt)
+
+    console.log('6. 解析输出...')
+    const { providers: newProviders, docUrls: newDocUrls } = parseOutput(output)
+
+    console.log('7. 验证...')
+    if (newProviders) validateProviders(newProviders)
+    if (newDocUrls) validateDocUrls(newDocUrls)
+
+    const providersChanged = newProviders
+      && JSON.stringify(newProviders) !== JSON.stringify(currentProviders)
+    const docUrlsChanged = newDocUrls
+      && JSON.stringify(newDocUrls) !== JSON.stringify(currentDocUrls)
+
+    if (!providersChanged && !docUrlsChanged) {
+      console.log('没有检测到变更。')
+      cleanup(branch)
+      return
+    }
+
+    console.log(`8. 写入更新 (providers: ${!!providersChanged}, docUrls: ${!!docUrlsChanged})...`)
+    if (providersChanged) writeFileSync(CONFIG_PATH, JSON.stringify(newProviders, null, 2) + '\n')
+    if (docUrlsChanged) writeFileSync(DOC_URL_PATH, JSON.stringify(newDocUrls, null, 2) + '\n')
+
+    console.log('9. 提交并创建 PR...')
+    commitAndPR(branch, !!providersChanged, !!docUrlsChanged)
+  } catch (err) {
+    console.error(`\n✗ 执行失败: ${err.message}`)
+    cleanup(branch)
+    process.exit(1)
+  }
+}
+
+main()


### PR DESCRIPTION
## Summary

- 添加 provider 文档自动更新脚本（`scripts/update-provider-docs.mjs`），支持从官方文档抓取模型列表并更新推荐配置
- 新增 `docs/provider/doc_url.json` 存储 provider 文档 URL 映射
- 修正 DeepSeek 默认 api_type 为 Anthropic 格式，修复硬编码 api_type 问题

## Test plan

- [ ] 运行 `node scripts/update-provider-docs.mjs` 验证脚本正常执行
- [ ] 确认 `config/recommended-providers.json` 中 DeepSeek 配置正确
- [ ] 前端 Provider 页面功能正常