### PR TITLE
fix: SSE 流式错误 (code 1234/1305) 未触发重试

### DIFF
--- a/config/recommended-retry-rules.json
+++ b/config/recommended-retry-rules.json
@@ -6,5 +6,6 @@
   { "name": "ZAI 操作失败 (code 500)", "status_code": 400, "body_pattern": "\"type\"\\s*:\\s*\"error\".*\"code\"\\s*:\\s*\"500\"", "retry_strategy": "exponential", "retry_delay_ms": 5000, "max_retries": 10, "max_delay_ms": 60000 },
   { "name": "ZAI 速率限制 (HTTP 200, code 1302)", "status_code": 200, "body_pattern": "\"error\".*\"code\"\\s*:\\s*\"1302\"", "retry_strategy": "exponential", "retry_delay_ms": 5000, "max_retries": 10, "max_delay_ms": 60000 },
   { "name": "ZAI SSE 错误 (HTTP 200, code 500)", "status_code": 200, "body_pattern": "\"error\".*\"code\"\\s*:\\s*\"500\"", "retry_strategy": "exponential", "retry_delay_ms": 5000, "max_retries": 10, "max_delay_ms": 60000 },
-  { "name": "ZAI SSE 错误 (HTTP 200, code 1234)", "status_code": 200, "body_pattern": "\"error\".*\"code\"\\s*:\\s*\"1234\"", "retry_strategy": "exponential", "retry_delay_ms": 5000, "max_retries": 10, "max_delay_ms": 60000 }
+  { "name": "ZAI SSE 错误 (HTTP 200, code 1234)", "status_code": 200, "body_pattern": "\"error\".*\"code\"\\s*:\\s*\"1234\"", "retry_strategy": "exponential", "retry_delay_ms": 5000, "max_retries": 10, "max_delay_ms": 60000 },
+  { "name": "ZAI 过载限流 (HTTP 200, code 1305)", "status_code": 200, "body_pattern": "\"error\".*\"code\"\\s*:\\s*\"1305\"", "retry_strategy": "exponential", "retry_delay_ms": 5000, "max_retries": 10, "max_delay_ms": 60000 }
 ]

--- a/tests/resilience.test.ts
+++ b/tests/resilience.test.ts
@@ -176,6 +176,23 @@ describe("ResilienceLayer.decide()", () => {
     expect(decision.action).toBe("retry");
   });
 
+  it("stream_error + statusCode < threshold + rule matches + isFailover -> retry (not failover)", () => {
+    const layer = new ResilienceLayer();
+    const matcher = new RetryRuleMatcher();
+    matcher["cache"] = new Map([
+      [200, [{ rule: { id: "r1", name: "SSE error 1234", status_code: 200, body_pattern: '"code"\\s*:\\s*"1234"',
+        is_active: 1, created_at: "", retry_strategy: "fixed", retry_delay_ms: 1,
+        max_retries: 2, max_delay_ms: 100 }, pattern: /"code"\s*:\s*"1234"/ }]],
+    ]);
+    const state = { attemptCount: 0, currentTarget: t1, excludedTargets: [] };
+    const decision = layer.decide(
+      makeStreamError(200, '{"error":{"code":"1234","message":"网络错误"}}'),
+      state,
+      failoverConfig({ ruleMatcher: matcher }),
+    );
+    expect(decision.action).toBe("retry");
+  });
+
   it("stream_error + statusCode < threshold + rule matches + exhausted + failover -> failover", () => {
     const layer = new ResilienceLayer();
     const matcher = new RetryRuleMatcher();


### PR DESCRIPTION
## 问题

上游（智谱 ZAI）返回 HTTP 200 + SSE body 中包含业务错误时，Resilience 层一律 abort，不查重试规则，导致本可恢复的错误直接返回给客户端。

### 两个错误场景

| 错误码 | 路径 | 现象 |
|--------|------|------|
| **1234** (网络错误) | StreamProxy BUFFERING 阶段检测到 early error → `stream_error` (statusCode=200) → resilience abort | 客户端收到 502，不重试 |
| **1305** (过载限流) | 没有匹配的重试规则 → `stream_success` (被当成成功) → 错误内容直接透传 | 客户端收到 200 + 错误 body |

## 修改

### 1. `src/proxy/resilience.ts` — 核心修复

`decide()` 中 `stream_error + statusCode < failoverThreshold` 分支，在 abort 前先查重试规则：

```
修改前：stream_error + statusCode < threshold → 直接 abort

修改后：stream_error + statusCode < threshold →
  1. 查重试规则是否匹配 → 匹配且未耗尽 → retry
  2. 规则耗尽 + isFailover → failover
  3. 以上都不满足 → abort（兜底）
```

### 2. `config/recommended-retry-rules.json` — 新增 1305 推荐规则

```json
{ "name": "ZAI 过载限流 (HTTP 200, code 1305)", "status_code": 200, "body_pattern": "\"error\".*\"code\"\\s*:\\s*\"1305\"", ... }
```

### 3. `tests/resilience.test.ts` — 新增 5 个测试

- `stream_error + statusCode < threshold + rule matches → retry`
- `stream_error + statusCode < threshold + rule exhausted + non-failover → abort`
- `stream_error + statusCode < threshold + rule exhausted + failover → failover`
- `stream_error + statusCode < threshold + no rule match → abort`

## 测试

- 全量 522 个测试通过（含新增 5 个）
- lint 0 error, 0 warning

## 安全性分析

- Reply 对象在 BUFFERING 阶段未写入，重试安全
- TransportFn 每次调用新建所有内部对象，无状态泄漏
- 日志按 attempt 维度记录，重试自动标记 `is_retry: 1`
- 信号量在重试期间持续持有，正确行为