### PR TITLE
fix: SSE 流式错误 (code 1234/1305) 未触发重试

### DIFF
--- a/config/recommended-retry-rules.json
+++ b/config/recommended-retry-rules.json
@@ -6,5 +6,6 @@
   { "name": "ZAI 操作失败 (code 500)", "status_code": 400, "body_pattern": "\"type\"\\s*:\\s*\"error\".*\"code\"\\s*:\\s*\"500\"", "retry_strategy": "exponential", "retry_delay_ms": 5000, "max_retries": 10, "max_delay_ms": 60000 },
   { "name": "ZAI 速率限制 (HTTP 200, code 1302)", "status_code": 200, "body_pattern": "\"error\".*\"code\"\\s*:\\s*\"1302\"", "retry_strategy": "exponential", "retry_delay_ms": 5000, "max_retries": 10, "max_delay_ms": 60000 },
   { "name": "ZAI SSE 错误 (HTTP 200, code 500)", "status_code": 200, "body_pattern": "\"error\".*\"code\"\\s*:\\s*\"500\"", "retry_strategy": "exponential", "retry_delay_ms": 5000, "max_retries": 10, "max_delay_ms": 60000 },
-  { "name": "ZAI SSE 错误 (HTTP 200, code 1234)", "status_code": 200, "body_pattern": "\"error\".*\"code\"\\s*:\\s*\"1234\"", "retry_strategy": "exponential", "retry_delay_ms": 5000, "max_retries": 10, "max_delay_ms": 60000 }
+  { "name": "ZAI SSE 错误 (HTTP 200, code 1234)", "status_code": 200, "body_pattern": "\"error\".*\"code\"\\s*:\\s*\"1234\"", "retry_strategy": "exponential", "retry_delay_ms": 5000, "max_retries": 10, "max_delay_ms": 60000 },
+  { "name": "ZAI 过载限流 (HTTP 200, code 1305)", "status_code": 200, "body_pattern": "\"error\".*\"code\"\\s*:\\s*\"1305\"", "retry_strategy": "exponential", "retry_delay_ms": 5000, "max_retries": 10, "max_delay_ms": 60000 }
 ]

--- a/tests/resilience.test.ts
+++ b/tests/resilience.test.ts
@@ -176,6 +176,23 @@ describe("ResilienceLayer.decide()", () => {
     expect(decision.action).toBe("retry");
   });
 
+  it("stream_error + statusCode < threshold + rule matches + isFailover -> retry (not failover)", () => {
+    const layer = new ResilienceLayer();
+    const matcher = new RetryRuleMatcher();
+    matcher["cache"] = new Map([
+      [200, [{ rule: { id: "r1", name: "SSE error 1234", status_code: 200, body_pattern: '"code"\\s*:\\s*"1234"',
+        is_active: 1, created_at: "", retry_strategy: "fixed", retry_delay_ms: 1,
+        max_retries: 2, max_delay_ms: 100 }, pattern: /"code"\s*:\s*"1234"/ }]],
+    ]);
+    const state = { attemptCount: 0, currentTarget: t1, excludedTargets: [] };
+    const decision = layer.decide(
+      makeStreamError(200, '{"error":{"code":"1234","message":"网络错误"}}'),
+      state,
+      failoverConfig({ ruleMatcher: matcher }),
+    );
+    expect(decision.action).toBe("retry");
+  });
+
   it("stream_error + statusCode < threshold + rule matches + exhausted + failover -> failover", () => {
     const layer = new ResilienceLayer();
     const matcher = new RetryRuleMatcher();


### PR DESCRIPTION
## 变更内容

修复 SSE 流式代理在收到错误码 1234/1305 时未正确触发重试的问题。

## 提交
- - 53d6017 chore: bump version to 0.6.2
- e4cbf1b fix: SSE 流式错误 (code 1234/1305) 未触发重试 (#61)