### PR TITLE
fix: remove DEFAULT_RETRY_CAP that silently overrides retry rule max_retries

### DIFF
--- a/src/proxy/resilience.ts
+++ b/src/proxy/resilience.ts
@@ -39,8 +39,6 @@ export interface ResilienceConfig {
   failoverThreshold: number;
   ruleMatcher?: RetryRuleMatcher;
   isFailover: boolean;
-  /** DB 规则 max_retries 的全局安全阀，防止单规则配置导致过多重试 */
-  globalRetryCap?: number;
   /** 全局迭代上限，防止极端配置导致 while(true) 循环过多 */
   iterationCap?: number;
 }
@@ -81,7 +79,6 @@ export interface ResilienceState {
 const RETRYABLE_THROW_CODES = new Set(["ETIMEDOUT", "ECONNRESET", "ECONNREFUSED"]);
 const HTTP_TOO_MANY_REQUESTS = 429;
 const DEFAULT_THROW_MAX_RETRIES = 3;
-const DEFAULT_RETRY_CAP = 3;
 const DEFAULT_ITERATION_CAP = 50;
 
 // ---------- Internal helpers ----------
@@ -161,7 +158,7 @@ export class ResilienceLayer {
         ? config.ruleMatcher.match(result.statusCode, body)
         : null;
 
-      if (matchedRule && state.attemptCount < Math.min(matchedRule.max_retries, config.globalRetryCap ?? DEFAULT_RETRY_CAP)) {
+      if (matchedRule && state.attemptCount < matchedRule.max_retries) {
         const strategy = createStrategy(matchedRule);
         const headers = extractHeaders(result);
         const retryAfterMs = result.statusCode === HTTP_TOO_MANY_REQUESTS
@@ -178,7 +175,7 @@ export class ResilienceLayer {
     const body = extractBody(result);
     if (body && config.ruleMatcher) {
       const matchedRule = config.ruleMatcher.match(result.statusCode, body);
-      if (matchedRule && state.attemptCount < Math.min(matchedRule.max_retries, config.globalRetryCap ?? DEFAULT_RETRY_CAP)) {
+      if (matchedRule && state.attemptCount < matchedRule.max_retries) {
         const strategy = createStrategy(matchedRule);
         return { action: "retry", delayMs: strategy.getDelay(state.attemptCount) };
       }


### PR DESCRIPTION
## Summary
- `DEFAULT_RETRY_CAP = 3` 在 `resilience.ts` 中通过 `Math.min()` 将用户在 Retry Rules 中配置的 `max_retries` 截断为 3，导致配置值不生效
- 该常量与 `retry_rules.max_retries` 重复作用（同一个决策中的两个限制取较小值），直接删除以 rules 配置为准
- 同步清理 `ResilienceConfig.globalRetryCap` 死代码字段（从未被任何调用方赋值）

## 分析

`decide()` 的决策树中各分支互斥：
- **HTTP 错误分支**（有 statusCode/body）：由 retry rules 的 `max_retries` 控制 → `DEFAULT_RETRY_CAP` 与之重复，已删除
- **throw 分支**（网络异常，无 HTTP 响应）：由 `DEFAULT_THROW_MAX_RETRIES` 控制 → retry rules 无法介入（没有 statusCode/body），保留不动

## Test plan
- [x] 518 个现有测试全部通过
- [x] resilience.test.ts 30 个测试全部通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)