### PR TITLE
fix: 修复流式代理 mid-stream error 导致进程 crash

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "llm-simple-router",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "LLM API proxy router with OpenAI/Anthropic support, model mapping, retry strategies, and admin dashboard",
   "license": "MIT",
   "author": "ZZzzswszzZZ",

--- a/src/proxy/orchestrator.ts
+++ b/src/proxy/orchestrator.ts
@@ -158,6 +158,10 @@ export class ProxyOrchestrator {
     if (result.kind === "stream_success" || result.kind === "stream_abort" || result.kind === "throw") {
       return;
     }
+    // stream_error 且 headers 已发送：StreamProxy 已处理响应，无需再次写入
+    if (result.kind === "stream_error" && result.headersSent) {
+      return;
+    }
     // failover 场景下错误响应由外层 proxy-handler 控制，此处不发送
     if (ctx?.isFailover && "statusCode" in result && result.statusCode >= (ctx.failoverThreshold ?? DEFAULT_FAILOVER_THRESHOLD)) {
       return;

--- a/src/proxy/proxy-handler.ts
+++ b/src/proxy/proxy-handler.ts
@@ -298,6 +298,10 @@ async function executeFailoverLoop(ctx: FailoverContext): Promise<FastifyReply> 
       return reply;
     } catch (e) {
       if (e instanceof ProviderSwitchNeeded) {
+        // headers 已发送给客户端时不能 failover，直接返回
+        if (reply.raw.headersSent) {
+          return reply;
+        }
         // 跨 provider failover：resilience 层携带了 attempts 数据，补写失败日志
         if (e.attempts && e.attempts.length > 0) {
           const fakeResult = e.lastResult ?? { kind: "throw" as const, error: new Error("provider switch") };

--- a/src/proxy/proxy-handler.ts
+++ b/src/proxy/proxy-handler.ts
@@ -136,7 +136,11 @@ export async function handleProxyRequest(
     beforeSendProxy?: (body: Record<string, unknown>, isStream: boolean) => void;
   },
 ): Promise<FastifyReply> {
-  request.raw.socket.on("error", (err) => request.log.debug({ err }, "client socket error"));
+  const socketErrorHandler = (err: Error) => request.log.debug({ err }, "client socket error");
+  request.raw.socket.on("error", socketErrorHandler);
+  reply.raw.on("close", () => {
+    request.raw.socket.removeListener("error", socketErrorHandler);
+  });
   const clientModel = ((request.body as Record<string, unknown>).model as string) || "unknown";
   const sessionId = (request.headers as RawHeaders)["x-claude-code-session-id"] as string | undefined;
   const { effectiveModel, originalModel, interceptResponse } = applyEnhancement(deps.db, request, clientModel, sessionId);

--- a/src/proxy/resilience.ts
+++ b/src/proxy/resilience.ts
@@ -157,6 +157,10 @@ export class ResilienceLayer {
 
     // throw -> 网络异常
     if (result.kind === "throw") {
+      // headers 已发送给客户端时不能 retry/failover
+      if (result.headersSent) {
+        return { action: "abort", reason: "throw_headers_sent" };
+      }
       if (!isRetryableThrow(result.error)) {
         return { action: "abort", reason: result.error.message };
       }

--- a/src/proxy/resilience.ts
+++ b/src/proxy/resilience.ts
@@ -128,6 +128,10 @@ export class ResilienceLayer {
     // stream_error + statusCode < failoverThreshold -> 上游返回 200 但 body 包含错误内容（early error）
     // 先检查 retry rules 是否匹配，匹配则重试，否则不可恢复
     if (result.kind === "stream_error" && result.statusCode < config.failoverThreshold) {
+      // headers 已发送给客户端时不能 retry/failover，只能 abort
+      if (result.headersSent) {
+        return { action: "abort", reason: "stream_error_headers_sent" };
+      }
       const body = extractBody(result);
       if (body && config.ruleMatcher) {
         const matchedRule = config.ruleMatcher.match(result.statusCode, body);

--- a/src/proxy/stream-proxy.ts
+++ b/src/proxy/stream-proxy.ts
@@ -89,7 +89,7 @@ class StreamProxy {
         result = { kind: "stream_success", ...base, metrics: extra.metrics as MetricsResult | undefined };
         break;
       case "stream_error":
-        result = { kind: "stream_error", ...base, body: extra.body as string, headers: this.sseHeaders, headersSent: extra.headersSent as boolean | undefined };
+        result = { kind: "stream_error", ...base, body: extra.body as string, headers: this.sseHeaders, headersSent: this.headersSent || undefined };
         break;
       case "stream_abort":
         result = { kind: "stream_abort", ...base, metrics: extra.metrics as MetricsResult | undefined };
@@ -198,7 +198,7 @@ class StreamProxy {
       if (this.sseScanBuffer.includes("event: error") || this.sseScanBuffer.includes('"type":"error"')) {
         const body = Buffer.concat(this.captureChunks).toString("utf-8");
         if (this.checkEarlyError(body)) {
-          this.terminal("stream_error", { body, headersSent: true });
+          this.terminal("stream_error", { body });
           // headers 已发送：必须结束 reply 避免 client hang
           if (this.headersSent) {
             setImmediate(() => this.reply.raw.end());

--- a/src/proxy/stream-proxy.ts
+++ b/src/proxy/stream-proxy.ts
@@ -89,7 +89,7 @@ class StreamProxy {
         result = { kind: "stream_success", ...base, metrics: extra.metrics as MetricsResult | undefined };
         break;
       case "stream_error":
-        result = { kind: "stream_error", ...base, body: extra.body as string, headers: this.sseHeaders };
+        result = { kind: "stream_error", ...base, body: extra.body as string, headers: this.sseHeaders, headersSent: extra.headersSent as boolean | undefined };
         break;
       case "stream_abort":
         result = { kind: "stream_abort", ...base, metrics: extra.metrics as MetricsResult | undefined };
@@ -198,9 +198,8 @@ class StreamProxy {
       if (this.sseScanBuffer.includes("event: error") || this.sseScanBuffer.includes('"type":"error"')) {
         const body = Buffer.concat(this.captureChunks).toString("utf-8");
         if (this.checkEarlyError(body)) {
-          this.terminal("stream_error", { body });
+          this.terminal("stream_error", { body, headersSent: true });
           // headers 已发送：必须结束 reply 避免 client hang
-          // headers 未发送：terminal 已处理，无需额外操作
           if (this.headersSent) {
             setImmediate(() => this.reply.raw.end());
           }

--- a/src/proxy/stream-proxy.ts
+++ b/src/proxy/stream-proxy.ts
@@ -105,6 +105,10 @@ class StreamProxy {
         this.pendingResult = result;
       }
     } else {
+      // stream_abort 且 headers 已发送时，必须 end reply 避免客户端挂起
+      if (kind === "stream_abort" && this.headersSent) {
+        try { this.reply.raw.end(); } catch { /* reply may already be destroyed */ }
+      }
       this.cleanup();
       if (this.resolveFn) {
         this.resolveFn(result);
@@ -137,6 +141,13 @@ class StreamProxy {
 
   startStreaming(): void {
     if (this.headersSent) return;
+    if (this.reply.raw.headersSent) {
+      // headers 已由其他代码路径（如前一次 retry 的 StreamProxy）发送，
+      // 仅更新状态机避免 BUFFERING 阶段的重复逻辑
+      this.transition("STREAMING");
+      this.headersSent = true;
+      return;
+    }
     this.transition("STREAMING");
     this.headersSent = true;
     this.reply.raw.writeHead(this.statusCode, this.sseHeaders);
@@ -249,7 +260,7 @@ class StreamProxy {
     if (this.resolved) return;
     this.resolved = true;
     this.cleanup();
-    const result: TransportResult = { kind: "throw", error: err };
+    const result: TransportResult = { kind: "throw", error: err, headersSent: this.headersSent };
     if (this.resolveFn) {
       this.resolveFn(result);
     } else {

--- a/src/proxy/types.ts
+++ b/src/proxy/types.ts
@@ -53,6 +53,8 @@ export type TransportResult =
       body: string;
       headers: Record<string, string>;
       sentHeaders: Record<string, string>;
+      /** 响应 headers 是否已发送给客户端。mid-stream 检测到错误时为 true */
+      headersSent?: boolean;
     }
   | {
       kind: "stream_abort";

--- a/src/proxy/types.ts
+++ b/src/proxy/types.ts
@@ -74,6 +74,8 @@ export type TransportResult =
   | {
       kind: "throw";
       error: Error;
+      /** 响应 headers 是否已发送给客户端。stream 阶段 throw 时为 true */
+      headersSent?: boolean;
     };
 
 /**

--- a/tests/proxy-handler.test.ts
+++ b/tests/proxy-handler.test.ts
@@ -63,7 +63,7 @@ function createRequest(overrides = {}) {
 function createReply() {
   return {
     code: vi.fn().mockReturnThis(), status: vi.fn().mockReturnThis(), send: vi.fn().mockReturnThis(), header: vi.fn().mockReturnThis(),
-    raw: { headersSent: false, writableEnded: false },
+    raw: { headersSent: false, writableEnded: false, on: vi.fn(), removeListener: vi.fn() },
   } as any;
 }
 


### PR DESCRIPTION
## Summary

StreamProxy 在 STREAMING 阶段检测到 SSE error 时，headers 已发送给客户端。但 resilience 层的 failover 机制和 orchestrator 的 sendResponse 不知道这一状态，尝试对同一 reply 再次 `writeHead()`，导致 `ERR_HTTP_HEADERS_SENT` 进程崩溃。

## 根因

三层防御缺口：
1. `StreamProxy.onData()` STREAMING 阶段检测错误 → `terminal("stream_error")` 返回，此时 headers 已发送
2. `resilience.decide()` 看到 `stream_error` + statusCode=200 < failoverThreshold → failover 模式触发 `ProviderSwitchNeeded`
3. `executeFailoverLoop` 切换 provider → 新 `callStream()` → 新 StreamProxy 对同一 reply `writeHead()` → crash

第二路径：非 failover 场景下 `orchestrator.sendResponse()` 对 `stream_error` 没有 early return。

## 修改

| 文件 | 修改 |
|------|------|
| `types.ts` | `stream_error` 添加 `headersSent?: boolean` |
| `stream-proxy.ts` | STREAMING 错误时设 `headersSent: true` |
| `resilience.ts` | `decide()` 检查 `headersSent` → 直接 abort |
| `orchestrator.ts` | `sendResponse()` 对已发送 headers 的 stream_error 提前返回 |
| `proxy-handler.ts` | `ProviderSwitchNeeded` catch 检查 `reply.raw.headersSent` |

## Test plan

- [x] 全部 550 个测试通过
- [ ] 本地 `npx llm-simple-router` 验证 stream error 场景不再 crash

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>