### PR TITLE
feat: adaptive concurrency control

### DIFF
--- a/.superpowers/2026-04-29-adaptive-concurrency/plan.md
+++ b/.superpowers/2026-04-29-adaptive-concurrency/plan.md
@@ -1,0 +1,855 @@
+# Adaptive Concurrency Control Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add per-provider adaptive concurrency control that dynamically adjusts the semaphore limit based on observed success/failure patterns.
+
+**Architecture:** New `AdaptiveConcurrencyController` manages per-provider state machines in memory. It observes request outcomes through a callback in `ProxyOrchestrator` (and `ProviderSwitchNeeded` catch) and dynamically adjusts the semaphore's `maxConcurrency` via `updateConfig()`. No changes to the semaphore itself.
+
+**Tech Stack:** TypeScript, Vitest, better-sqlite3, Vue 3 + shadcn-vue
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `src/db/migrations/033_add_adaptive_concurrency.sql` | Create | DB migration |
+| `src/db/providers.ts` | Modify: lines 5-29 | Provider interface + PROVIDER_FIELDS |
+| `src/proxy/adaptive-controller.ts` | Create | AdaptiveConcurrencyController state machine |
+| `src/proxy/orchestrator.ts` | Modify: lines 49-57, 59-104 | Add adaptive notification |
+| `src/proxy/types.ts` | Read only | ProviderSwitchNeeded (lastResult has statusCode) |
+| `src/index.ts` | Modify: lines 184-230 | Init adaptive controller, pass to deps |
+| `src/admin/providers.ts` | Modify: lines 110-129, 239-251 | Schema + handler + new endpoint |
+| `tests/adaptive-controller.test.ts` | Create | Unit tests for all state transitions |
+| `frontend/src/types/mapping.ts` | Modify: lines 29-40 | Provider type |
+| `frontend/src/api/client.ts` | Modify: lines 122-132 | ProviderPayload type |
+| `frontend/src/views/Providers.vue` | Modify: lines 149-171, 283-302, 406-419 | Form UI + validation + payload |
+| `frontend/src/components/monitor/ConcurrencyPanel.vue` | Modify: lines 13-16 | Show adaptive status |
+| `frontend/src/types/monitor.ts` | Modify: lines 61-69 | Add adaptive fields |
+
+---
+
+## Task 1: DB Migration
+
+**Files:**
+- Create: `src/db/migrations/033_add_adaptive_concurrency.sql`
+
+- [ ] **Step 1: Create migration file**
+
+```sql
+-- 033_add_adaptive_concurrency.sql
+ALTER TABLE providers ADD COLUMN adaptive_enabled INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE providers ADD COLUMN adaptive_min INTEGER NOT NULL DEFAULT 1;
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/db/migrations/033_add_adaptive_concurrency.sql
+git commit -m "feat: add adaptive concurrency DB migration"
+```
+
+---
+
+## Task 2: DB Layer — Provider Type + Fields
+
+**Files:**
+- Modify: `src/db/providers.ts` (Provider interface, PROVIDER_FIELDS, PROVIDER_CONCURRENCY_DEFAULTS)
+
+- [ ] **Step 1: Add fields to Provider interface (after line 16 `max_queue_size`)**
+
+```typescript
+  adaptive_enabled: number;
+  adaptive_min: number;
+```
+
+- [ ] **Step 2: Add fields to PROVIDER_FIELDS set (line 29)**
+
+Add to the Set constructor:
+```typescript
+"adaptive_enabled", "adaptive_min",
+```
+
+- [ ] **Step 3: Run existing provider tests**
+
+Run: `npx vitest run tests/providers.test.ts`
+
+Expected: PASS (new fields have NOT NULL DEFAULT in migration)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/db/providers.ts
+git commit -m "feat: add adaptive fields to Provider type"
+```
+
+---
+
+## Task 3: AdaptiveConcurrencyController — TDD
+
+**Files:**
+- Create: `tests/adaptive-controller.test.ts`
+- Create: `src/proxy/adaptive-controller.ts`
+
+This is the core state machine. Pure logic, no I/O.
+
+- [ ] **Step 1: Write the test file**
+
+```typescript
+// tests/adaptive-controller.test.ts
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { AdaptiveConcurrencyController } from "../src/proxy/adaptive-controller.js";
+
+function createMockSemaphore() {
+  return {
+    updateConfig: vi.fn(),
+    getStatus: vi.fn().mockReturnValue({ active: 0, queued: 0 }),
+    acquire: vi.fn(),
+    release: vi.fn(),
+    remove: vi.fn(),
+    removeAll: vi.fn(),
+  };
+}
+
+describe("AdaptiveConcurrencyController", () => {
+  let ctrl: AdaptiveConcurrencyController;
+  let sem: ReturnType<typeof createMockSemaphore>;
+
+  beforeEach(() => {
+    sem = createMockSemaphore();
+    ctrl = new AdaptiveConcurrencyController(sem as any);
+  });
+
+  describe("init", () => {
+    it("starts at adaptive_min", () => {
+      ctrl.init("p1", { min: 3, max: 20 }, { queueTimeoutMs: 5000, maxQueueSize: 10 });
+      expect(ctrl.getStatus("p1")!.currentLimit).toBe(3);
+      expect(ctrl.getStatus("p1")!.probeActive).toBe(false);
+      expect(sem.updateConfig).toHaveBeenCalledWith("p1", {
+        maxConcurrency: 3, queueTimeoutMs: 5000, maxQueueSize: 10,
+      });
+    });
+  });
+
+  describe("success transitions", () => {
+    beforeEach(() => {
+      ctrl.init("p1", { min: 3, max: 20 }, { queueTimeoutMs: 0, maxQueueSize: 0 });
+      sem.updateConfig.mockClear();
+    });
+
+    it("opens probe window after 3 consecutive successes", () => {
+      for (let i = 0; i < 3; i++) ctrl.onRequestComplete("p1", { success: true });
+      expect(ctrl.getStatus("p1")!.probeActive).toBe(true);
+      expect(ctrl.getStatus("p1")!.currentLimit).toBe(3);
+      // semaphore allows 3+1=4
+      expect(sem.updateConfig).toHaveBeenLastCalledWith("p1", {
+        maxConcurrency: 4, queueTimeoutMs: 0, maxQueueSize: 0,
+      });
+    });
+
+    it("increases limit after 3 more successes with probe active", () => {
+      for (let i = 0; i < 3; i++) ctrl.onRequestComplete("p1", { success: true }); // open probe
+      sem.updateConfig.mockClear();
+      for (let i = 0; i < 3; i++) ctrl.onRequestComplete("p1", { success: true }); // confirm
+      expect(ctrl.getStatus("p1")!.currentLimit).toBe(4);
+      expect(ctrl.getStatus("p1")!.probeActive).toBe(true); // continues probing
+      // semaphore allows 4+1=5
+      expect(sem.updateConfig).toHaveBeenLastCalledWith("p1", {
+        maxConcurrency: 5, queueTimeoutMs: 0, maxQueueSize: 0,
+      });
+    });
+
+    it("does not exceed hard max", () => {
+      ctrl.init("p1", { min: 3, max: 4 }, { queueTimeoutMs: 0, maxQueueSize: 0 });
+      // 3 successes → probe → 3 more → confirm to 4 → 3 more → probe but capped
+      for (let i = 0; i < 3; i++) ctrl.onRequestComplete("p1", { success: true });
+      for (let i = 0; i < 3; i++) ctrl.onRequestComplete("p1", { success: true });
+      sem.updateConfig.mockClear();
+      for (let i = 0; i < 3; i++) ctrl.onRequestComplete("p1", { success: true });
+      expect(ctrl.getStatus("p1")!.currentLimit).toBe(4);
+      // probe active but maxConcurrency stays at 4 (capped by hard max)
+      expect(sem.updateConfig).toHaveBeenLastCalledWith("p1", {
+        maxConcurrency: 4, queueTimeoutMs: 0, maxQueueSize: 0,
+      });
+    });
+
+    it("resets failure counter on success", () => {
+      ctrl.onRequestComplete("p1", { success: false });
+      ctrl.onRequestComplete("p1", { success: true });
+      expect(ctrl.getStatus("p1")!.consecutiveFailures).toBe(0);
+      expect(ctrl.getStatus("p1")!.consecutiveSuccesses).toBe(1);
+    });
+  });
+
+  describe("429 handling", () => {
+    beforeEach(() => {
+      ctrl.init("p1", { min: 2, max: 20 }, { queueTimeoutMs: 0, maxQueueSize: 0 });
+      ctrl["entries"].get("p1")!.state.currentLimit = 8;
+      sem.updateConfig.mockClear();
+    });
+
+    it("halves limit on 429", () => {
+      ctrl.onRequestComplete("p1", { success: false, statusCode: 429 });
+      expect(ctrl.getStatus("p1")!.currentLimit).toBe(4);
+      expect(ctrl.getStatus("p1")!.probeActive).toBe(false);
+    });
+
+    it("enters cooldown after 429", () => {
+      ctrl.onRequestComplete("p1", { success: false, statusCode: 429 });
+      expect(ctrl.getStatus("p1")!.cooldownUntil).toBeGreaterThan(Date.now());
+    });
+
+    it("does not adjust during cooldown", () => {
+      ctrl.onRequestComplete("p1", { success: false, statusCode: 429 });
+      for (let i = 0; i < 3; i++) ctrl.onRequestComplete("p1", { success: true });
+      expect(ctrl.getStatus("p1")!.currentLimit).toBe(4); // unchanged
+      expect(ctrl.getStatus("p1")!.consecutiveSuccesses).toBe(3); // counted
+    });
+
+    it("respects hard min", () => {
+      ctrl["entries"].get("p1")!.state.currentLimit = 3;
+      ctrl.onRequestComplete("p1", { success: false, statusCode: 429 });
+      expect(ctrl.getStatus("p1")!.currentLimit).toBe(2);
+    });
+  });
+
+  describe("non-429 failures", () => {
+    beforeEach(() => {
+      ctrl.init("p1", { min: 1, max: 20 }, { queueTimeoutMs: 0, maxQueueSize: 0 });
+      ctrl["entries"].get("p1")!.state.currentLimit = 6;
+      sem.updateConfig.mockClear();
+    });
+
+    it("decreases by 2 after 3 consecutive failures", () => {
+      for (let i = 0; i < 3; i++) ctrl.onRequestComplete("p1", { success: false, statusCode: 500 });
+      expect(ctrl.getStatus("p1")!.currentLimit).toBe(4);
+      expect(ctrl.getStatus("p1")!.probeActive).toBe(false);
+    });
+
+    it("does not decrease on non-consecutive failures", () => {
+      ctrl.onRequestComplete("p1", { success: false, statusCode: 500 });
+      ctrl.onRequestComplete("p1", { success: true });
+      ctrl.onRequestComplete("p1", { success: false, statusCode: 500 });
+      ctrl.onRequestComplete("p1", { success: false, statusCode: 500 });
+      expect(ctrl.getStatus("p1")!.currentLimit).toBe(6);
+    });
+
+    it("respects hard min", () => {
+      ctrl["entries"].get("p1")!.state.currentLimit = 2;
+      for (let i = 0; i < 3; i++) ctrl.onRequestComplete("p1", { success: false, statusCode: 500 });
+      expect(ctrl.getStatus("p1")!.currentLimit).toBe(1);
+    });
+  });
+
+  describe("cooldown expiry", () => {
+    it("resumes after cooldown", () => {
+      vi.useFakeTimers();
+      ctrl.init("p1", { min: 2, max: 20 }, { queueTimeoutMs: 0, maxQueueSize: 0 });
+      ctrl["entries"].get("p1")!.state.currentLimit = 4;
+      ctrl.onRequestComplete("p1", { success: false, statusCode: 429 });
+      expect(ctrl.getStatus("p1")!.currentLimit).toBe(2);
+      vi.advanceTimersByTime(31_000);
+      for (let i = 0; i < 3; i++) ctrl.onRequestComplete("p1", { success: true });
+      expect(ctrl.getStatus("p1")!.probeActive).toBe(true);
+      vi.useRealTimers();
+    });
+  });
+
+  describe("remove / re-init", () => {
+    it("cleans up on remove", () => {
+      ctrl.init("p1", { min: 3, max: 20 }, { queueTimeoutMs: 0, maxQueueSize: 0 });
+      ctrl.remove("p1");
+      expect(ctrl.getStatus("p1")).toBeUndefined();
+    });
+
+    it("re-inits from scratch", () => {
+      ctrl.init("p1", { min: 3, max: 20 }, { queueTimeoutMs: 0, maxQueueSize: 0 });
+      ctrl["entries"].get("p1")!.state.currentLimit = 6;
+      ctrl.remove("p1");
+      ctrl.init("p1", { min: 3, max: 20 }, { queueTimeoutMs: 0, maxQueueSize: 0 });
+      expect(ctrl.getStatus("p1")!.currentLimit).toBe(3);
+    });
+  });
+
+  describe("syncProvider", () => {
+    it("initializes on enable", () => {
+      ctrl.syncProvider("p1", {
+        adaptive_enabled: 1, adaptive_min: 3, max_concurrency: 20,
+        queue_timeout_ms: 5000, max_queue_size: 10,
+      });
+      expect(ctrl.getStatus("p1")!.currentLimit).toBe(3);
+    });
+
+    it("removes on disable", () => {
+      ctrl.init("p1", { min: 3, max: 20 }, { queueTimeoutMs: 0, maxQueueSize: 0 });
+      ctrl.syncProvider("p1", {
+        adaptive_enabled: 0, adaptive_min: 1, max_concurrency: 20,
+        queue_timeout_ms: 0, max_queue_size: 0,
+      });
+      expect(ctrl.getStatus("p1")).toBeUndefined();
+    });
+
+    it("clamps current limit when bounds change", () => {
+      ctrl.init("p1", { min: 3, max: 20 }, { queueTimeoutMs: 0, maxQueueSize: 0 });
+      ctrl["entries"].get("p1")!.state.currentLimit = 10;
+      ctrl.syncProvider("p1", {
+        adaptive_enabled: 1, adaptive_min: 3, max_concurrency: 5,
+        queue_timeout_ms: 0, max_queue_size: 0,
+      });
+      expect(ctrl.getStatus("p1")!.currentLimit).toBe(5); // clamped to new max
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run tests/adaptive-controller.test.ts`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Implement AdaptiveConcurrencyController**
+
+```typescript
+// src/proxy/adaptive-controller.ts
+import type { ProviderSemaphoreManager } from "./semaphore.js";
+
+export interface AdaptiveState {
+  currentLimit: number;
+  probeActive: boolean;
+  consecutiveSuccesses: number;
+  consecutiveFailures: number;
+  cooldownUntil: number;
+}
+
+interface AdaptiveResult {
+  success: boolean;
+  statusCode?: number;
+}
+
+const SUCCESS_THRESHOLD = 3;
+const FAILURE_THRESHOLD = 3;
+const DECREASE_STEP = 2;
+const COOLDOWN_MS = 30_000;
+
+interface AdaptiveEntry {
+  state: AdaptiveState;
+  min: number;
+  max: number;
+  queueTimeoutMs: number;
+  maxQueueSize: number;
+}
+
+export class AdaptiveConcurrencyController {
+  private readonly entries = new Map<string, AdaptiveEntry>();
+
+  constructor(private semaphoreManager: ProviderSemaphoreManager) {}
+
+  init(providerId: string, config: { min: number; max: number }, semParams: { queueTimeoutMs: number; maxQueueSize: number }): void {
+    this.entries.set(providerId, {
+      state: {
+        currentLimit: config.min,
+        probeActive: false,
+        consecutiveSuccesses: 0,
+        consecutiveFailures: 0,
+        cooldownUntil: 0,
+      },
+      min: config.min,
+      max: config.max,
+      queueTimeoutMs: semParams.queueTimeoutMs,
+      maxQueueSize: semParams.maxQueueSize,
+    });
+    this.syncToSemaphore(providerId);
+  }
+
+  remove(providerId: string): void {
+    this.entries.delete(providerId);
+  }
+
+  onRequestComplete(providerId: string, result: AdaptiveResult): void {
+    const entry = this.entries.get(providerId);
+    if (!entry) return;
+    if (result.success) {
+      this.transitionSuccess(providerId, entry);
+    } else {
+      this.transitionFailure(providerId, entry, result.statusCode);
+    }
+  }
+
+  getStatus(providerId: string): AdaptiveState | undefined {
+    return this.entries.get(providerId)?.state;
+  }
+
+  /** Admin API 调用：启用/禁用/参数变更时同步 */
+  syncProvider(providerId: string, p: {
+    adaptive_enabled: number; adaptive_min: number; max_concurrency: number;
+    queue_timeout_ms: number; max_queue_size: number;
+  }): void {
+    if (p.adaptive_enabled) {
+      const existing = this.entries.get(providerId);
+      if (existing) {
+        existing.min = p.adaptive_min;
+        existing.max = p.max_concurrency;
+        existing.queueTimeoutMs = p.queue_timeout_ms;
+        existing.maxQueueSize = p.max_queue_size;
+        existing.state.currentLimit = Math.min(
+          Math.max(existing.state.currentLimit, existing.min), existing.max,
+        );
+        this.syncToSemaphore(providerId);
+      } else {
+        this.init(providerId, { min: p.adaptive_min, max: p.max_concurrency }, {
+          queueTimeoutMs: p.queue_timeout_ms, maxQueueSize: p.max_queue_size,
+        });
+      }
+    } else {
+      this.remove(providerId);
+    }
+  }
+
+  private transitionSuccess(providerId: string, entry: AdaptiveEntry): void {
+    const s = entry.state;
+    s.consecutiveSuccesses++;
+    s.consecutiveFailures = 0;
+    if (Date.now() < s.cooldownUntil) return;
+
+    if (s.consecutiveSuccesses >= SUCCESS_THRESHOLD) {
+      if (!s.probeActive) {
+        s.probeActive = true;
+        s.consecutiveSuccesses = 0;
+      } else {
+        s.currentLimit = Math.min(s.currentLimit + 1, entry.max);
+        s.consecutiveSuccesses = 0;
+      }
+      this.syncToSemaphore(providerId);
+    }
+  }
+
+  private transitionFailure(providerId: string, entry: AdaptiveEntry, statusCode?: number): void {
+    const s = entry.state;
+    s.consecutiveFailures++;
+    s.consecutiveSuccesses = 0;
+
+    if (statusCode === 429) {
+      s.currentLimit = Math.max(Math.floor(s.currentLimit / 2), entry.min);
+      s.probeActive = false;
+      s.cooldownUntil = Date.now() + COOLDOWN_MS;
+      s.consecutiveFailures = 0;
+      this.syncToSemaphore(providerId);
+    } else if (s.consecutiveFailures >= FAILURE_THRESHOLD) {
+      s.currentLimit = Math.max(s.currentLimit - DECREASE_STEP, entry.min);
+      s.probeActive = false;
+      s.consecutiveFailures = 0;
+      this.syncToSemaphore(providerId);
+    }
+  }
+
+  private syncToSemaphore(providerId: string): void {
+    const entry = this.entries.get(providerId);
+    if (!entry) return;
+    this.semaphoreManager.updateConfig(providerId, {
+      maxConcurrency: entry.state.currentLimit + (entry.state.probeActive ? 1 : 0),
+      queueTimeoutMs: entry.queueTimeoutMs,
+      maxQueueSize: entry.maxQueueSize,
+    });
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run tests/adaptive-controller.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/proxy/adaptive-controller.ts tests/adaptive-controller.test.ts
+git commit -m "feat: add AdaptiveConcurrencyController with state machine and tests"
+```
+
+---
+
+## Task 4: Admin API Backend
+
+**Files:**
+- Modify: `src/admin/providers.ts`
+
+Depends on: Task 3 (imports AdaptiveConcurrencyController)
+
+- [ ] **Step 1: Add import at top of file**
+
+```typescript
+import { AdaptiveConcurrencyController } from "../proxy/adaptive-controller.js";
+```
+
+- [ ] **Step 2: Update options interface (around line 125-129)**
+
+Add `adaptiveController` to the interface:
+
+```typescript
+interface ProviderRoutesOptions {
+  db: Database.Database;
+  matcher?: RetryRuleMatcher;
+  tracker?: RequestTracker;
+  semaphoreManager?: ProviderSemaphoreManager;
+  adaptiveController?: AdaptiveConcurrencyController;
+}
+```
+
+- [ ] **Step 3: Add adaptive fields to validation schema (around line 110-123)**
+
+Add to the zod body schema:
+
+```typescript
+adaptive_enabled: z.number().int().min(0).max(1).optional(),
+adaptive_min: z.number().int().min(1).optional(),
+```
+
+- [ ] **Step 4: Update PUT handler — add adaptive sync (after line 245 semaphore updateConfig block)**
+
+```typescript
+// Adaptive controller sync
+if (body.adaptive_enabled !== undefined || body.adaptive_min !== undefined || body.max_concurrency !== undefined) {
+  adaptiveController?.syncProvider(id, {
+    adaptive_enabled: updated.adaptive_enabled,
+    adaptive_min: updated.adaptive_min,
+    max_concurrency: updated.max_concurrency,
+    queue_timeout_ms: updated.queue_timeout_ms,
+    max_queue_size: updated.max_queue_size,
+  });
+}
+```
+
+- [ ] **Step 5: Add adaptive-status endpoint (after existing routes)**
+
+```typescript
+app.get("/admin/api/providers/:id/adaptive-status", async (request, reply) => {
+  const { id } = request.params as { id: string };
+  const status = adaptiveController?.getStatus(id);
+  if (!status) return reply.code(404).send({ error: "Not found or adaptive not enabled" });
+  return status;
+});
+```
+
+- [ ] **Step 6: Run admin tests**
+
+Run: `npx vitest run tests/admin-providers.test.ts`
+Expected: PASS (new fields are optional with defaults)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/admin/providers.ts
+git commit -m "feat: add adaptive concurrency admin API and status endpoint"
+```
+
+---
+
+## Task 5: Orchestrator Integration
+
+**Files:**
+- Modify: `src/proxy/orchestrator.ts` (createOrchestrator, constructor, handle)
+- Modify: `src/index.ts` (init, pass to deps)
+
+Depends on: Task 3
+
+- [ ] **Step 1: Update orchestrator.ts — add import**
+
+```typescript
+import type { AdaptiveConcurrencyController } from "./adaptive-controller.js";
+```
+
+- [ ] **Step 2: Update createOrchestrator (line 49-57)**
+
+Add `adaptiveController` parameter:
+
+```typescript
+export function createOrchestrator(
+  semaphoreManager?: ProviderSemaphoreManager,
+  tracker?: RequestTracker,
+  adaptiveController?: AdaptiveConcurrencyController,
+): ProxyOrchestrator | undefined {
+  const semaphoreScope = semaphoreManager ? new SemaphoreScopeClass(semaphoreManager) : undefined;
+  const trackerScope = tracker ? new TrackerScopeClass(tracker) : undefined;
+  if (!semaphoreScope || !trackerScope) return undefined;
+  return new ProxyOrchestrator({
+    semaphoreScope, trackerScope, resilience: new ResilienceLayerClass(),
+    adaptiveController,
+  });
+}
+```
+
+- [ ] **Step 3: Update constructor deps type**
+
+```typescript
+constructor(
+  private deps: {
+    semaphoreScope: SemaphoreScope;
+    trackerScope: TrackerScope;
+    resilience: ResilienceLayer;
+    adaptiveController?: AdaptiveConcurrencyController;
+  },
+) {}
+```
+
+- [ ] **Step 4: Update handle() — wrap with try/catch for adaptive notification**
+
+Replace lines 76-103 with:
+
+```typescript
+    const trackerReq = this.buildActiveRequest(request, config, apiType);
+    try {
+      const result = await this.deps.trackerScope.track<ResilienceResult>(
+        trackerReq,
+        () => this.deps.semaphoreScope.withSlot(
+          config.provider.id,
+          this.createAbortSignal(request),
+          () => {
+            trackerReq.queued = true;
+            this.deps.trackerScope.markQueued(trackerReq.id, true);
+          },
+          () => {
+            if (trackerReq.queued) {
+              trackerReq.queued = false;
+              this.deps.trackerScope.markQueued(trackerReq.id, false);
+            }
+            return this.executeResilience(config, ctx);
+          },
+          config.concurrencyOverride,
+        ),
+        (result) => this.extractTrackStatus(result),
+        (result) => result.attempts.map(a => ({
+          statusCode: a.statusCode,
+          error: a.error,
+          latencyMs: a.latencyMs,
+          providerId: a.target.provider_id,
+        })),
+      );
+      // Adaptive notification — normal completion
+      if (this.deps.adaptiveController) {
+        const ts = this.extractTrackStatus(result);
+        this.deps.adaptiveController.onRequestComplete(config.provider.id, {
+          success: ts.status === "completed",
+          statusCode: ts.statusCode,
+        });
+      }
+      this.sendResponse(reply, result.result, ctx);
+      return result;
+    } catch (e) {
+      // Adaptive notification — ProviderSwitchNeeded
+      if (e instanceof ProviderSwitchNeeded && this.deps.adaptiveController) {
+        const lr = e.lastResult;
+        this.deps.adaptiveController.onRequestComplete(config.provider.id, {
+          success: false,
+          statusCode: "statusCode" in lr ? (lr as { statusCode: number }).statusCode : undefined,
+        });
+      }
+      throw e;
+    }
+```
+
+Note: Add `import { ProviderSwitchNeeded } from "./types.js";` at the top if not already imported.
+
+- [ ] **Step 5: Update src/index.ts — create and wire controller**
+
+After line 186 (`tracker.startPushInterval()`), add:
+
+```typescript
+const adaptiveController = new AdaptiveConcurrencyController(semaphoreManager);
+```
+
+Update provider init loop (lines 193-208):
+
+```typescript
+const allProviders = getAllProviders(db);
+for (const p of allProviders) {
+  if (p.adaptive_enabled) {
+    adaptiveController.init(p.id, { min: p.adaptive_min, max: p.max_concurrency }, {
+      queueTimeoutMs: p.queue_timeout_ms, maxQueueSize: p.max_queue_size,
+    });
+  } else if (p.max_concurrency > 0) {
+    semaphoreManager.updateConfig(p.id, {
+      maxConcurrency: p.max_concurrency,
+      queueTimeoutMs: p.queue_timeout_ms,
+      maxQueueSize: p.max_queue_size,
+    });
+  }
+  tracker.updateProviderConfig(p.id, { ... }); // existing tracker update unchanged
+}
+```
+
+Update `createOrchestrator` calls — add `adaptiveController` as 3rd arg.
+
+Update `adminRoutes` registration — add `adaptiveController` to options.
+
+- [ ] **Step 6: Run full test suite**
+
+Run: `npx vitest run tests/`
+Expected: ALL PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/proxy/orchestrator.ts src/index.ts
+git commit -m "feat: integrate adaptive controller into orchestrator and init"
+```
+
+---
+
+## Task 6: Frontend Provider Form
+
+**Files:**
+- Modify: `frontend/src/types/mapping.ts` (Provider type)
+- Modify: `frontend/src/api/client.ts` (ProviderPayload type)
+- Modify: `frontend/src/views/Providers.vue` (form UI + validation + payload)
+
+- [ ] **Step 1: Update Provider type in mapping.ts (lines 29-40)**
+
+Add after `max_queue_size`:
+```typescript
+  adaptive_enabled: number
+  adaptive_min: number
+```
+
+- [ ] **Step 2: Update ProviderPayload in client.ts (lines 122-132)**
+
+Add optional fields:
+```typescript
+  adaptive_enabled?: number
+  adaptive_min?: number
+```
+
+- [ ] **Step 3: Update Providers.vue — form ref**
+
+Add to the form ref object:
+```typescript
+adaptive_enabled: false,
+adaptive_min: 1,
+```
+
+- [ ] **Step 4: Update Providers.vue — add adaptive UI after concurrency section (after line 171)**
+
+After the closing `</div>` of the concurrency fields block:
+
+```html
+<!-- 自适应并发 (仅并发控制启用时显示) -->
+<div v-if="concurrencyEnabled" class="mt-3 border-t pt-3">
+  <div class="flex items-center gap-2 mb-1">
+    <Switch v-model="form.adaptive_enabled" id="adaptive-switch" />
+    <Label for="adaptive-switch" class="text-sm text-foreground">自适应并发</Label>
+  </div>
+  <p v-if="form.adaptive_enabled" class="text-xs text-muted-foreground mb-2">
+    从 {{ form.adaptive_min || 1 }} 开始自动调整，上限为 {{ form.max_concurrency || '-' }}
+  </p>
+  <div v-if="form.adaptive_enabled" class="space-y-2">
+    <div>
+      <Label class="block text-sm font-medium text-foreground mb-1">自适应下限</Label>
+      <Input v-model.number="form.adaptive_min" type="number" min="1" :max="form.max_concurrency || 100" placeholder="1" @input="delete errors.adaptive_min" />
+      <p v-if="errors.adaptive_min" class="text-sm text-destructive mt-1">{{ errors.adaptive_min }}</p>
+    </div>
+  </div>
+</div>
+```
+
+- [ ] **Step 5: Update Providers.vue — max_concurrency label**
+
+Change line with "最大并发数" to:
+
+```html
+<Label class="block text-sm font-medium text-foreground mb-1">
+  {{ form.adaptive_enabled ? '自适应上限' : '最大并发数' }}
+</Label>
+```
+
+- [ ] **Step 6: Update Providers.vue — validate() (around line 283-302)**
+
+Add after the concurrency validation block:
+
+```typescript
+if (concurrencyEnabled.value && form.value.adaptive_enabled) {
+  const min = form.value.adaptive_min;
+  if (!min || min < 1) errs.adaptive_min = '最小为 1';
+  if (min > form.value.max_concurrency) errs.adaptive_min = '不能超过上限 ' + form.value.max_concurrency;
+}
+```
+
+- [ ] **Step 7: Update Providers.vue — buildPayload() (around line 406-419)**
+
+Add to the payload object:
+
+```typescript
+adaptive_enabled: concurrencyEnabled.value && form.value.adaptive_enabled ? 1 : 0,
+adaptive_min: concurrencyEnabled.value && form.value.adaptive_enabled ? form.value.adaptive_min : 1,
+```
+
+- [ ] **Step 8: Update Providers.vue — resetForm()**
+
+Add adaptive fields to the reset state:
+```typescript
+adaptive_enabled: false,
+adaptive_min: 1,
+```
+
+- [ ] **Step 9: Update Providers.vue — table concurrency cell (lines 50-53)**
+
+Replace with:
+
+```html
+<TableCell>
+  <Badge v-if="p.adaptive_enabled" variant="outline">自适应</Badge>
+  <Badge v-else-if="p.max_concurrency > 0" variant="secondary">{{ p.max_concurrency }}</Badge>
+  <span v-else class="text-muted-foreground">-</span>
+</TableCell>
+```
+
+- [ ] **Step 10: Verify frontend builds**
+
+Run: `cd frontend && npm run build`
+Expected: SUCCESS
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add frontend/src/types/mapping.ts frontend/src/api/client.ts frontend/src/views/Providers.vue
+git commit -m "feat: add adaptive concurrency UI in provider form"
+```
+
+---
+
+## Task 7: Frontend Monitor Display
+
+**Files:**
+- Modify: `frontend/src/types/monitor.ts`
+- Modify: `frontend/src/components/monitor/ConcurrencyPanel.vue`
+
+- [ ] **Step 1: Update ProviderConcurrencySnapshot in monitor.ts (lines 61-69)**
+
+Add optional adaptive fields:
+
+```typescript
+adaptiveEnabled?: boolean
+adaptiveLimit?: number
+adaptiveProbeActive?: boolean
+```
+
+- [ ] **Step 2: Update ConcurrencyPanel.vue — status text (around line 13-16)**
+
+Replace the active/max display:
+
+```html
+<span class="text-muted-foreground">
+  <template v-if="provider.adaptiveEnabled">
+    {{ provider.active }} / {{ provider.adaptiveLimit ?? provider.maxConcurrency }}
+    <span class="text-xs">(自适应)</span>
+  </template>
+  <template v-else-if="provider.maxConcurrency === 0">未限制</template>
+  <template v-else>{{ provider.active }} / {{ provider.maxConcurrency }}</template>
+</span>
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/types/monitor.ts frontend/src/components/monitor/ConcurrencyPanel.vue
+git commit -m "feat: show adaptive concurrency status in monitor"
+```

--- a/.superpowers/2026-04-29-adaptive-concurrency/spec.md
+++ b/.superpowers/2026-04-29-adaptive-concurrency/spec.md
@@ -1,0 +1,88 @@
+# 自适应并发控制
+
+## 问题
+
+当前并发控制是静态的：用户手动配置每个 Provider 的 `max_concurrency`。找到最优值需要反复试错，且无法适应上游条件变化（速率限制、负载波动）。
+
+## 方案
+
+Per-provider 自适应并发控制器。启用后，基于观察到的成功/失败模式动态调整信号量的 `maxConcurrency`。
+
+## 核心算法
+
+### 状态（per provider，纯内存）
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| currentLimit | number | 当前生效的并发限制 N |
+| probeActive | boolean | 试探窗口是否开放 |
+| consecutiveSuccesses | number | 连续成功计数（遇失败清零） |
+| consecutiveFailures | number | 连续失败计数（遇成功清零） |
+| cooldownUntil | number | 冷却期截止时间戳（ms） |
+
+### 状态转换
+
+**请求成功**（最终结果，含重试成功）：
+1. `consecutiveSuccesses++`，`consecutiveFailures = 0`
+2. 冷却期内 → 仅计数，不触发调整
+3. `consecutiveSuccesses == 3` 且 `!probeActive` → 打开试探窗口
+4. `consecutiveSuccesses == 3` 且 `probeActive` → `N = min(N + 1, hardMax)`，重置计数
+
+**请求失败**（所有重试耗尽的最终结果）：
+1. `consecutiveFailures++`，`consecutiveSuccesses = 0`
+2. `statusCode == 429`：
+   - `N = max(floor(N / 2), hardMin)`（乘法减少）
+   - 关闭试探窗口，进入冷却期（30s），重置计数
+3. 其他失败，`consecutiveFailures == 3`：
+   - `N = max(N - 2, hardMin)`（加法减少）
+   - 关闭试探窗口，重置计数
+
+### 信号量集成
+
+控制器设置 semaphore 的 `maxConcurrency = N + (probeActive ? 1 : 0)`。试探窗口通过临时增加限制自然实现，信号量代码无需修改。
+
+## 集成架构
+
+### 新增文件
+- `src/proxy/adaptive-controller.ts` — AdaptiveConcurrencyController 类
+
+### 钩子点
+- `src/proxy/orchestrator.ts` — `withSlot()` 完成后通知控制器
+  - 正常完成：报告成功/失败
+  - `ProviderSwitchNeeded`：为原始 Provider 报告失败（即使 failover 成功）
+
+### 初始化
+- `src/index.ts` — `buildApp()` 中，对 `adaptive_enabled` 的 Provider 初始化控制器
+  - 范围：`[adaptive_min, max_concurrency]`
+  - 初始值：`adaptive_min`
+
+### Admin API 联动
+- `src/admin/providers.ts` — 开关切换、参数更新时同步控制器
+- 新端点：`GET /admin/api/providers/:id/adaptive-status` — 返回当前自适应状态
+
+## 数据模型
+
+```sql
+ALTER TABLE providers ADD COLUMN adaptive_enabled INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE providers ADD COLUMN adaptive_min INTEGER NOT NULL DEFAULT 1;
+```
+
+启用自适应时：
+- `max_concurrency` = 硬上限（信号量永远不会超过此值）
+- `adaptive_min` = 硬下限 + 初始值
+- 控制器在 `[adaptive_min, max_concurrency]` 范围内调整
+
+## 前端
+
+- Provider 编辑弹窗：自适应开关 + `adaptive_min` 输入框
+- 启用时 `max_concurrency` 标签变为"自适应上限"
+- Monitor 页面：显示当前自适应并发值
+
+## 参数默认值
+
+| 参数 | 默认值 | 说明 |
+|------|--------|------|
+| successThreshold | 3 | 连续成功次数阈值 |
+| failureThreshold | 3 | 连续失败次数阈值 |
+| decreaseStep | 2 | 连续失败时的减少量 |
+| cooldownMs | 30000 | 429 后的冷却期（ms） |

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -129,6 +129,8 @@ export interface ProviderPayload {
   max_concurrency?: number;
   queue_timeout_ms?: number;
   max_queue_size?: number;
+  adaptive_enabled?: number;
+  adaptive_min?: number;
 }
 
 interface MappingPayload {

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -130,7 +130,6 @@ export interface ProviderPayload {
   queue_timeout_ms?: number;
   max_queue_size?: number;
   adaptive_enabled?: number;
-  adaptive_min?: number;
 }
 
 interface MappingPayload {

--- a/frontend/src/components/monitor/ConcurrencyPanel.vue
+++ b/frontend/src/components/monitor/ConcurrencyPanel.vue
@@ -11,7 +11,11 @@
       <div class="flex items-center justify-between text-sm">
         <span class="font-medium text-foreground">{{ provider.providerName }}</span>
         <span class="text-muted-foreground">
-          <template v-if="provider.maxConcurrency === 0">未限制</template>
+          <template v-if="provider.adaptiveEnabled">
+            {{ provider.active }} / {{ provider.adaptiveLimit ?? provider.maxConcurrency }}
+            <span class="text-xs">(自适应)</span>
+          </template>
+          <template v-else-if="provider.maxConcurrency === 0">未限制</template>
           <template v-else>{{ provider.active }} / {{ provider.maxConcurrency }}</template>
         </span>
       </div>

--- a/frontend/src/components/monitor/ConcurrencyPanel.vue
+++ b/frontend/src/components/monitor/ConcurrencyPanel.vue
@@ -24,15 +24,15 @@
       <div v-if="provider.maxConcurrency > 0" class="h-2 bg-muted rounded-full overflow-hidden">
         <div
           class="h-full rounded-full transition-all duration-300"
-          :class="barColor(provider.active, provider.maxConcurrency)"
-          :style="{ width: `${Math.min(100, (provider.active / provider.maxConcurrency) * 100)}%` }"
+          :class="barColor(provider.active, effectiveLimit(provider))"
+          :style="{ width: `${Math.min(100, (provider.active / effectiveLimit(provider)) * 100)}%` }"
         />
       </div>
 
       <!-- 队列信息 -->
       <div v-if="provider.maxConcurrency > 0" class="flex gap-3 text-xs text-muted-foreground">
         <span>排队: {{ provider.queued }}</span>
-        <span>队列上限: {{ provider.maxQueueSize }}</span>
+        <span>队列上限: {{ provider.adaptiveLimit ?? provider.maxQueueSize }}</span>
       </div>
     </div>
   </div>
@@ -45,6 +45,10 @@ import type { ProviderConcurrencySnapshot } from '@/types/monitor'
 defineProps<{
   providers: ProviderConcurrencySnapshot[]
 }>()
+
+function effectiveLimit(provider: ProviderConcurrencySnapshot): number {
+  return provider.adaptiveLimit ?? provider.maxConcurrency
+}
 
 function barColor(active: number, max: number): string {
   const ratio = active / max

--- a/frontend/src/types/mapping.ts
+++ b/frontend/src/types/mapping.ts
@@ -38,7 +38,6 @@ export interface Provider {
   queue_timeout_ms: number
   max_queue_size: number
   adaptive_enabled: number
-  adaptive_min: number
 }
 
 /** Provider 精简信息（映射配置、下拉选择等场景使用） */

--- a/frontend/src/types/mapping.ts
+++ b/frontend/src/types/mapping.ts
@@ -37,6 +37,8 @@ export interface Provider {
   max_concurrency: number
   queue_timeout_ms: number
   max_queue_size: number
+  adaptive_enabled: number
+  adaptive_min: number
 }
 
 /** Provider 精简信息（映射配置、下拉选择等场景使用） */

--- a/frontend/src/types/monitor.ts
+++ b/frontend/src/types/monitor.ts
@@ -66,6 +66,9 @@ export interface ProviderConcurrencySnapshot {
   queued: number
   queueTimeoutMs: number
   maxQueueSize: number
+  adaptiveEnabled?: boolean
+  adaptiveLimit?: number
+  adaptiveProbeActive?: boolean
 }
 
 export interface ProviderStats {

--- a/frontend/src/types/monitor.ts
+++ b/frontend/src/types/monitor.ts
@@ -68,7 +68,6 @@ export interface ProviderConcurrencySnapshot {
   maxQueueSize: number
   adaptiveEnabled?: boolean
   adaptiveLimit?: number
-  adaptiveProbeActive?: boolean
 }
 
 export interface ProviderStats {

--- a/frontend/src/views/Providers.vue
+++ b/frontend/src/views/Providers.vue
@@ -153,10 +153,9 @@
               <Label for="concurrency-switch" class="text-sm text-foreground">并发控制</Label>
             </div>
             <div v-if="concurrencyEnabled" class="mt-2 space-y-2">
-              <div>
-                <Label class="block text-sm font-medium text-foreground mb-1">
-                  {{ form.adaptive_enabled ? '自适应上限' : '最大并发数' }}
-                </Label>
+              <!-- 非自适应时显示固定并发数 -->
+              <div v-if="!form.adaptive_enabled">
+                <Label class="block text-sm font-medium text-foreground mb-1">最大并发数</Label>
                 <Input v-model.number="form.max_concurrency" type="number" min="1" :max="MAX_CONCURRENCY" placeholder="3" @input="delete errors.max_concurrency" />
                 <p v-if="errors.max_concurrency" class="text-sm text-destructive mt-1">{{ errors.max_concurrency }}</p>
               </div>
@@ -176,9 +175,14 @@
                   <Switch v-model="form.adaptive_enabled" id="adaptive-switch" />
                   <Label for="adaptive-switch" class="text-sm text-foreground">自适应并发</Label>
                 </div>
-                <p v-if="form.adaptive_enabled" class="text-xs text-muted-foreground mb-2">
-                  从 1 开始自动调整，上限为 {{ form.max_concurrency || '-' }}
-                </p>
+                <div v-if="form.adaptive_enabled" class="mt-2 space-y-2">
+                  <p class="text-xs text-muted-foreground">最低并发度为 1</p>
+                  <div>
+                    <Label class="block text-sm font-medium text-foreground mb-1">自适应上限</Label>
+                    <Input v-model.number="form.max_concurrency" type="number" min="1" :max="MAX_CONCURRENCY" placeholder="3" @input="delete errors.max_concurrency" />
+                    <p v-if="errors.max_concurrency" class="text-sm text-destructive mt-1">{{ errors.max_concurrency }}</p>
+                  </div>
+                </div>
               </div>
             </div>
           </div>

--- a/frontend/src/views/Providers.vue
+++ b/frontend/src/views/Providers.vue
@@ -177,15 +177,8 @@
                   <Label for="adaptive-switch" class="text-sm text-foreground">自适应并发</Label>
                 </div>
                 <p v-if="form.adaptive_enabled" class="text-xs text-muted-foreground mb-2">
-                  从 {{ form.adaptive_min || 1 }} 开始自动调整，上限为 {{ form.max_concurrency || '-' }}
+                  从 1 开始自动调整，上限为 {{ form.max_concurrency || '-' }}
                 </p>
-                <div v-if="form.adaptive_enabled" class="space-y-2">
-                  <div>
-                    <Label class="block text-sm font-medium text-foreground mb-1">自适应下限</Label>
-                    <Input v-model.number="form.adaptive_min" type="number" min="1" :max="form.max_concurrency || 100" placeholder="1" @input="delete errors.adaptive_min" />
-                    <p v-if="errors.adaptive_min" class="text-sm text-destructive mt-1">{{ errors.adaptive_min }}</p>
-                  </div>
-                </div>
               </div>
             </div>
           </div>
@@ -269,7 +262,7 @@ const CONTEXT_WINDOW_OPTIONS = [
   { label: '256K', value: '256000' },
   { label: '1M', value: '1000000' },
 ] as const
-const DEFAULT_FORM = { name: '', api_type: 'anthropic', base_url: '', api_key: '', models: [] as ModelInfo[], is_active: true, max_concurrency: DEFAULT_CONCURRENCY, queue_timeout_ms: DEFAULT_QUEUE_TIMEOUT_MS, max_queue_size: DEFAULT_QUEUE_SIZE, adaptive_enabled: false, adaptive_min: 1 }
+const DEFAULT_FORM = { name: '', api_type: 'anthropic', base_url: '', api_key: '', models: [] as ModelInfo[], is_active: true, max_concurrency: DEFAULT_CONCURRENCY, queue_timeout_ms: DEFAULT_QUEUE_TIMEOUT_MS, max_queue_size: DEFAULT_QUEUE_SIZE, adaptive_enabled: false }
 const modelInput = ref('')
 const modelContextWindow = ref(DEFAULT_CONTEXT_WINDOW)
 const contextWindowSelect = computed({
@@ -316,11 +309,6 @@ function validate(): boolean {
     if (form.value.queue_timeout_ms < 0) errs.queue_timeout_ms = '不能为负数'
     const qs = form.value.max_queue_size
     if (!qs || qs < 1 || qs > MAX_QUEUE_SIZE) errs.max_queue_size = `范围 1-${MAX_QUEUE_SIZE}`
-    if (form.value.adaptive_enabled) {
-      const min = form.value.adaptive_min
-      if (!min || min < 1) errs.adaptive_min = '最小为 1'
-      if (min > form.value.max_concurrency) errs.adaptive_min = '不能超过上限 ' + form.value.max_concurrency
-    }
   }
   errors.value = errs
   return Object.keys(errs).length === 0
@@ -416,7 +404,7 @@ function openCreate() {
 
 function openEdit(p: Provider) {
   editingId.value = p.id
-  form.value = { name: p.name, api_type: p.api_type, base_url: p.base_url, api_key: '', models: (p.models || []).map(m => ({ name: m.name, context_window: m.context_window ?? DEFAULT_CONTEXT_WINDOW })), is_active: !!p.is_active, max_concurrency: p.max_concurrency ?? DEFAULT_CONCURRENCY, queue_timeout_ms: p.queue_timeout_ms ?? DEFAULT_QUEUE_TIMEOUT_MS, max_queue_size: p.max_queue_size ?? DEFAULT_QUEUE_SIZE, adaptive_enabled: !!p.adaptive_enabled, adaptive_min: p.adaptive_min || 1 }
+  form.value = { name: p.name, api_type: p.api_type, base_url: p.base_url, api_key: '', models: (p.models || []).map(m => ({ name: m.name, context_window: m.context_window ?? DEFAULT_CONTEXT_WINDOW })), is_active: !!p.is_active, max_concurrency: p.max_concurrency ?? DEFAULT_CONCURRENCY, queue_timeout_ms: p.queue_timeout_ms ?? DEFAULT_QUEUE_TIMEOUT_MS, max_queue_size: p.max_queue_size ?? DEFAULT_QUEUE_SIZE, adaptive_enabled: !!p.adaptive_enabled }
   concurrencyEnabled.value = (p.max_concurrency ?? 0) > 0
   modelInput.value = ''
   modelContextWindow.value = DEFAULT_CONTEXT_WINDOW
@@ -426,7 +414,7 @@ function openEdit(p: Provider) {
   dialogOpen.value = true
 }
 
-type ProviderFormPayload = Pick<ProviderPayload, 'name' | 'api_type' | 'base_url' | 'models' | 'is_active' | 'max_concurrency' | 'queue_timeout_ms' | 'max_queue_size' | 'adaptive_enabled' | 'adaptive_min'> & { api_key?: string }
+type ProviderFormPayload = Pick<ProviderPayload, 'name' | 'api_type' | 'base_url' | 'models' | 'is_active' | 'max_concurrency' | 'queue_timeout_ms' | 'max_queue_size' | 'adaptive_enabled'> & { api_key?: string }
 
 function buildPayload(): ProviderFormPayload {
   const payload: ProviderFormPayload = {
@@ -439,7 +427,6 @@ function buildPayload(): ProviderFormPayload {
     queue_timeout_ms: concurrencyEnabled.value ? form.value.queue_timeout_ms : 0,
     max_queue_size: concurrencyEnabled.value ? form.value.max_queue_size : DEFAULT_QUEUE_SIZE,
     adaptive_enabled: concurrencyEnabled.value && form.value.adaptive_enabled ? 1 : 0,
-    adaptive_min: concurrencyEnabled.value && form.value.adaptive_enabled ? form.value.adaptive_min : 1,
   }
   if (form.value.api_key) payload.api_key = form.value.api_key
   return payload

--- a/frontend/src/views/Providers.vue
+++ b/frontend/src/views/Providers.vue
@@ -147,41 +147,38 @@
               <Button type="button" variant="outline" size="sm" @click="addModel" :disabled="!modelInput.trim()">添加</Button>
             </div>
           </div>
-          <div>
-            <div class="flex items-center gap-2 mb-1">
-              <Switch v-model="concurrencyEnabled" id="concurrency-switch" />
-              <Label for="concurrency-switch" class="text-sm text-foreground">并发控制</Label>
-            </div>
-            <div v-if="concurrencyEnabled" class="mt-2 space-y-2">
-              <!-- 非自适应时显示固定并发数 -->
-              <div v-if="!form.adaptive_enabled">
-                <Label class="block text-sm font-medium text-foreground mb-1">最大并发数</Label>
-                <Input v-model.number="form.max_concurrency" type="number" min="1" :max="MAX_CONCURRENCY" placeholder="3" @input="delete errors.max_concurrency" />
-                <p v-if="errors.max_concurrency" class="text-sm text-destructive mt-1">{{ errors.max_concurrency }}</p>
-              </div>
+          <!-- 并发控制 -->
+          <div class="border-t pt-4 mt-4">
+            <div class="text-sm font-medium text-foreground mb-3">并发控制</div>
+            <div class="space-y-3">
               <div>
-                <Label class="block text-sm font-medium text-foreground mb-1">队列超时 (ms)</Label>
-                <Input v-model.number="form.queue_timeout_ms" type="number" min="0" placeholder="0 = 无限等待" @input="delete errors.queue_timeout_ms" />
-                <p v-if="errors.queue_timeout_ms" class="text-sm text-destructive mt-1">{{ errors.queue_timeout_ms }}</p>
+                <Label class="block text-sm font-medium text-foreground mb-1">模式</Label>
+                <Select v-model="concurrencyMode" @update:model-value="(v: unknown) => onConcurrencyModeChange(v as 'auto' | 'manual' | 'none')">
+                  <SelectTrigger>
+                    <SelectValue placeholder="选择模式" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="auto">自动（自适应）</SelectItem>
+                    <SelectItem value="manual">手动</SelectItem>
+                    <SelectItem value="none">无</SelectItem>
+                  </SelectContent>
+                </Select>
               </div>
-              <div>
-                <Label class="block text-sm font-medium text-foreground mb-1">最大队列长度</Label>
-                <Input v-model.number="form.max_queue_size" type="number" min="1" :max="MAX_QUEUE_SIZE" :placeholder="DEFAULT_QUEUE_SIZE" @input="delete errors.max_queue_size" />
-                <p v-if="errors.max_queue_size" class="text-sm text-destructive mt-1">{{ errors.max_queue_size }}</p>
-              </div>
-              <!-- 自适应并发 -->
-              <div class="mt-3 border-t pt-3">
-                <div class="flex items-center gap-2 mb-1">
-                  <Switch v-model="form.adaptive_enabled" id="adaptive-switch" />
-                  <Label for="adaptive-switch" class="text-sm text-foreground">自适应并发</Label>
+              <div v-if="concurrencyMode !== 'none'" class="space-y-2">
+                <div>
+                  <Label class="block text-sm font-medium text-foreground mb-1">最大并发度</Label>
+                  <Input v-model.number="form.max_concurrency" type="number" min="1" :max="MAX_CONCURRENCY" :placeholder="concurrencyMode === 'auto' ? '10' : '3'" @input="delete errors.max_concurrency" />
+                  <p v-if="errors.max_concurrency" class="text-sm text-destructive mt-1">{{ errors.max_concurrency }}</p>
                 </div>
-                <div v-if="form.adaptive_enabled" class="mt-2 space-y-2">
-                  <p class="text-xs text-muted-foreground">最低并发度为 1</p>
-                  <div>
-                    <Label class="block text-sm font-medium text-foreground mb-1">自适应上限</Label>
-                    <Input v-model.number="form.max_concurrency" type="number" min="1" :max="MAX_CONCURRENCY" placeholder="3" @input="delete errors.max_concurrency" />
-                    <p v-if="errors.max_concurrency" class="text-sm text-destructive mt-1">{{ errors.max_concurrency }}</p>
-                  </div>
+                <div>
+                  <Label class="block text-sm font-medium text-foreground mb-1">队列超时 (ms)</Label>
+                  <Input v-model.number="form.queue_timeout_ms" type="number" min="0" placeholder="0 = 无限等待" @input="delete errors.queue_timeout_ms" />
+                  <p v-if="errors.queue_timeout_ms" class="text-sm text-destructive mt-1">{{ errors.queue_timeout_ms }}</p>
+                </div>
+                <div>
+                  <Label class="block text-sm font-medium text-foreground mb-1">最大队列长度</Label>
+                  <Input v-model.number="form.max_queue_size" type="number" min="1" :max="MAX_QUEUE_SIZE" :placeholder="DEFAULT_QUEUE_SIZE" @input="delete errors.max_queue_size" />
+                  <p v-if="errors.max_queue_size" class="text-sm text-destructive mt-1">{{ errors.max_queue_size }}</p>
                 </div>
               </div>
             </div>
@@ -245,10 +242,10 @@ import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@
 import { Table, TableHeader, TableBody, TableRow, TableHead, TableCell } from '@/components/ui/table'
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog'
 import { AlertDialog, AlertDialogContent, AlertDialogHeader, AlertDialogTitle, AlertDialogDescription, AlertDialogFooter, AlertDialogCancel, AlertDialogAction } from '@/components/ui/alert-dialog'
-import { Switch } from '@/components/ui/switch'
 import { Copy, Check } from 'lucide-vue-next'
 
 const DEFAULT_CONCURRENCY = 3
+const DEFAULT_CONCURRENCY_AUTO = 10
 const DEFAULT_QUEUE_TIMEOUT_MS = 120_000
 const DEFAULT_QUEUE_SIZE = 10
 const MAX_CONCURRENCY = 100
@@ -266,7 +263,7 @@ const CONTEXT_WINDOW_OPTIONS = [
   { label: '256K', value: '256000' },
   { label: '1M', value: '1000000' },
 ] as const
-const DEFAULT_FORM = { name: '', api_type: 'anthropic', base_url: '', api_key: '', models: [] as ModelInfo[], is_active: true, max_concurrency: DEFAULT_CONCURRENCY, queue_timeout_ms: DEFAULT_QUEUE_TIMEOUT_MS, max_queue_size: DEFAULT_QUEUE_SIZE, adaptive_enabled: false }
+const DEFAULT_FORM = { name: '', api_type: 'anthropic', base_url: '', api_key: '', models: [] as ModelInfo[], is_active: true, max_concurrency: DEFAULT_CONCURRENCY_AUTO, queue_timeout_ms: DEFAULT_QUEUE_TIMEOUT_MS, max_queue_size: DEFAULT_QUEUE_SIZE, adaptive_enabled: true }
 const modelInput = ref('')
 const modelContextWindow = ref(DEFAULT_CONTEXT_WINDOW)
 const contextWindowSelect = computed({
@@ -285,7 +282,8 @@ const pendingToggleActive = ref<boolean>(false)
 const toggleDependencies = ref<string[]>([])
 const form = ref({ ...DEFAULT_FORM })
 const errors = ref<Record<string, string>>({})
-const concurrencyEnabled = ref(false)
+type ConcurrencyMode = 'auto' | 'manual' | 'none'
+const concurrencyMode = ref<ConcurrencyMode>('auto')
 const copiedId = ref<string | null>(null)
 
 const MASK_VISIBLE_LEN = 7
@@ -307,7 +305,7 @@ function validate(): boolean {
     }
   }
   if (!editingId.value && !form.value.api_key.trim()) errs.api_key = '请输入 API Key'
-  if (concurrencyEnabled.value) {
+  if (concurrencyMode.value !== 'none') {
     const mc = form.value.max_concurrency
     if (!mc || mc < 1 || mc > MAX_CONCURRENCY) errs.max_concurrency = `范围 1-${MAX_CONCURRENCY}`
     if (form.value.queue_timeout_ms < 0) errs.queue_timeout_ms = '不能为负数'
@@ -394,10 +392,20 @@ function removeModel(index: number) {
   form.value.models.splice(index, 1)
 }
 
+function onConcurrencyModeChange(mode: ConcurrencyMode) {
+  if (mode === 'auto') {
+    if (!form.value.max_concurrency || form.value.max_concurrency < 1) form.value.max_concurrency = DEFAULT_CONCURRENCY_AUTO
+    form.value.adaptive_enabled = true
+  } else if (mode === 'manual') {
+    if (!form.value.max_concurrency || form.value.max_concurrency < 1) form.value.max_concurrency = DEFAULT_CONCURRENCY
+    form.value.adaptive_enabled = false
+  }
+}
+
 function openCreate() {
   editingId.value = null
   form.value = { ...DEFAULT_FORM, models: [] }
-  concurrencyEnabled.value = true
+  concurrencyMode.value = 'auto'
   modelInput.value = ''
   modelContextWindow.value = DEFAULT_CONTEXT_WINDOW
   presetGroup.value = ''
@@ -408,8 +416,15 @@ function openCreate() {
 
 function openEdit(p: Provider) {
   editingId.value = p.id
-  form.value = { name: p.name, api_type: p.api_type, base_url: p.base_url, api_key: '', models: (p.models || []).map(m => ({ name: m.name, context_window: m.context_window ?? DEFAULT_CONTEXT_WINDOW })), is_active: !!p.is_active, max_concurrency: p.max_concurrency ?? DEFAULT_CONCURRENCY, queue_timeout_ms: p.queue_timeout_ms ?? DEFAULT_QUEUE_TIMEOUT_MS, max_queue_size: p.max_queue_size ?? DEFAULT_QUEUE_SIZE, adaptive_enabled: !!p.adaptive_enabled }
-  concurrencyEnabled.value = (p.max_concurrency ?? 0) > 0
+  const mc = p.max_concurrency ?? 0
+  if (mc === 0) {
+    concurrencyMode.value = 'none'
+  } else if (p.adaptive_enabled) {
+    concurrencyMode.value = 'auto'
+  } else {
+    concurrencyMode.value = 'manual'
+  }
+  form.value = { name: p.name, api_type: p.api_type, base_url: p.base_url, api_key: '', models: (p.models || []).map(m => ({ name: m.name, context_window: m.context_window ?? DEFAULT_CONTEXT_WINDOW })), is_active: !!p.is_active, max_concurrency: concurrencyMode.value === 'none' ? DEFAULT_CONCURRENCY_AUTO : mc, queue_timeout_ms: p.queue_timeout_ms ?? DEFAULT_QUEUE_TIMEOUT_MS, max_queue_size: p.max_queue_size ?? DEFAULT_QUEUE_SIZE, adaptive_enabled: concurrencyMode.value === 'auto' }
   modelInput.value = ''
   modelContextWindow.value = DEFAULT_CONTEXT_WINDOW
   presetGroup.value = ''
@@ -427,10 +442,10 @@ function buildPayload(): ProviderFormPayload {
     base_url: form.value.base_url,
     models: form.value.models.map(m => ({ name: m.name, context_window: m.context_window ?? undefined })),
     is_active: form.value.is_active ? 1 : 0,
-    max_concurrency: concurrencyEnabled.value ? form.value.max_concurrency : 0,
-    queue_timeout_ms: concurrencyEnabled.value ? form.value.queue_timeout_ms : 0,
-    max_queue_size: concurrencyEnabled.value ? form.value.max_queue_size : DEFAULT_QUEUE_SIZE,
-    adaptive_enabled: concurrencyEnabled.value && form.value.adaptive_enabled ? 1 : 0,
+    max_concurrency: concurrencyMode.value === 'none' ? 0 : form.value.max_concurrency,
+    queue_timeout_ms: concurrencyMode.value === 'none' ? 0 : form.value.queue_timeout_ms,
+    max_queue_size: concurrencyMode.value === 'none' ? DEFAULT_QUEUE_SIZE : form.value.max_queue_size,
+    adaptive_enabled: concurrencyMode.value === 'auto' ? 1 : 0,
   }
   if (form.value.api_key) payload.api_key = form.value.api_key
   return payload

--- a/frontend/src/views/Providers.vue
+++ b/frontend/src/views/Providers.vue
@@ -48,7 +48,8 @@
               </div>
             </TableCell>
             <TableCell>
-              <Badge v-if="p.max_concurrency > 0" variant="secondary">{{ p.max_concurrency }}</Badge>
+              <Badge v-if="p.adaptive_enabled" variant="outline">自适应</Badge>
+              <Badge v-else-if="p.max_concurrency > 0" variant="secondary">{{ p.max_concurrency }}</Badge>
               <span v-else class="text-muted-foreground">-</span>
             </TableCell>
             <TableCell>
@@ -153,7 +154,9 @@
             </div>
             <div v-if="concurrencyEnabled" class="mt-2 space-y-2">
               <div>
-                <Label class="block text-sm font-medium text-foreground mb-1">最大并发数</Label>
+                <Label class="block text-sm font-medium text-foreground mb-1">
+                  {{ form.adaptive_enabled ? '自适应上限' : '最大并发数' }}
+                </Label>
                 <Input v-model.number="form.max_concurrency" type="number" min="1" :max="MAX_CONCURRENCY" placeholder="3" @input="delete errors.max_concurrency" />
                 <p v-if="errors.max_concurrency" class="text-sm text-destructive mt-1">{{ errors.max_concurrency }}</p>
               </div>
@@ -166,6 +169,23 @@
                 <Label class="block text-sm font-medium text-foreground mb-1">最大队列长度</Label>
                 <Input v-model.number="form.max_queue_size" type="number" min="1" :max="MAX_QUEUE_SIZE" :placeholder="DEFAULT_QUEUE_SIZE" @input="delete errors.max_queue_size" />
                 <p v-if="errors.max_queue_size" class="text-sm text-destructive mt-1">{{ errors.max_queue_size }}</p>
+              </div>
+              <!-- 自适应并发 -->
+              <div class="mt-3 border-t pt-3">
+                <div class="flex items-center gap-2 mb-1">
+                  <Switch v-model="form.adaptive_enabled" id="adaptive-switch" />
+                  <Label for="adaptive-switch" class="text-sm text-foreground">自适应并发</Label>
+                </div>
+                <p v-if="form.adaptive_enabled" class="text-xs text-muted-foreground mb-2">
+                  从 {{ form.adaptive_min || 1 }} 开始自动调整，上限为 {{ form.max_concurrency || '-' }}
+                </p>
+                <div v-if="form.adaptive_enabled" class="space-y-2">
+                  <div>
+                    <Label class="block text-sm font-medium text-foreground mb-1">自适应下限</Label>
+                    <Input v-model.number="form.adaptive_min" type="number" min="1" :max="form.max_concurrency || 100" placeholder="1" @input="delete errors.adaptive_min" />
+                    <p v-if="errors.adaptive_min" class="text-sm text-destructive mt-1">{{ errors.adaptive_min }}</p>
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -249,7 +269,7 @@ const CONTEXT_WINDOW_OPTIONS = [
   { label: '256K', value: '256000' },
   { label: '1M', value: '1000000' },
 ] as const
-const DEFAULT_FORM = { name: '', api_type: 'anthropic', base_url: '', api_key: '', models: [] as ModelInfo[], is_active: true, max_concurrency: DEFAULT_CONCURRENCY, queue_timeout_ms: DEFAULT_QUEUE_TIMEOUT_MS, max_queue_size: DEFAULT_QUEUE_SIZE }
+const DEFAULT_FORM = { name: '', api_type: 'anthropic', base_url: '', api_key: '', models: [] as ModelInfo[], is_active: true, max_concurrency: DEFAULT_CONCURRENCY, queue_timeout_ms: DEFAULT_QUEUE_TIMEOUT_MS, max_queue_size: DEFAULT_QUEUE_SIZE, adaptive_enabled: false, adaptive_min: 1 }
 const modelInput = ref('')
 const modelContextWindow = ref(DEFAULT_CONTEXT_WINDOW)
 const contextWindowSelect = computed({
@@ -296,6 +316,11 @@ function validate(): boolean {
     if (form.value.queue_timeout_ms < 0) errs.queue_timeout_ms = '不能为负数'
     const qs = form.value.max_queue_size
     if (!qs || qs < 1 || qs > MAX_QUEUE_SIZE) errs.max_queue_size = `范围 1-${MAX_QUEUE_SIZE}`
+    if (form.value.adaptive_enabled) {
+      const min = form.value.adaptive_min
+      if (!min || min < 1) errs.adaptive_min = '最小为 1'
+      if (min > form.value.max_concurrency) errs.adaptive_min = '不能超过上限 ' + form.value.max_concurrency
+    }
   }
   errors.value = errs
   return Object.keys(errs).length === 0
@@ -391,7 +416,7 @@ function openCreate() {
 
 function openEdit(p: Provider) {
   editingId.value = p.id
-  form.value = { name: p.name, api_type: p.api_type, base_url: p.base_url, api_key: '', models: (p.models || []).map(m => ({ name: m.name, context_window: m.context_window ?? DEFAULT_CONTEXT_WINDOW })), is_active: !!p.is_active, max_concurrency: p.max_concurrency ?? DEFAULT_CONCURRENCY, queue_timeout_ms: p.queue_timeout_ms ?? DEFAULT_QUEUE_TIMEOUT_MS, max_queue_size: p.max_queue_size ?? DEFAULT_QUEUE_SIZE }
+  form.value = { name: p.name, api_type: p.api_type, base_url: p.base_url, api_key: '', models: (p.models || []).map(m => ({ name: m.name, context_window: m.context_window ?? DEFAULT_CONTEXT_WINDOW })), is_active: !!p.is_active, max_concurrency: p.max_concurrency ?? DEFAULT_CONCURRENCY, queue_timeout_ms: p.queue_timeout_ms ?? DEFAULT_QUEUE_TIMEOUT_MS, max_queue_size: p.max_queue_size ?? DEFAULT_QUEUE_SIZE, adaptive_enabled: !!p.adaptive_enabled, adaptive_min: p.adaptive_min || 1 }
   concurrencyEnabled.value = (p.max_concurrency ?? 0) > 0
   modelInput.value = ''
   modelContextWindow.value = DEFAULT_CONTEXT_WINDOW
@@ -401,7 +426,7 @@ function openEdit(p: Provider) {
   dialogOpen.value = true
 }
 
-type ProviderFormPayload = Pick<ProviderPayload, 'name' | 'api_type' | 'base_url' | 'models' | 'is_active' | 'max_concurrency' | 'queue_timeout_ms' | 'max_queue_size'> & { api_key?: string }
+type ProviderFormPayload = Pick<ProviderPayload, 'name' | 'api_type' | 'base_url' | 'models' | 'is_active' | 'max_concurrency' | 'queue_timeout_ms' | 'max_queue_size' | 'adaptive_enabled' | 'adaptive_min'> & { api_key?: string }
 
 function buildPayload(): ProviderFormPayload {
   const payload: ProviderFormPayload = {
@@ -413,6 +438,8 @@ function buildPayload(): ProviderFormPayload {
     max_concurrency: concurrencyEnabled.value ? form.value.max_concurrency : 0,
     queue_timeout_ms: concurrencyEnabled.value ? form.value.queue_timeout_ms : 0,
     max_queue_size: concurrencyEnabled.value ? form.value.max_queue_size : DEFAULT_QUEUE_SIZE,
+    adaptive_enabled: concurrencyEnabled.value && form.value.adaptive_enabled ? 1 : 0,
+    adaptive_min: concurrencyEnabled.value && form.value.adaptive_enabled ? form.value.adaptive_min : 1,
   }
   if (form.value.api_key) payload.api_key = form.value.api_key
   return payload

--- a/src/admin/providers.ts
+++ b/src/admin/providers.ts
@@ -107,7 +107,6 @@ const CreateProviderSchema = Type.Object({
   queue_timeout_ms: Type.Optional(Type.Integer({ minimum: 0 })),
   max_queue_size: Type.Optional(Type.Integer({ minimum: 1 })),
   adaptive_enabled: Type.Optional(Type.Integer({ minimum: 0, maximum: 1 })),
-  adaptive_min: Type.Optional(Type.Integer({ minimum: 1 })),
 });
 
 const UpdateProviderSchema = Type.Object({
@@ -124,7 +123,6 @@ const UpdateProviderSchema = Type.Object({
   queue_timeout_ms: Type.Optional(Type.Integer({ minimum: 0 })),
   max_queue_size: Type.Optional(Type.Integer({ minimum: 1 })),
   adaptive_enabled: Type.Optional(Type.Integer({ minimum: 0, maximum: 1 })),
-  adaptive_min: Type.Optional(Type.Integer({ minimum: 1 })),
 });
 
 interface ProviderRoutesOptions {
@@ -157,7 +155,6 @@ export const adminProviderRoutes: FastifyPluginCallback<ProviderRoutesOptions> =
         queue_timeout_ms: s.queue_timeout_ms,
         max_queue_size: s.max_queue_size,
         adaptive_enabled: s.adaptive_enabled,
-        adaptive_min: s.adaptive_min,
         concurrency_status: semaphoreManager?.getStatus(s.id) ?? { active: 0, queued: 0 },
         created_at: s.created_at,
         updated_at: s.updated_at,
@@ -189,7 +186,6 @@ export const adminProviderRoutes: FastifyPluginCallback<ProviderRoutesOptions> =
       queue_timeout_ms: body.queue_timeout_ms ?? PROVIDER_CONCURRENCY_DEFAULTS.queue_timeout_ms,
       max_queue_size: body.max_queue_size ?? PROVIDER_CONCURRENCY_DEFAULTS.max_queue_size,
       adaptive_enabled: isAdaptiveEnabled,
-      adaptive_min: body.adaptive_min ?? 1,
     });
     if (contextOverrides.length > 0) {
       setModelInfoForProvider(db, id, contextOverrides.map(o => ({ model_name: o.name, context_window: o.context_window })));
@@ -201,7 +197,6 @@ export const adminProviderRoutes: FastifyPluginCallback<ProviderRoutesOptions> =
     });
     adaptiveController?.syncProvider(id, {
       adaptive_enabled: isAdaptiveEnabled,
-      adaptive_min: body.adaptive_min ?? 1,
       max_concurrency: body.max_concurrency ?? PROVIDER_CONCURRENCY_DEFAULTS.max_concurrency,
       queue_timeout_ms: body.queue_timeout_ms ?? PROVIDER_CONCURRENCY_DEFAULTS.queue_timeout_ms,
       max_queue_size: body.max_queue_size ?? PROVIDER_CONCURRENCY_DEFAULTS.max_queue_size,
@@ -225,7 +220,7 @@ export const adminProviderRoutes: FastifyPluginCallback<ProviderRoutesOptions> =
     if (body.name !== undefined && !PROVIDER_NAME_RE.test(body.name)) {
       return reply.code(HTTP_BAD_REQUEST).send(apiError(API_CODE.VALIDATION_FAILED, "Provider 名称仅允许英文大小写字母、数字、横线和下划线"));
     }
-    const fields: Partial<Pick<Provider, 'name' | 'api_type' | 'base_url' | 'api_key' | 'api_key_preview' | 'models' | 'is_active' | 'max_concurrency' | 'queue_timeout_ms' | 'max_queue_size' | 'adaptive_enabled' | 'adaptive_min'>> = {};
+    const fields: Partial<Pick<Provider, 'name' | 'api_type' | 'base_url' | 'api_key' | 'api_key_preview' | 'models' | 'is_active' | 'max_concurrency' | 'queue_timeout_ms' | 'max_queue_size' | 'adaptive_enabled'>> = {};
     if (body.name !== undefined) fields.name = body.name;
     if (body.api_type !== undefined) fields.api_type = body.api_type;
     if (body.base_url !== undefined) fields.base_url = body.base_url;
@@ -243,7 +238,6 @@ export const adminProviderRoutes: FastifyPluginCallback<ProviderRoutesOptions> =
     if (body.queue_timeout_ms !== undefined) fields.queue_timeout_ms = body.queue_timeout_ms;
     if (body.max_queue_size !== undefined) fields.max_queue_size = body.max_queue_size;
     if (body.adaptive_enabled !== undefined) fields.adaptive_enabled = body.adaptive_enabled;
-    if (body.adaptive_min !== undefined) fields.adaptive_min = body.adaptive_min;
     if (body.api_key) {
       fields.api_key = encrypt(body.api_key, getSetting(db, "encryption_key")!);
       fields.api_key_preview = body.api_key.length > API_KEY_PREVIEW_MIN_LENGTH ? `${body.api_key.slice(0, API_KEY_PREVIEW_PREFIX_LEN)}...${body.api_key.slice(-API_KEY_PREVIEW_PREFIX_LEN)}` : "****";
@@ -263,10 +257,9 @@ export const adminProviderRoutes: FastifyPluginCallback<ProviderRoutesOptions> =
         maxQueueSize: updated.max_queue_size,
       });
     }
-    if (body.adaptive_enabled !== undefined || body.adaptive_min !== undefined || body.max_concurrency !== undefined || body.queue_timeout_ms !== undefined || body.max_queue_size !== undefined) {
+    if (body.adaptive_enabled !== undefined || body.max_concurrency !== undefined || body.queue_timeout_ms !== undefined || body.max_queue_size !== undefined) {
       adaptiveController?.syncProvider(id, {
         adaptive_enabled: updated.adaptive_enabled,
-        adaptive_min: updated.adaptive_min,
         max_concurrency: updated.max_concurrency,
         queue_timeout_ms: updated.queue_timeout_ms,
         max_queue_size: updated.max_queue_size,

--- a/src/admin/providers.ts
+++ b/src/admin/providers.ts
@@ -106,6 +106,8 @@ const CreateProviderSchema = Type.Object({
   max_concurrency: Type.Optional(Type.Integer({ minimum: 0 })),
   queue_timeout_ms: Type.Optional(Type.Integer({ minimum: 0 })),
   max_queue_size: Type.Optional(Type.Integer({ minimum: 1 })),
+  adaptive_enabled: Type.Optional(Type.Integer({ minimum: 0, maximum: 1 })),
+  adaptive_min: Type.Optional(Type.Integer({ minimum: 1 })),
 });
 
 const UpdateProviderSchema = Type.Object({
@@ -174,6 +176,7 @@ export const adminProviderRoutes: FastifyPluginCallback<ProviderRoutesOptions> =
     }
     const encryptedKey = encrypt(body.api_key, getSetting(db, "encryption_key")!);
     const { names: normalizedModels, overrides: contextOverrides } = extractModelOverrides((body.models ?? []) as ModelInput[]);
+    const isAdaptiveEnabled = body.adaptive_enabled ?? 0;
     const id = createProvider(db, {
       name: body.name,
       api_type: body.api_type,
@@ -185,6 +188,8 @@ export const adminProviderRoutes: FastifyPluginCallback<ProviderRoutesOptions> =
       max_concurrency: body.max_concurrency ?? PROVIDER_CONCURRENCY_DEFAULTS.max_concurrency,
       queue_timeout_ms: body.queue_timeout_ms ?? PROVIDER_CONCURRENCY_DEFAULTS.queue_timeout_ms,
       max_queue_size: body.max_queue_size ?? PROVIDER_CONCURRENCY_DEFAULTS.max_queue_size,
+      adaptive_enabled: isAdaptiveEnabled,
+      adaptive_min: body.adaptive_min ?? 1,
     });
     if (contextOverrides.length > 0) {
       setModelInfoForProvider(db, id, contextOverrides.map(o => ({ model_name: o.name, context_window: o.context_window })));
@@ -193,6 +198,13 @@ export const adminProviderRoutes: FastifyPluginCallback<ProviderRoutesOptions> =
       maxConcurrency: body.max_concurrency ?? PROVIDER_CONCURRENCY_DEFAULTS.max_concurrency,
       queueTimeoutMs: body.queue_timeout_ms ?? PROVIDER_CONCURRENCY_DEFAULTS.queue_timeout_ms,
       maxQueueSize: body.max_queue_size ?? PROVIDER_CONCURRENCY_DEFAULTS.max_queue_size,
+    });
+    adaptiveController?.syncProvider(id, {
+      adaptive_enabled: isAdaptiveEnabled,
+      adaptive_min: body.adaptive_min ?? 1,
+      max_concurrency: body.max_concurrency ?? PROVIDER_CONCURRENCY_DEFAULTS.max_concurrency,
+      queue_timeout_ms: body.queue_timeout_ms ?? PROVIDER_CONCURRENCY_DEFAULTS.queue_timeout_ms,
+      max_queue_size: body.max_queue_size ?? PROVIDER_CONCURRENCY_DEFAULTS.max_queue_size,
     });
     tracker?.updateProviderConfig(id, {
       name: body.name,
@@ -251,7 +263,7 @@ export const adminProviderRoutes: FastifyPluginCallback<ProviderRoutesOptions> =
         maxQueueSize: updated.max_queue_size,
       });
     }
-    if (body.adaptive_enabled !== undefined || body.adaptive_min !== undefined || body.max_concurrency !== undefined) {
+    if (body.adaptive_enabled !== undefined || body.adaptive_min !== undefined || body.max_concurrency !== undefined || body.queue_timeout_ms !== undefined || body.max_queue_size !== undefined) {
       adaptiveController?.syncProvider(id, {
         adaptive_enabled: updated.adaptive_enabled,
         adaptive_min: updated.adaptive_min,

--- a/src/admin/providers.ts
+++ b/src/admin/providers.ts
@@ -6,6 +6,7 @@ import { getAllProviders, getProviderById, createProvider, updateProvider, delet
 import { encrypt, decrypt } from "../utils/crypto.js";
 import { getSetting } from "../db/settings.js";
 import { ProviderSemaphoreManager } from "../proxy/semaphore.js";
+import type { AdaptiveConcurrencyController } from "../proxy/adaptive-controller.js";
 import type { RequestTracker } from "../monitor/request-tracker.js";
 import { HTTP_CREATED, HTTP_NOT_FOUND, HTTP_CONFLICT, HTTP_BAD_REQUEST } from "./constants.js";
 import { API_CODE, apiError } from "./api-response.js";
@@ -120,16 +121,19 @@ const UpdateProviderSchema = Type.Object({
   max_concurrency: Type.Optional(Type.Integer({ minimum: 0 })),
   queue_timeout_ms: Type.Optional(Type.Integer({ minimum: 0 })),
   max_queue_size: Type.Optional(Type.Integer({ minimum: 1 })),
+  adaptive_enabled: Type.Optional(Type.Integer({ minimum: 0, maximum: 1 })),
+  adaptive_min: Type.Optional(Type.Integer({ minimum: 1 })),
 });
 
 interface ProviderRoutesOptions {
   db: Database.Database;
   semaphoreManager?: ProviderSemaphoreManager;
   tracker?: RequestTracker;
+  adaptiveController?: AdaptiveConcurrencyController;
 }
 
 export const adminProviderRoutes: FastifyPluginCallback<ProviderRoutesOptions> = (app, options, done) => {
-  const { db, semaphoreManager, tracker } = options;
+  const { db, semaphoreManager, tracker, adaptiveController } = options;
 
   app.get("/admin/api/providers", async (_request, reply) => {
     const encryptionKey = getSetting(db, "encryption_key")!;
@@ -150,6 +154,8 @@ export const adminProviderRoutes: FastifyPluginCallback<ProviderRoutesOptions> =
         max_concurrency: s.max_concurrency,
         queue_timeout_ms: s.queue_timeout_ms,
         max_queue_size: s.max_queue_size,
+        adaptive_enabled: s.adaptive_enabled,
+        adaptive_min: s.adaptive_min,
         concurrency_status: semaphoreManager?.getStatus(s.id) ?? { active: 0, queued: 0 },
         created_at: s.created_at,
         updated_at: s.updated_at,
@@ -207,7 +213,7 @@ export const adminProviderRoutes: FastifyPluginCallback<ProviderRoutesOptions> =
     if (body.name !== undefined && !PROVIDER_NAME_RE.test(body.name)) {
       return reply.code(HTTP_BAD_REQUEST).send(apiError(API_CODE.VALIDATION_FAILED, "Provider 名称仅允许英文大小写字母、数字、横线和下划线"));
     }
-    const fields: Partial<Pick<Provider, 'name' | 'api_type' | 'base_url' | 'api_key' | 'api_key_preview' | 'models' | 'is_active' | 'max_concurrency' | 'queue_timeout_ms' | 'max_queue_size'>> = {};
+    const fields: Partial<Pick<Provider, 'name' | 'api_type' | 'base_url' | 'api_key' | 'api_key_preview' | 'models' | 'is_active' | 'max_concurrency' | 'queue_timeout_ms' | 'max_queue_size' | 'adaptive_enabled' | 'adaptive_min'>> = {};
     if (body.name !== undefined) fields.name = body.name;
     if (body.api_type !== undefined) fields.api_type = body.api_type;
     if (body.base_url !== undefined) fields.base_url = body.base_url;
@@ -224,6 +230,8 @@ export const adminProviderRoutes: FastifyPluginCallback<ProviderRoutesOptions> =
     if (body.max_concurrency !== undefined) fields.max_concurrency = body.max_concurrency;
     if (body.queue_timeout_ms !== undefined) fields.queue_timeout_ms = body.queue_timeout_ms;
     if (body.max_queue_size !== undefined) fields.max_queue_size = body.max_queue_size;
+    if (body.adaptive_enabled !== undefined) fields.adaptive_enabled = body.adaptive_enabled;
+    if (body.adaptive_min !== undefined) fields.adaptive_min = body.adaptive_min;
     if (body.api_key) {
       fields.api_key = encrypt(body.api_key, getSetting(db, "encryption_key")!);
       fields.api_key_preview = body.api_key.length > API_KEY_PREVIEW_MIN_LENGTH ? `${body.api_key.slice(0, API_KEY_PREVIEW_PREFIX_LEN)}...${body.api_key.slice(-API_KEY_PREVIEW_PREFIX_LEN)}` : "****";
@@ -241,6 +249,15 @@ export const adminProviderRoutes: FastifyPluginCallback<ProviderRoutesOptions> =
         maxConcurrency: updated.max_concurrency,
         queueTimeoutMs: updated.queue_timeout_ms,
         maxQueueSize: updated.max_queue_size,
+      });
+    }
+    if (body.adaptive_enabled !== undefined || body.adaptive_min !== undefined || body.max_concurrency !== undefined) {
+      adaptiveController?.syncProvider(id, {
+        adaptive_enabled: updated.adaptive_enabled,
+        adaptive_min: updated.adaptive_min,
+        max_concurrency: updated.max_concurrency,
+        queue_timeout_ms: updated.queue_timeout_ms,
+        max_queue_size: updated.max_queue_size,
       });
     }
     tracker?.updateProviderConfig(id, {
@@ -305,8 +322,16 @@ export const adminProviderRoutes: FastifyPluginCallback<ProviderRoutesOptions> =
     }
     deleteProvider(db, id);
     semaphoreManager?.remove(id);
+    adaptiveController?.remove(id);
     tracker?.removeProviderConfig(id);
     return reply.send({ success: true });
+  });
+
+  app.get("/admin/api/providers/:id/adaptive-status", async (request, reply) => {
+    const { id } = request.params as { id: string };
+    const status = adaptiveController?.getStatus(id);
+    if (!status) return reply.code(HTTP_NOT_FOUND).send({ error: "Not found or adaptive not enabled" });
+    return status;
   });
 
   done();

--- a/src/admin/routes.ts
+++ b/src/admin/routes.ts
@@ -21,12 +21,14 @@ import { adminScheduleRoutes } from "./schedules.js";
 import { RetryRuleMatcher } from "../proxy/retry-rules.js";
 import type { RequestTracker } from "../monitor/request-tracker.js";
 import { ProviderSemaphoreManager } from "../proxy/semaphore.js";
+import type { AdaptiveConcurrencyController } from "../proxy/adaptive-controller.js";
 
 interface AdminRoutesOptions {
   db: Database.Database;
   matcher: RetryRuleMatcher | null;
   tracker?: RequestTracker;
   semaphoreManager?: ProviderSemaphoreManager;
+  adaptiveController?: AdaptiveConcurrencyController;
 }
 
 export const adminRoutes: FastifyPluginCallback<AdminRoutesOptions> = (app, options, done) => {
@@ -34,7 +36,7 @@ export const adminRoutes: FastifyPluginCallback<AdminRoutesOptions> = (app, opti
   app.register(adminSetupRoutes, { db: options.db });
   app.register(adminAuthPlugin, { db: options.db });
   app.register(adminLoginRoutes, { db: options.db });
-  app.register(adminProviderRoutes, { db: options.db, semaphoreManager: options.semaphoreManager, tracker: options.tracker });
+  app.register(adminProviderRoutes, { db: options.db, semaphoreManager: options.semaphoreManager, tracker: options.tracker, adaptiveController: options.adaptiveController });
   app.register(adminMappingRoutes, { db: options.db });
   app.register(adminGroupRoutes, { db: options.db });
   app.register(adminScheduleRoutes, { db: options.db });

--- a/src/db/migrations/033_add_adaptive_concurrency.sql
+++ b/src/db/migrations/033_add_adaptive_concurrency.sql
@@ -1,0 +1,3 @@
+-- 033_add_adaptive_concurrency.sql
+ALTER TABLE providers ADD COLUMN adaptive_enabled INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE providers ADD COLUMN adaptive_min INTEGER NOT NULL DEFAULT 1;

--- a/src/db/providers.ts
+++ b/src/db/providers.ts
@@ -60,13 +60,15 @@ export function createProvider(
     max_concurrency?: number;
     queue_timeout_ms?: number;
     max_queue_size?: number;
+    adaptive_enabled?: number;
+    adaptive_min?: number;
   },
 ): string {
   const id = randomUUID();
   const now = new Date().toISOString();
   db.prepare(
-    `INSERT INTO providers (id, name, api_type, base_url, api_key, api_key_preview, models, is_active, max_concurrency, queue_timeout_ms, max_queue_size, created_at, updated_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    `INSERT INTO providers (id, name, api_type, base_url, api_key, api_key_preview, models, is_active, max_concurrency, queue_timeout_ms, max_queue_size, adaptive_enabled, adaptive_min, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
     id, provider.name, provider.api_type, provider.base_url,
     provider.api_key, provider.api_key_preview ?? null,
@@ -75,6 +77,8 @@ export function createProvider(
     provider.max_concurrency ?? PROVIDER_CONCURRENCY_DEFAULTS.max_concurrency,
     provider.queue_timeout_ms ?? PROVIDER_CONCURRENCY_DEFAULTS.queue_timeout_ms,
     provider.max_queue_size ?? PROVIDER_CONCURRENCY_DEFAULTS.max_queue_size,
+    provider.adaptive_enabled ?? 0,
+    provider.adaptive_min ?? 1,
     now, now,
   );
   return id;

--- a/src/db/providers.ts
+++ b/src/db/providers.ts
@@ -15,7 +15,6 @@ export interface Provider {
   queue_timeout_ms: number;
   max_queue_size: number;
   adaptive_enabled: number;
-  adaptive_min: number;
   created_at: string;
   updated_at: string;
 }
@@ -27,7 +26,7 @@ export const PROVIDER_CONCURRENCY_DEFAULTS = {
 } as const;
 
 const PROVIDER_FIELDS = new Set([
-  "name", "api_type", "base_url", "api_key", "api_key_preview", "models", "is_active", "max_concurrency", "queue_timeout_ms", "max_queue_size", "adaptive_enabled", "adaptive_min",
+  "name", "api_type", "base_url", "api_key", "api_key_preview", "models", "is_active", "max_concurrency", "queue_timeout_ms", "max_queue_size", "adaptive_enabled",
 ]);
 
 export function getActiveProviders(
@@ -61,14 +60,13 @@ export function createProvider(
     queue_timeout_ms?: number;
     max_queue_size?: number;
     adaptive_enabled?: number;
-    adaptive_min?: number;
   },
 ): string {
   const id = randomUUID();
   const now = new Date().toISOString();
   db.prepare(
-    `INSERT INTO providers (id, name, api_type, base_url, api_key, api_key_preview, models, is_active, max_concurrency, queue_timeout_ms, max_queue_size, adaptive_enabled, adaptive_min, created_at, updated_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    `INSERT INTO providers (id, name, api_type, base_url, api_key, api_key_preview, models, is_active, max_concurrency, queue_timeout_ms, max_queue_size, adaptive_enabled, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
     id, provider.name, provider.api_type, provider.base_url,
     provider.api_key, provider.api_key_preview ?? null,
@@ -78,7 +76,6 @@ export function createProvider(
     provider.queue_timeout_ms ?? PROVIDER_CONCURRENCY_DEFAULTS.queue_timeout_ms,
     provider.max_queue_size ?? PROVIDER_CONCURRENCY_DEFAULTS.max_queue_size,
     provider.adaptive_enabled ?? 0,
-    provider.adaptive_min ?? 1,
     now, now,
   );
   return id;
@@ -87,7 +84,7 @@ export function createProvider(
 export function updateProvider(
   db: Database.Database,
   id: string,
-  fields: Partial<Pick<Provider, "name" | "api_type" | "base_url" | "api_key" | "api_key_preview" | "models" | "is_active" | "max_concurrency" | "queue_timeout_ms" | "max_queue_size" | "adaptive_enabled" | "adaptive_min">>,
+  fields: Partial<Pick<Provider, "name" | "api_type" | "base_url" | "api_key" | "api_key_preview" | "models" | "is_active" | "max_concurrency" | "queue_timeout_ms" | "max_queue_size" | "adaptive_enabled">>,
 ): void {
   buildUpdateQuery(db, "providers", id, fields, PROVIDER_FIELDS, { updatedAt: true });
 }

--- a/src/db/providers.ts
+++ b/src/db/providers.ts
@@ -14,6 +14,8 @@ export interface Provider {
   max_concurrency: number;
   queue_timeout_ms: number;
   max_queue_size: number;
+  adaptive_enabled: number;
+  adaptive_min: number;
   created_at: string;
   updated_at: string;
 }
@@ -25,7 +27,7 @@ export const PROVIDER_CONCURRENCY_DEFAULTS = {
 } as const;
 
 const PROVIDER_FIELDS = new Set([
-  "name", "api_type", "base_url", "api_key", "api_key_preview", "models", "is_active", "max_concurrency", "queue_timeout_ms", "max_queue_size",
+  "name", "api_type", "base_url", "api_key", "api_key_preview", "models", "is_active", "max_concurrency", "queue_timeout_ms", "max_queue_size", "adaptive_enabled", "adaptive_min",
 ]);
 
 export function getActiveProviders(
@@ -81,7 +83,7 @@ export function createProvider(
 export function updateProvider(
   db: Database.Database,
   id: string,
-  fields: Partial<Pick<Provider, "name" | "api_type" | "base_url" | "api_key" | "api_key_preview" | "models" | "is_active" | "max_concurrency" | "queue_timeout_ms" | "max_queue_size">>,
+  fields: Partial<Pick<Provider, "name" | "api_type" | "base_url" | "api_key" | "api_key_preview" | "models" | "is_active" | "max_concurrency" | "queue_timeout_ms" | "max_queue_size" | "adaptive_enabled" | "adaptive_min">>,
 ): void {
   buildUpdateQuery(db, "providers", id, fields, PROVIDER_FIELDS, { updatedAt: true });
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -202,7 +202,7 @@ export async function buildApp(
   const allProviders = getAllProviders(db);
   for (const p of allProviders) {
     if (p.adaptive_enabled) {
-      adaptiveController.init(p.id, { min: p.adaptive_min, max: p.max_concurrency }, {
+      adaptiveController.init(p.id, { max: p.max_concurrency }, {
         queueTimeoutMs: p.queue_timeout_ms,
         maxQueueSize: p.max_queue_size,
       });

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ import { anthropicProxy } from "./proxy/anthropic.js";
 import { adminRoutes } from "./admin/routes.js";
 import { RetryRuleMatcher } from "./proxy/retry-rules.js";
 import { ProviderSemaphoreManager } from "./proxy/semaphore.js";
+import { AdaptiveConcurrencyController } from "./proxy/adaptive-controller.js";
 import { RequestTracker } from "./monitor/request-tracker.js";
 import { modelState } from "./proxy/model-state.js";
 import { UsageWindowTracker } from "./proxy/usage-window-tracker.js";
@@ -187,6 +188,8 @@ export async function buildApp(
   const tracker = new RequestTracker({ semaphoreManager, logger: app.log });
   tracker.startPushInterval();
 
+  const adaptiveController = new AdaptiveConcurrencyController(semaphoreManager);
+
   // 5h 用量窗口追踪器，启动时自动补齐缺失窗口
   const usageWindowTracker = new UsageWindowTracker(db);
   usageWindowTracker.reconcileOnStartup();
@@ -197,7 +200,12 @@ export async function buildApp(
   // 从 DB 读取已有 provider 的并发配置，初始化信号量管理器和 tracker
   const allProviders = getAllProviders(db);
   for (const p of allProviders) {
-    if (p.max_concurrency > 0) {
+    if (p.adaptive_enabled) {
+      adaptiveController.init(p.id, { min: p.adaptive_min, max: p.max_concurrency }, {
+        queueTimeoutMs: p.queue_timeout_ms,
+        maxQueueSize: p.max_queue_size,
+      });
+    } else if (p.max_concurrency > 0) {
       semaphoreManager.updateConfig(p.id, {
         maxConcurrency: p.max_concurrency,
         queueTimeoutMs: p.queue_timeout_ms,
@@ -222,6 +230,7 @@ export async function buildApp(
     tracker,
     usageWindowTracker,
     sessionTracker,
+    adaptiveController,
   });
   app.register(anthropicProxy, {
     db,
@@ -232,9 +241,10 @@ export async function buildApp(
     tracker,
     usageWindowTracker,
     sessionTracker,
+    adaptiveController,
   });
 
-  app.register(adminRoutes, { db, matcher, tracker, semaphoreManager });
+  app.register(adminRoutes, { db, matcher, tracker, semaphoreManager, adaptiveController });
 
   // 前端静态文件服务（生产环境）
   const frontendDist = path.resolve(

--- a/src/index.ts
+++ b/src/index.ts
@@ -189,6 +189,7 @@ export async function buildApp(
   tracker.startPushInterval();
 
   const adaptiveController = new AdaptiveConcurrencyController(semaphoreManager);
+  tracker.setAdaptiveController(adaptiveController);
 
   // 5h 用量窗口追踪器，启动时自动补齐缺失窗口
   const usageWindowTracker = new UsageWindowTracker(db);

--- a/src/index.ts
+++ b/src/index.ts
@@ -188,7 +188,7 @@ export async function buildApp(
   const tracker = new RequestTracker({ semaphoreManager, logger: app.log });
   tracker.startPushInterval();
 
-  const adaptiveController = new AdaptiveConcurrencyController(semaphoreManager);
+  const adaptiveController = new AdaptiveConcurrencyController(semaphoreManager, app.log);
   tracker.setAdaptiveController(adaptiveController);
 
   // 5h 用量窗口追踪器，启动时自动补齐缺失窗口

--- a/src/monitor/request-tracker.ts
+++ b/src/monitor/request-tracker.ts
@@ -3,6 +3,7 @@ import { StatsAggregator } from "./stats-aggregator.js";
 import { RuntimeCollector } from "./runtime-collector.js";
 import { StreamContentAccumulator } from "./stream-content-accumulator.js";
 import type { ProviderSemaphoreManager } from "../proxy/semaphore.js";
+import type { AdaptiveConcurrencyController } from "../proxy/adaptive-controller.js";
 import type {
   ActiveRequest,
   AttemptSnapshot,
@@ -47,6 +48,7 @@ export class RequestTracker {
   readonly statsAggregator: StatsAggregator;
   readonly runtimeCollector: RuntimeCollector;
   private readonly semaphoreManager?: ProviderSemaphoreManager;
+  private adaptiveController?: AdaptiveConcurrencyController;
 
   constructor(deps?: {
     semaphoreManager?: ProviderSemaphoreManager;
@@ -57,6 +59,10 @@ export class RequestTracker {
     this.runtimeCollector = deps?.runtimeCollector ?? new RuntimeCollector();
     this.statsAggregator = new StatsAggregator();
     this.logger = deps?.logger;
+  }
+
+  setAdaptiveController(ctrl: AdaptiveConcurrencyController): void {
+    this.adaptiveController = ctrl;
   }
 
   // --- Core methods ---
@@ -207,6 +213,7 @@ export class RequestTracker {
     const result: ProviderConcurrencySnapshot[] = [];
     for (const [providerId, config] of this.providerConfigCache) {
       const status = this.semaphoreManager.getStatus(providerId);
+      const adaptiveState = this.adaptiveController?.getStatus(providerId);
       result.push({
         providerId,
         providerName: config.name,
@@ -215,6 +222,8 @@ export class RequestTracker {
         queued: status.queued,
         queueTimeoutMs: config.queueTimeoutMs,
         maxQueueSize: config.maxQueueSize,
+        adaptiveEnabled: adaptiveState !== undefined,
+        adaptiveLimit: adaptiveState?.currentLimit,
       });
     }
     return result;

--- a/src/monitor/types.ts
+++ b/src/monitor/types.ts
@@ -69,6 +69,8 @@ export interface ProviderConcurrencySnapshot {
   queued: number;
   queueTimeoutMs: number;
   maxQueueSize: number;
+  adaptiveEnabled?: boolean;
+  adaptiveLimit?: number;
 }
 
 export interface StatsSnapshot {

--- a/src/proxy/adaptive-controller.ts
+++ b/src/proxy/adaptive-controller.ts
@@ -26,8 +26,16 @@ interface AdaptiveEntry {
   maxQueueSize: number;
 }
 
+export interface ProviderAdaptiveConfig {
+  adaptive_enabled: number;
+  adaptive_min: number;
+  max_concurrency: number;
+  queue_timeout_ms: number;
+  max_queue_size: number;
+}
+
 export class AdaptiveConcurrencyController {
-  readonly entries = new Map<string, AdaptiveEntry>();
+  private readonly entries = new Map<string, AdaptiveEntry>();
 
   constructor(private semaphoreManager: ProviderSemaphoreManager) {}
 
@@ -66,10 +74,7 @@ export class AdaptiveConcurrencyController {
     return this.entries.get(providerId)?.state;
   }
 
-  syncProvider(providerId: string, p: {
-    adaptive_enabled: number; adaptive_min: number; max_concurrency: number;
-    queue_timeout_ms: number; max_queue_size: number;
-  }): void {
+  syncProvider(providerId: string, p: ProviderAdaptiveConfig): void {
     if (p.adaptive_enabled) {
       const existing = this.entries.get(providerId);
       if (existing) {
@@ -95,6 +100,7 @@ export class AdaptiveConcurrencyController {
     const s = entry.state;
     s.consecutiveSuccesses++;
     s.consecutiveFailures = 0;
+    // 冷却期内只累加计数，不触发调整；过期后累积的成功计数可能立即触发 probe
     if (Date.now() < s.cooldownUntil) return;
 
     if (s.consecutiveSuccesses >= SUCCESS_THRESHOLD) {

--- a/src/proxy/adaptive-controller.ts
+++ b/src/proxy/adaptive-controller.ts
@@ -17,6 +17,8 @@ const SUCCESS_THRESHOLD = 3;
 const FAILURE_THRESHOLD = 3;
 const DECREASE_STEP = 2;
 const COOLDOWN_MS = 30_000;
+const RATE_LIMIT_STATUS = 429;
+const HALF_DIVISOR = 2;
 
 interface AdaptiveEntry {
   state: AdaptiveState;
@@ -34,10 +36,18 @@ export interface ProviderAdaptiveConfig {
   max_queue_size: number;
 }
 
+export interface ControllerLogger {
+  debug(obj: Record<string, unknown>, msg: string): void;
+  warn(obj: Record<string, unknown>, msg: string): void;
+}
+
 export class AdaptiveConcurrencyController {
   private readonly entries = new Map<string, AdaptiveEntry>();
 
-  constructor(private semaphoreManager: ProviderSemaphoreManager) {}
+  constructor(
+    private semaphoreManager: ProviderSemaphoreManager,
+    private logger?: ControllerLogger,
+  ) {}
 
   init(providerId: string, config: { min: number; max: number }, semParams: { queueTimeoutMs: number; maxQueueSize: number }): void {
     this.entries.set(providerId, {
@@ -93,6 +103,12 @@ export class AdaptiveConcurrencyController {
       }
     } else {
       this.remove(providerId);
+      // 禁用自适应后恢复信号量到原始 max_concurrency
+      this.semaphoreManager.updateConfig(providerId, {
+        maxConcurrency: p.max_concurrency,
+        queueTimeoutMs: p.queue_timeout_ms,
+        maxQueueSize: p.max_queue_size,
+      });
     }
   }
 
@@ -100,16 +116,17 @@ export class AdaptiveConcurrencyController {
     const s = entry.state;
     s.consecutiveSuccesses++;
     s.consecutiveFailures = 0;
-    // 冷却期内只累加计数，不触发调整；过期后累积的成功计数可能立即触发 probe
     if (Date.now() < s.cooldownUntil) return;
 
     if (s.consecutiveSuccesses >= SUCCESS_THRESHOLD) {
       if (!s.probeActive) {
         s.probeActive = true;
         s.consecutiveSuccesses = 0;
+        this.logger?.debug({ providerId, currentLimit: s.currentLimit, action: "probe_open" }, "Adaptive: probe window opened");
       } else {
         s.currentLimit = Math.min(s.currentLimit + 1, entry.max);
         s.consecutiveSuccesses = 0;
+        this.logger?.debug({ providerId, currentLimit: s.currentLimit, max: entry.max, action: "limit_increased" }, "Adaptive: limit increased by 1");
       }
       this.syncToSemaphore(providerId);
     }
@@ -120,17 +137,21 @@ export class AdaptiveConcurrencyController {
     s.consecutiveFailures++;
     s.consecutiveSuccesses = 0;
 
-    if (statusCode === 429) {
-      s.currentLimit = Math.max(Math.floor(s.currentLimit / 2), entry.min);
+    if (statusCode === RATE_LIMIT_STATUS) {
+      const prevLimit = s.currentLimit;
+      s.currentLimit = Math.max(Math.floor(s.currentLimit / HALF_DIVISOR), entry.min);
       s.probeActive = false;
       s.cooldownUntil = Date.now() + COOLDOWN_MS;
       s.consecutiveFailures = 0;
       this.syncToSemaphore(providerId);
+      this.logger?.warn({ providerId, prevLimit, newLimit: s.currentLimit, cooldownMs: COOLDOWN_MS, action: "rate_limit_backoff" }, "Adaptive: 429 rate limit, halved concurrency and entered cooldown");
     } else if (s.consecutiveFailures >= FAILURE_THRESHOLD) {
+      const prevLimit = s.currentLimit;
       s.currentLimit = Math.max(s.currentLimit - DECREASE_STEP, entry.min);
       s.probeActive = false;
       s.consecutiveFailures = 0;
       this.syncToSemaphore(providerId);
+      this.logger?.warn({ providerId, prevLimit, newLimit: s.currentLimit, action: "failure_backoff" }, "Adaptive: sustained failures, decreased concurrency");
     }
   }
 

--- a/src/proxy/adaptive-controller.ts
+++ b/src/proxy/adaptive-controller.ts
@@ -20,9 +20,10 @@ const COOLDOWN_MS = 30_000;
 const RATE_LIMIT_STATUS = 429;
 const HALF_DIVISOR = 2;
 
+const ADAPTIVE_MIN = 1;
+
 interface AdaptiveEntry {
   state: AdaptiveState;
-  min: number;
   max: number;
   queueTimeoutMs: number;
   maxQueueSize: number;
@@ -30,7 +31,6 @@ interface AdaptiveEntry {
 
 export interface ProviderAdaptiveConfig {
   adaptive_enabled: number;
-  adaptive_min: number;
   max_concurrency: number;
   queue_timeout_ms: number;
   max_queue_size: number;
@@ -49,16 +49,15 @@ export class AdaptiveConcurrencyController {
     private logger?: ControllerLogger,
   ) {}
 
-  init(providerId: string, config: { min: number; max: number }, semParams: { queueTimeoutMs: number; maxQueueSize: number }): void {
+  init(providerId: string, config: { max: number }, semParams: { queueTimeoutMs: number; maxQueueSize: number }): void {
     this.entries.set(providerId, {
       state: {
-        currentLimit: config.min,
+        currentLimit: ADAPTIVE_MIN,
         probeActive: false,
         consecutiveSuccesses: 0,
         consecutiveFailures: 0,
         cooldownUntil: 0,
       },
-      min: config.min,
       max: config.max,
       queueTimeoutMs: semParams.queueTimeoutMs,
       maxQueueSize: semParams.maxQueueSize,
@@ -88,16 +87,15 @@ export class AdaptiveConcurrencyController {
     if (p.adaptive_enabled) {
       const existing = this.entries.get(providerId);
       if (existing) {
-        existing.min = p.adaptive_min;
         existing.max = p.max_concurrency;
         existing.queueTimeoutMs = p.queue_timeout_ms;
         existing.maxQueueSize = p.max_queue_size;
         existing.state.currentLimit = Math.min(
-          Math.max(existing.state.currentLimit, existing.min), existing.max,
+          Math.max(existing.state.currentLimit, ADAPTIVE_MIN), existing.max,
         );
         this.syncToSemaphore(providerId);
       } else {
-        this.init(providerId, { min: p.adaptive_min, max: p.max_concurrency }, {
+        this.init(providerId, { max: p.max_concurrency }, {
           queueTimeoutMs: p.queue_timeout_ms, maxQueueSize: p.max_queue_size,
         });
       }
@@ -139,7 +137,7 @@ export class AdaptiveConcurrencyController {
 
     if (statusCode === RATE_LIMIT_STATUS) {
       const prevLimit = s.currentLimit;
-      s.currentLimit = Math.max(Math.floor(s.currentLimit / HALF_DIVISOR), entry.min);
+      s.currentLimit = Math.max(Math.floor(s.currentLimit / HALF_DIVISOR), ADAPTIVE_MIN);
       s.probeActive = false;
       s.cooldownUntil = Date.now() + COOLDOWN_MS;
       s.consecutiveFailures = 0;
@@ -147,7 +145,7 @@ export class AdaptiveConcurrencyController {
       this.logger?.warn({ providerId, prevLimit, newLimit: s.currentLimit, cooldownMs: COOLDOWN_MS, action: "rate_limit_backoff" }, "Adaptive: 429 rate limit, halved concurrency and entered cooldown");
     } else if (s.consecutiveFailures >= FAILURE_THRESHOLD) {
       const prevLimit = s.currentLimit;
-      s.currentLimit = Math.max(s.currentLimit - DECREASE_STEP, entry.min);
+      s.currentLimit = Math.max(s.currentLimit - DECREASE_STEP, ADAPTIVE_MIN);
       s.probeActive = false;
       s.consecutiveFailures = 0;
       this.syncToSemaphore(providerId);
@@ -160,8 +158,8 @@ export class AdaptiveConcurrencyController {
     if (!entry) return;
     // probeActive 时额外加 1 个探针槽位，但不超过 max
     const effectiveLimit = entry.state.probeActive
-      ? Math.min(entry.state.currentLimit + 1, entry.max)
-      : entry.state.currentLimit;
+      ? Math.min(Math.max(entry.state.currentLimit + 1, ADAPTIVE_MIN), entry.max)
+      : Math.max(entry.state.currentLimit, ADAPTIVE_MIN);
     this.semaphoreManager.updateConfig(providerId, {
       maxConcurrency: effectiveLimit,
       queueTimeoutMs: entry.queueTimeoutMs,

--- a/src/proxy/adaptive-controller.ts
+++ b/src/proxy/adaptive-controller.ts
@@ -1,0 +1,144 @@
+import type { ProviderSemaphoreManager } from "./semaphore.js";
+
+export interface AdaptiveState {
+  currentLimit: number;
+  probeActive: boolean;
+  consecutiveSuccesses: number;
+  consecutiveFailures: number;
+  cooldownUntil: number;
+}
+
+interface AdaptiveResult {
+  success: boolean;
+  statusCode?: number;
+}
+
+const SUCCESS_THRESHOLD = 3;
+const FAILURE_THRESHOLD = 3;
+const DECREASE_STEP = 2;
+const COOLDOWN_MS = 30_000;
+
+interface AdaptiveEntry {
+  state: AdaptiveState;
+  min: number;
+  max: number;
+  queueTimeoutMs: number;
+  maxQueueSize: number;
+}
+
+export class AdaptiveConcurrencyController {
+  readonly entries = new Map<string, AdaptiveEntry>();
+
+  constructor(private semaphoreManager: ProviderSemaphoreManager) {}
+
+  init(providerId: string, config: { min: number; max: number }, semParams: { queueTimeoutMs: number; maxQueueSize: number }): void {
+    this.entries.set(providerId, {
+      state: {
+        currentLimit: config.min,
+        probeActive: false,
+        consecutiveSuccesses: 0,
+        consecutiveFailures: 0,
+        cooldownUntil: 0,
+      },
+      min: config.min,
+      max: config.max,
+      queueTimeoutMs: semParams.queueTimeoutMs,
+      maxQueueSize: semParams.maxQueueSize,
+    });
+    this.syncToSemaphore(providerId);
+  }
+
+  remove(providerId: string): void {
+    this.entries.delete(providerId);
+  }
+
+  onRequestComplete(providerId: string, result: AdaptiveResult): void {
+    const entry = this.entries.get(providerId);
+    if (!entry) return;
+    if (result.success) {
+      this.transitionSuccess(providerId, entry);
+    } else {
+      this.transitionFailure(providerId, entry, result.statusCode);
+    }
+  }
+
+  getStatus(providerId: string): AdaptiveState | undefined {
+    return this.entries.get(providerId)?.state;
+  }
+
+  syncProvider(providerId: string, p: {
+    adaptive_enabled: number; adaptive_min: number; max_concurrency: number;
+    queue_timeout_ms: number; max_queue_size: number;
+  }): void {
+    if (p.adaptive_enabled) {
+      const existing = this.entries.get(providerId);
+      if (existing) {
+        existing.min = p.adaptive_min;
+        existing.max = p.max_concurrency;
+        existing.queueTimeoutMs = p.queue_timeout_ms;
+        existing.maxQueueSize = p.max_queue_size;
+        existing.state.currentLimit = Math.min(
+          Math.max(existing.state.currentLimit, existing.min), existing.max,
+        );
+        this.syncToSemaphore(providerId);
+      } else {
+        this.init(providerId, { min: p.adaptive_min, max: p.max_concurrency }, {
+          queueTimeoutMs: p.queue_timeout_ms, maxQueueSize: p.max_queue_size,
+        });
+      }
+    } else {
+      this.remove(providerId);
+    }
+  }
+
+  private transitionSuccess(providerId: string, entry: AdaptiveEntry): void {
+    const s = entry.state;
+    s.consecutiveSuccesses++;
+    s.consecutiveFailures = 0;
+    if (Date.now() < s.cooldownUntil) return;
+
+    if (s.consecutiveSuccesses >= SUCCESS_THRESHOLD) {
+      if (!s.probeActive) {
+        s.probeActive = true;
+        s.consecutiveSuccesses = 0;
+      } else {
+        s.currentLimit = Math.min(s.currentLimit + 1, entry.max);
+        s.consecutiveSuccesses = 0;
+      }
+      this.syncToSemaphore(providerId);
+    }
+  }
+
+  private transitionFailure(providerId: string, entry: AdaptiveEntry, statusCode?: number): void {
+    const s = entry.state;
+    s.consecutiveFailures++;
+    s.consecutiveSuccesses = 0;
+
+    if (statusCode === 429) {
+      s.currentLimit = Math.max(Math.floor(s.currentLimit / 2), entry.min);
+      s.probeActive = false;
+      s.cooldownUntil = Date.now() + COOLDOWN_MS;
+      s.consecutiveFailures = 0;
+      this.syncToSemaphore(providerId);
+    } else if (s.consecutiveFailures >= FAILURE_THRESHOLD) {
+      s.currentLimit = Math.max(s.currentLimit - DECREASE_STEP, entry.min);
+      s.probeActive = false;
+      s.consecutiveFailures = 0;
+      this.syncToSemaphore(providerId);
+    }
+  }
+
+  private syncToSemaphore(providerId: string): void {
+    const entry = this.entries.get(providerId);
+    if (!entry) return;
+    // probeActive 时额外加 1 个探针槽位，但不超过 max
+    const effectiveLimit = entry.state.probeActive
+      ? Math.min(entry.state.currentLimit + 1, entry.max)
+      : entry.state.currentLimit;
+    this.semaphoreManager.updateConfig(providerId, {
+      maxConcurrency: effectiveLimit,
+      queueTimeoutMs: entry.queueTimeoutMs,
+      maxQueueSize: entry.maxQueueSize,
+    });
+  }
+}

--- a/src/proxy/anthropic.ts
+++ b/src/proxy/anthropic.ts
@@ -11,6 +11,7 @@ import { RetryRuleMatcher } from "./retry-rules.js";
 import { ProviderSemaphoreManager } from "./semaphore.js";
 import type { RequestTracker } from "../monitor/request-tracker.js";
 import type { UsageWindowTracker } from "./usage-window-tracker.js";
+import type { AdaptiveConcurrencyController } from "./adaptive-controller.js";
 import { HTTP_BAD_GATEWAY } from "../constants.js";
 
 export interface AnthropicProxyOptions {
@@ -22,6 +23,7 @@ export interface AnthropicProxyOptions {
   tracker?: RequestTracker;
   usageWindowTracker?: UsageWindowTracker;
   sessionTracker?: import("./loop-prevention/session-tracker.js").SessionTracker;
+  adaptiveController?: AdaptiveConcurrencyController;
 }
 
 const MESSAGES_PATH = "/v1/messages";
@@ -42,9 +44,9 @@ const anthropicErrors = createErrorFormatter(
 );
 
 const anthropicProxyRaw: FastifyPluginCallback<AnthropicProxyOptions> = (app, opts, done) => {
-  const { db, streamTimeoutMs, retryBaseDelayMs, matcher, semaphoreManager, tracker, usageWindowTracker, sessionTracker } = opts;
+  const { db, streamTimeoutMs, retryBaseDelayMs, matcher, semaphoreManager, tracker, usageWindowTracker, sessionTracker, adaptiveController } = opts;
 
-  const orchestrator = createOrchestrator(semaphoreManager, tracker);
+  const orchestrator = createOrchestrator(semaphoreManager, tracker, adaptiveController);
 
   app.post(MESSAGES_PATH, async (request, reply) => {
     if (!orchestrator) {

--- a/src/proxy/openai.ts
+++ b/src/proxy/openai.ts
@@ -14,6 +14,7 @@ import { RetryRuleMatcher } from "./retry-rules.js";
 import { ProviderSemaphoreManager } from "./semaphore.js";
 import type { RequestTracker } from "../monitor/request-tracker.js";
 import type { UsageWindowTracker } from "./usage-window-tracker.js";
+import type { AdaptiveConcurrencyController } from "./adaptive-controller.js";
 import { HTTP_NOT_FOUND, HTTP_BAD_GATEWAY } from "../constants.js";
 
 export interface OpenaiProxyOptions {
@@ -25,6 +26,7 @@ export interface OpenaiProxyOptions {
   tracker?: RequestTracker;
   usageWindowTracker?: UsageWindowTracker;
   sessionTracker?: import("./loop-prevention/session-tracker.js").SessionTracker;
+  adaptiveController?: AdaptiveConcurrencyController;
 }
 
 const CHAT_COMPLETIONS_PATH = "/v1/chat/completions";
@@ -50,9 +52,9 @@ function sendError(reply: FastifyReply, e: ProxyErrorResponse) {
 }
 
 const openaiProxyRaw: FastifyPluginCallback<OpenaiProxyOptions> = (app, opts, done) => {
-  const { db, streamTimeoutMs, retryBaseDelayMs, matcher, semaphoreManager, tracker, usageWindowTracker, sessionTracker } = opts;
+  const { db, streamTimeoutMs, retryBaseDelayMs, matcher, semaphoreManager, tracker, usageWindowTracker, sessionTracker, adaptiveController } = opts;
 
-  const orchestrator = createOrchestrator(semaphoreManager, tracker);
+  const orchestrator = createOrchestrator(semaphoreManager, tracker, adaptiveController);
 
   app.post(CHAT_COMPLETIONS_PATH, async (request, reply) => {
     if (!orchestrator) {

--- a/src/proxy/orchestrator.ts
+++ b/src/proxy/orchestrator.ts
@@ -1,5 +1,6 @@
 import type { FastifyReply, FastifyRequest } from "fastify";
 import type { TransportResult } from "./types.js";
+import { ProviderSwitchNeeded } from "./types.js";
 import type { Target, ConcurrencyOverride } from "./strategy/types.js";
 import type { ResilienceLayer, ResilienceResult, ResilienceConfig } from "./resilience.js";
 import { ResilienceLayer as ResilienceLayerClass } from "./resilience.js";
@@ -11,6 +12,7 @@ import { TrackerScope as TrackerScopeClass } from "./scope.js";
 import type { ActiveRequest } from "../monitor/types.js";
 import type { ProviderSemaphoreManager } from "./semaphore.js";
 import type { RequestTracker } from "../monitor/request-tracker.js";
+import type { AdaptiveConcurrencyController } from "./adaptive-controller.js";
 
 const DEFAULT_BASE_DELAY_MS = 1000;
 const DEFAULT_FAILOVER_THRESHOLD = 400;
@@ -49,11 +51,12 @@ export interface HandleContext {
 export function createOrchestrator(
   semaphoreManager?: ProviderSemaphoreManager,
   tracker?: RequestTracker,
+  adaptiveController?: AdaptiveConcurrencyController,
 ): ProxyOrchestrator | undefined {
   const semaphoreScope = semaphoreManager ? new SemaphoreScopeClass(semaphoreManager) : undefined;
   const trackerScope = tracker ? new TrackerScopeClass(tracker) : undefined;
   if (!semaphoreScope || !trackerScope) return undefined;
-  return new ProxyOrchestrator({ semaphoreScope, trackerScope, resilience: new ResilienceLayerClass() });
+  return new ProxyOrchestrator({ semaphoreScope, trackerScope, resilience: new ResilienceLayerClass(), adaptiveController });
 }
 
 export class ProxyOrchestrator {
@@ -62,6 +65,7 @@ export class ProxyOrchestrator {
       semaphoreScope: SemaphoreScope;
       trackerScope: TrackerScope;
       resilience: ResilienceLayer;
+      adaptiveController?: AdaptiveConcurrencyController;
     },
   ) {}
 
@@ -72,35 +76,47 @@ export class ProxyOrchestrator {
     config: OrchestratorConfig,
     ctx?: HandleContext,
   ): Promise<ResilienceResult> {
+    const providerId = config.provider.id;
     const trackerReq = this.buildActiveRequest(request, config, apiType);
-    const result = await this.deps.trackerScope.track<ResilienceResult>(
-      trackerReq,
-      () => this.deps.semaphoreScope.withSlot(
-        config.provider.id,
-        this.createAbortSignal(request),
-        () => {
-          trackerReq.queued = true;
-          this.deps.trackerScope.markQueued(trackerReq.id, true);
-        },
-        () => {
-          if (trackerReq.queued) {
-            trackerReq.queued = false;
-            this.deps.trackerScope.markQueued(trackerReq.id, false);
-          }
-          return this.executeResilience(config, ctx);
-        },
-        config.concurrencyOverride,
-      ),
-      (result) => this.extractTrackStatus(result),
-      (result) => result.attempts.map(a => ({
-        statusCode: a.statusCode,
-        error: a.error,
-        latencyMs: a.latencyMs,
-        providerId: a.target.provider_id,
-      })),
-    );
-    this.sendResponse(reply, result.result, ctx);
-    return result;
+    try {
+      const result = await this.deps.trackerScope.track<ResilienceResult>(
+        trackerReq,
+        () => this.deps.semaphoreScope.withSlot(
+          providerId,
+          this.createAbortSignal(request),
+          () => {
+            trackerReq.queued = true;
+            this.deps.trackerScope.markQueued(trackerReq.id, true);
+          },
+          () => {
+            if (trackerReq.queued) {
+              trackerReq.queued = false;
+              this.deps.trackerScope.markQueued(trackerReq.id, false);
+            }
+            return this.executeResilience(config, ctx);
+          },
+          config.concurrencyOverride,
+        ),
+        (result) => this.extractTrackStatus(result),
+        (result) => result.attempts.map(a => ({
+          statusCode: a.statusCode,
+          error: a.error,
+          latencyMs: a.latencyMs,
+          providerId: a.target.provider_id,
+        })),
+      );
+      const { status, statusCode } = this.extractTrackStatus(result);
+      this.deps.adaptiveController?.onRequestComplete(providerId, { success: status === "completed", statusCode });
+      this.sendResponse(reply, result.result, ctx);
+      return result;
+    } catch (e) {
+      if (e instanceof ProviderSwitchNeeded) {
+        const lastResult = e.lastResult;
+        const statusCode = lastResult && "statusCode" in lastResult ? lastResult.statusCode : undefined;
+        this.deps.adaptiveController?.onRequestComplete(providerId, { success: false, statusCode });
+      }
+      throw e;
+    }
   }
 
   private buildActiveRequest(

--- a/tests/adaptive-controller.test.ts
+++ b/tests/adaptive-controller.test.ts
@@ -22,19 +22,20 @@ describe("AdaptiveConcurrencyController", () => {
   });
 
   describe("init", () => {
-    it("starts at adaptive_min", () => {
-      ctrl.init("p1", { min: 3, max: 20 }, { queueTimeoutMs: 5000, maxQueueSize: 10 });
-      expect(ctrl.getStatus("p1")!.currentLimit).toBe(3);
+    it("starts at ADAPTIVE_MIN (1)", () => {
+      ctrl.init("p1", { max: 20 }, { queueTimeoutMs: 5000, maxQueueSize: 10 });
+      expect(ctrl.getStatus("p1")!.currentLimit).toBe(1);
       expect(ctrl.getStatus("p1")!.probeActive).toBe(false);
       expect(sem.updateConfig).toHaveBeenCalledWith("p1", {
-        maxConcurrency: 3, queueTimeoutMs: 5000, maxQueueSize: 10,
+        maxConcurrency: 1, queueTimeoutMs: 5000, maxQueueSize: 10,
       });
     });
   });
 
   describe("success transitions", () => {
     beforeEach(() => {
-      ctrl.init("p1", { min: 3, max: 20 }, { queueTimeoutMs: 0, maxQueueSize: 0 });
+      ctrl.init("p1", { max: 20 }, { queueTimeoutMs: 0, maxQueueSize: 0 });
+      ctrl["entries"].get("p1")!.state.currentLimit = 3;
       sem.updateConfig.mockClear();
     });
 
@@ -48,9 +49,9 @@ describe("AdaptiveConcurrencyController", () => {
     });
 
     it("increases limit after 3 more successes with probe active", () => {
-      for (let i = 0; i < 3; i++) ctrl.onRequestComplete("p1", { success: true });
+      for (let i = 0; i < 3; i++) ctrl.onRequestComplete("p1", { success: true }); // open probe
       sem.updateConfig.mockClear();
-      for (let i = 0; i < 3; i++) ctrl.onRequestComplete("p1", { success: true });
+      for (let i = 0; i < 3; i++) ctrl.onRequestComplete("p1", { success: true }); // confirm
       expect(ctrl.getStatus("p1")!.currentLimit).toBe(4);
       expect(ctrl.getStatus("p1")!.probeActive).toBe(true);
       expect(sem.updateConfig).toHaveBeenLastCalledWith("p1", {
@@ -59,11 +60,12 @@ describe("AdaptiveConcurrencyController", () => {
     });
 
     it("does not exceed hard max", () => {
-      ctrl.init("p1", { min: 3, max: 4 }, { queueTimeoutMs: 0, maxQueueSize: 0 });
-      for (let i = 0; i < 3; i++) ctrl.onRequestComplete("p1", { success: true });
-      for (let i = 0; i < 3; i++) ctrl.onRequestComplete("p1", { success: true });
+      ctrl.init("p1", { max: 4 }, { queueTimeoutMs: 0, maxQueueSize: 0 });
+      ctrl["entries"].get("p1")!.state.currentLimit = 3;
+      for (let i = 0; i < 3; i++) ctrl.onRequestComplete("p1", { success: true }); // open probe
+      for (let i = 0; i < 3; i++) ctrl.onRequestComplete("p1", { success: true }); // increase to 4
       sem.updateConfig.mockClear();
-      for (let i = 0; i < 3; i++) ctrl.onRequestComplete("p1", { success: true });
+      for (let i = 0; i < 3; i++) ctrl.onRequestComplete("p1", { success: true }); // try but capped
       expect(ctrl.getStatus("p1")!.currentLimit).toBe(4);
       expect(sem.updateConfig).toHaveBeenLastCalledWith("p1", {
         maxConcurrency: 4, queueTimeoutMs: 0, maxQueueSize: 0,
@@ -80,7 +82,7 @@ describe("AdaptiveConcurrencyController", () => {
 
   describe("429 handling", () => {
     beforeEach(() => {
-      ctrl.init("p1", { min: 2, max: 20 }, { queueTimeoutMs: 0, maxQueueSize: 0 });
+      ctrl.init("p1", { max: 20 }, { queueTimeoutMs: 0, maxQueueSize: 0 });
       ctrl["entries"].get("p1")!.state.currentLimit = 8;
       sem.updateConfig.mockClear();
     });
@@ -103,16 +105,16 @@ describe("AdaptiveConcurrencyController", () => {
       expect(ctrl.getStatus("p1")!.consecutiveSuccesses).toBe(3);
     });
 
-    it("respects hard min", () => {
+    it("respects hard min of 1", () => {
       ctrl["entries"].get("p1")!.state.currentLimit = 3;
       ctrl.onRequestComplete("p1", { success: false, statusCode: 429 });
-      expect(ctrl.getStatus("p1")!.currentLimit).toBe(2);
+      expect(ctrl.getStatus("p1")!.currentLimit).toBe(1);
     });
   });
 
   describe("non-429 failures", () => {
     beforeEach(() => {
-      ctrl.init("p1", { min: 1, max: 20 }, { queueTimeoutMs: 0, maxQueueSize: 0 });
+      ctrl.init("p1", { max: 20 }, { queueTimeoutMs: 0, maxQueueSize: 0 });
       ctrl["entries"].get("p1")!.state.currentLimit = 6;
       sem.updateConfig.mockClear();
     });
@@ -131,7 +133,7 @@ describe("AdaptiveConcurrencyController", () => {
       expect(ctrl.getStatus("p1")!.currentLimit).toBe(6);
     });
 
-    it("respects hard min", () => {
+    it("respects hard min of 1", () => {
       ctrl["entries"].get("p1")!.state.currentLimit = 2;
       for (let i = 0; i < 3; i++) ctrl.onRequestComplete("p1", { success: false, statusCode: 500 });
       expect(ctrl.getStatus("p1")!.currentLimit).toBe(1);
@@ -141,7 +143,7 @@ describe("AdaptiveConcurrencyController", () => {
   describe("cooldown expiry", () => {
     it("resumes after cooldown", () => {
       vi.useFakeTimers();
-      ctrl.init("p1", { min: 2, max: 20 }, { queueTimeoutMs: 0, maxQueueSize: 0 });
+      ctrl.init("p1", { max: 20 }, { queueTimeoutMs: 0, maxQueueSize: 0 });
       ctrl["entries"].get("p1")!.state.currentLimit = 4;
       ctrl.onRequestComplete("p1", { success: false, statusCode: 429 });
       expect(ctrl.getStatus("p1")!.currentLimit).toBe(2);
@@ -154,43 +156,43 @@ describe("AdaptiveConcurrencyController", () => {
 
   describe("remove / re-init", () => {
     it("cleans up on remove", () => {
-      ctrl.init("p1", { min: 3, max: 20 }, { queueTimeoutMs: 0, maxQueueSize: 0 });
+      ctrl.init("p1", { max: 20 }, { queueTimeoutMs: 0, maxQueueSize: 0 });
       ctrl.remove("p1");
       expect(ctrl.getStatus("p1")).toBeUndefined();
     });
 
     it("re-inits from scratch", () => {
-      ctrl.init("p1", { min: 3, max: 20 }, { queueTimeoutMs: 0, maxQueueSize: 0 });
+      ctrl.init("p1", { max: 20 }, { queueTimeoutMs: 0, maxQueueSize: 0 });
       ctrl["entries"].get("p1")!.state.currentLimit = 6;
       ctrl.remove("p1");
-      ctrl.init("p1", { min: 3, max: 20 }, { queueTimeoutMs: 0, maxQueueSize: 0 });
-      expect(ctrl.getStatus("p1")!.currentLimit).toBe(3);
+      ctrl.init("p1", { max: 20 }, { queueTimeoutMs: 0, maxQueueSize: 0 });
+      expect(ctrl.getStatus("p1")!.currentLimit).toBe(1);
     });
   });
 
   describe("syncProvider", () => {
     it("initializes on enable", () => {
       ctrl.syncProvider("p1", {
-        adaptive_enabled: 1, adaptive_min: 3, max_concurrency: 20,
+        adaptive_enabled: 1, max_concurrency: 20,
         queue_timeout_ms: 5000, max_queue_size: 10,
       });
-      expect(ctrl.getStatus("p1")!.currentLimit).toBe(3);
+      expect(ctrl.getStatus("p1")!.currentLimit).toBe(1);
     });
 
     it("removes on disable", () => {
-      ctrl.init("p1", { min: 3, max: 20 }, { queueTimeoutMs: 0, maxQueueSize: 0 });
+      ctrl.init("p1", { max: 20 }, { queueTimeoutMs: 0, maxQueueSize: 0 });
       ctrl.syncProvider("p1", {
-        adaptive_enabled: 0, adaptive_min: 1, max_concurrency: 20,
+        adaptive_enabled: 0, max_concurrency: 20,
         queue_timeout_ms: 0, max_queue_size: 0,
       });
       expect(ctrl.getStatus("p1")).toBeUndefined();
     });
 
-    it("clamps current limit when bounds change", () => {
-      ctrl.init("p1", { min: 3, max: 20 }, { queueTimeoutMs: 0, maxQueueSize: 0 });
+    it("clamps current limit when max_concurrency decreases", () => {
+      ctrl.init("p1", { max: 20 }, { queueTimeoutMs: 0, maxQueueSize: 0 });
       ctrl["entries"].get("p1")!.state.currentLimit = 10;
       ctrl.syncProvider("p1", {
-        adaptive_enabled: 1, adaptive_min: 3, max_concurrency: 5,
+        adaptive_enabled: 1, max_concurrency: 5,
         queue_timeout_ms: 0, max_queue_size: 0,
       });
       expect(ctrl.getStatus("p1")!.currentLimit).toBe(5);

--- a/tests/adaptive-controller.test.ts
+++ b/tests/adaptive-controller.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { AdaptiveConcurrencyController } from "../src/proxy/adaptive-controller.js";
+
+function createMockSemaphore() {
+  return {
+    updateConfig: vi.fn(),
+    getStatus: vi.fn().mockReturnValue({ active: 0, queued: 0 }),
+    acquire: vi.fn(),
+    release: vi.fn(),
+    remove: vi.fn(),
+    removeAll: vi.fn(),
+  };
+}
+
+describe("AdaptiveConcurrencyController", () => {
+  let ctrl: AdaptiveConcurrencyController;
+  let sem: ReturnType<typeof createMockSemaphore>;
+
+  beforeEach(() => {
+    sem = createMockSemaphore();
+    ctrl = new AdaptiveConcurrencyController(sem as any);
+  });
+
+  describe("init", () => {
+    it("starts at adaptive_min", () => {
+      ctrl.init("p1", { min: 3, max: 20 }, { queueTimeoutMs: 5000, maxQueueSize: 10 });
+      expect(ctrl.getStatus("p1")!.currentLimit).toBe(3);
+      expect(ctrl.getStatus("p1")!.probeActive).toBe(false);
+      expect(sem.updateConfig).toHaveBeenCalledWith("p1", {
+        maxConcurrency: 3, queueTimeoutMs: 5000, maxQueueSize: 10,
+      });
+    });
+  });
+
+  describe("success transitions", () => {
+    beforeEach(() => {
+      ctrl.init("p1", { min: 3, max: 20 }, { queueTimeoutMs: 0, maxQueueSize: 0 });
+      sem.updateConfig.mockClear();
+    });
+
+    it("opens probe window after 3 consecutive successes", () => {
+      for (let i = 0; i < 3; i++) ctrl.onRequestComplete("p1", { success: true });
+      expect(ctrl.getStatus("p1")!.probeActive).toBe(true);
+      expect(ctrl.getStatus("p1")!.currentLimit).toBe(3);
+      expect(sem.updateConfig).toHaveBeenLastCalledWith("p1", {
+        maxConcurrency: 4, queueTimeoutMs: 0, maxQueueSize: 0,
+      });
+    });
+
+    it("increases limit after 3 more successes with probe active", () => {
+      for (let i = 0; i < 3; i++) ctrl.onRequestComplete("p1", { success: true });
+      sem.updateConfig.mockClear();
+      for (let i = 0; i < 3; i++) ctrl.onRequestComplete("p1", { success: true });
+      expect(ctrl.getStatus("p1")!.currentLimit).toBe(4);
+      expect(ctrl.getStatus("p1")!.probeActive).toBe(true);
+      expect(sem.updateConfig).toHaveBeenLastCalledWith("p1", {
+        maxConcurrency: 5, queueTimeoutMs: 0, maxQueueSize: 0,
+      });
+    });
+
+    it("does not exceed hard max", () => {
+      ctrl.init("p1", { min: 3, max: 4 }, { queueTimeoutMs: 0, maxQueueSize: 0 });
+      for (let i = 0; i < 3; i++) ctrl.onRequestComplete("p1", { success: true });
+      for (let i = 0; i < 3; i++) ctrl.onRequestComplete("p1", { success: true });
+      sem.updateConfig.mockClear();
+      for (let i = 0; i < 3; i++) ctrl.onRequestComplete("p1", { success: true });
+      expect(ctrl.getStatus("p1")!.currentLimit).toBe(4);
+      expect(sem.updateConfig).toHaveBeenLastCalledWith("p1", {
+        maxConcurrency: 4, queueTimeoutMs: 0, maxQueueSize: 0,
+      });
+    });
+
+    it("resets failure counter on success", () => {
+      ctrl.onRequestComplete("p1", { success: false });
+      ctrl.onRequestComplete("p1", { success: true });
+      expect(ctrl.getStatus("p1")!.consecutiveFailures).toBe(0);
+      expect(ctrl.getStatus("p1")!.consecutiveSuccesses).toBe(1);
+    });
+  });
+
+  describe("429 handling", () => {
+    beforeEach(() => {
+      ctrl.init("p1", { min: 2, max: 20 }, { queueTimeoutMs: 0, maxQueueSize: 0 });
+      ctrl["entries"].get("p1")!.state.currentLimit = 8;
+      sem.updateConfig.mockClear();
+    });
+
+    it("halves limit on 429", () => {
+      ctrl.onRequestComplete("p1", { success: false, statusCode: 429 });
+      expect(ctrl.getStatus("p1")!.currentLimit).toBe(4);
+      expect(ctrl.getStatus("p1")!.probeActive).toBe(false);
+    });
+
+    it("enters cooldown after 429", () => {
+      ctrl.onRequestComplete("p1", { success: false, statusCode: 429 });
+      expect(ctrl.getStatus("p1")!.cooldownUntil).toBeGreaterThan(Date.now());
+    });
+
+    it("does not adjust during cooldown", () => {
+      ctrl.onRequestComplete("p1", { success: false, statusCode: 429 });
+      for (let i = 0; i < 3; i++) ctrl.onRequestComplete("p1", { success: true });
+      expect(ctrl.getStatus("p1")!.currentLimit).toBe(4);
+      expect(ctrl.getStatus("p1")!.consecutiveSuccesses).toBe(3);
+    });
+
+    it("respects hard min", () => {
+      ctrl["entries"].get("p1")!.state.currentLimit = 3;
+      ctrl.onRequestComplete("p1", { success: false, statusCode: 429 });
+      expect(ctrl.getStatus("p1")!.currentLimit).toBe(2);
+    });
+  });
+
+  describe("non-429 failures", () => {
+    beforeEach(() => {
+      ctrl.init("p1", { min: 1, max: 20 }, { queueTimeoutMs: 0, maxQueueSize: 0 });
+      ctrl["entries"].get("p1")!.state.currentLimit = 6;
+      sem.updateConfig.mockClear();
+    });
+
+    it("decreases by 2 after 3 consecutive failures", () => {
+      for (let i = 0; i < 3; i++) ctrl.onRequestComplete("p1", { success: false, statusCode: 500 });
+      expect(ctrl.getStatus("p1")!.currentLimit).toBe(4);
+      expect(ctrl.getStatus("p1")!.probeActive).toBe(false);
+    });
+
+    it("does not decrease on non-consecutive failures", () => {
+      ctrl.onRequestComplete("p1", { success: false, statusCode: 500 });
+      ctrl.onRequestComplete("p1", { success: true });
+      ctrl.onRequestComplete("p1", { success: false, statusCode: 500 });
+      ctrl.onRequestComplete("p1", { success: false, statusCode: 500 });
+      expect(ctrl.getStatus("p1")!.currentLimit).toBe(6);
+    });
+
+    it("respects hard min", () => {
+      ctrl["entries"].get("p1")!.state.currentLimit = 2;
+      for (let i = 0; i < 3; i++) ctrl.onRequestComplete("p1", { success: false, statusCode: 500 });
+      expect(ctrl.getStatus("p1")!.currentLimit).toBe(1);
+    });
+  });
+
+  describe("cooldown expiry", () => {
+    it("resumes after cooldown", () => {
+      vi.useFakeTimers();
+      ctrl.init("p1", { min: 2, max: 20 }, { queueTimeoutMs: 0, maxQueueSize: 0 });
+      ctrl["entries"].get("p1")!.state.currentLimit = 4;
+      ctrl.onRequestComplete("p1", { success: false, statusCode: 429 });
+      expect(ctrl.getStatus("p1")!.currentLimit).toBe(2);
+      vi.advanceTimersByTime(31_000);
+      for (let i = 0; i < 3; i++) ctrl.onRequestComplete("p1", { success: true });
+      expect(ctrl.getStatus("p1")!.probeActive).toBe(true);
+      vi.useRealTimers();
+    });
+  });
+
+  describe("remove / re-init", () => {
+    it("cleans up on remove", () => {
+      ctrl.init("p1", { min: 3, max: 20 }, { queueTimeoutMs: 0, maxQueueSize: 0 });
+      ctrl.remove("p1");
+      expect(ctrl.getStatus("p1")).toBeUndefined();
+    });
+
+    it("re-inits from scratch", () => {
+      ctrl.init("p1", { min: 3, max: 20 }, { queueTimeoutMs: 0, maxQueueSize: 0 });
+      ctrl["entries"].get("p1")!.state.currentLimit = 6;
+      ctrl.remove("p1");
+      ctrl.init("p1", { min: 3, max: 20 }, { queueTimeoutMs: 0, maxQueueSize: 0 });
+      expect(ctrl.getStatus("p1")!.currentLimit).toBe(3);
+    });
+  });
+
+  describe("syncProvider", () => {
+    it("initializes on enable", () => {
+      ctrl.syncProvider("p1", {
+        adaptive_enabled: 1, adaptive_min: 3, max_concurrency: 20,
+        queue_timeout_ms: 5000, max_queue_size: 10,
+      });
+      expect(ctrl.getStatus("p1")!.currentLimit).toBe(3);
+    });
+
+    it("removes on disable", () => {
+      ctrl.init("p1", { min: 3, max: 20 }, { queueTimeoutMs: 0, maxQueueSize: 0 });
+      ctrl.syncProvider("p1", {
+        adaptive_enabled: 0, adaptive_min: 1, max_concurrency: 20,
+        queue_timeout_ms: 0, max_queue_size: 0,
+      });
+      expect(ctrl.getStatus("p1")).toBeUndefined();
+    });
+
+    it("clamps current limit when bounds change", () => {
+      ctrl.init("p1", { min: 3, max: 20 }, { queueTimeoutMs: 0, maxQueueSize: 0 });
+      ctrl["entries"].get("p1")!.state.currentLimit = 10;
+      ctrl.syncProvider("p1", {
+        adaptive_enabled: 1, adaptive_min: 3, max_concurrency: 5,
+        queue_timeout_ms: 0, max_queue_size: 0,
+      });
+      expect(ctrl.getStatus("p1")!.currentLimit).toBe(5);
+    });
+  });
+});

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -39,7 +39,7 @@ describe("initDatabase", () => {
       .prepare("SELECT name FROM migrations")
       .all() as { name: string }[];
 
-    expect(rows.length).toBe(32);
+    expect(rows.length).toBe(33);
     expect(rows[0].name).toBe("001_init.sql");
     expect(rows[1].name).toBe("002_add_request_response_body.sql");
     expect(rows[2].name).toBe("003_add_full_request_chain_log.sql");

--- a/tests/metrics.test.ts
+++ b/tests/metrics.test.ts
@@ -29,7 +29,7 @@ describe("request_metrics migration and insertMetrics", () => {
       .prepare("SELECT name FROM migrations")
       .all() as { name: string }[];
 
-    expect(rows).toHaveLength(32);
+    expect(rows).toHaveLength(33);
     expect(rows[5].name).toBe("006_create_request_metrics.sql");
     expect(rows[6].name).toBe("007_add_retry_fields.sql");
     expect(rows[7].name).toBe("008_create_router_keys.sql");

--- a/tests/monitor/request-tracker.test.ts
+++ b/tests/monitor/request-tracker.test.ts
@@ -440,6 +440,8 @@ describe("RequestTracker", () => {
         queued: 0,
         queueTimeoutMs: 3000,
         maxQueueSize: 10,
+        adaptiveEnabled: false,
+        adaptiveLimit: undefined,
       });
     });
   });


### PR DESCRIPTION
## Summary

- Per-provider adaptive concurrency controller that dynamically adjusts the semaphore limit based on observed success/failure patterns
- Implements AIMD-style algorithm: multiplicative decrease on 429, additive decrease on other failures, additive increase on sustained success
- Probe window mechanism (+1 extra slot) to safely test higher concurrency
- Automatic cooldown after rate limiting events
- Full Admin API support: enable/disable per provider, adaptive-status endpoint
- Backend monitor integration: concurrency snapshot includes adaptive state
- Frontend UI: adaptive toggle + min limit in provider form, adaptive badge in table, (自适应) label in monitor

## Tasks
1. DB migration - `033_add_adaptive_concurrency.sql`
2. Provider type fields - `adaptive_enabled`, `adaptive_min`
3. AdaptiveConcurrencyController state machine + unit tests (18 tests)
4. Admin API backend - schema, PUT handler, adaptive-status endpoint
5. Orchestrator integration + init wiring
6. Frontend provider form - adaptive toggle, min input, validation
7. Frontend monitor display - adaptive status in ConcurrencyPanel