### PR TITLE
fix: adaptive 并发度冷启动过慢及非并发错误误触发退避

### DIFF
--- a/src/proxy/adaptive-controller.ts
+++ b/src/proxy/adaptive-controller.ts
@@ -50,10 +50,11 @@ export class AdaptiveConcurrencyController {
   ) {}
 
   init(providerId: string, config: { max: number }, semParams: { queueTimeoutMs: number; maxQueueSize: number }): void {
+    const initialLimit = config.max;
     this.entries.set(providerId, {
       state: {
-        currentLimit: ADAPTIVE_MIN,
-        probeActive: false,
+        currentLimit: initialLimit,
+        probeActive: true,
         consecutiveSuccesses: 0,
         consecutiveFailures: 0,
         cooldownUntil: 0,
@@ -131,6 +132,15 @@ export class AdaptiveConcurrencyController {
   }
 
   private transitionFailure(providerId: string, entry: AdaptiveEntry, statusCode?: number): void {
+    // 只对明确的并发相关错误做退避：
+    // - 429: 限流
+    // - 5xx: 服务端错误（可能过载）
+    // - undefined: 网络异常
+    // 2xx（如 upstream 200 body 含 error）和 4xx（客户端错误）不是并发问题，不触发退避
+    if (statusCode !== undefined && statusCode !== RATE_LIMIT_STATUS && statusCode < 500) {
+      return;
+    }
+
     const s = entry.state;
     s.consecutiveFailures++;
     s.consecutiveSuccesses = 0;

--- a/tests/adaptive-controller.test.ts
+++ b/tests/adaptive-controller.test.ts
@@ -22,12 +22,13 @@ describe("AdaptiveConcurrencyController", () => {
   });
 
   describe("init", () => {
-    it("starts at ADAPTIVE_MIN (1)", () => {
+    it("starts at max (optimistic start)", () => {
       ctrl.init("p1", { max: 20 }, { queueTimeoutMs: 5000, maxQueueSize: 10 });
-      expect(ctrl.getStatus("p1")!.currentLimit).toBe(1);
-      expect(ctrl.getStatus("p1")!.probeActive).toBe(false);
+      expect(ctrl.getStatus("p1")!.currentLimit).toBe(20);
+      expect(ctrl.getStatus("p1")!.probeActive).toBe(true);
+      // probeActive: effectiveLimit = min(20 + 1, 20) = 20
       expect(sem.updateConfig).toHaveBeenCalledWith("p1", {
-        maxConcurrency: 1, queueTimeoutMs: 5000, maxQueueSize: 10,
+        maxConcurrency: 20, queueTimeoutMs: 5000, maxQueueSize: 10,
       });
     });
   });
@@ -35,7 +36,9 @@ describe("AdaptiveConcurrencyController", () => {
   describe("success transitions", () => {
     beforeEach(() => {
       ctrl.init("p1", { max: 20 }, { queueTimeoutMs: 0, maxQueueSize: 0 });
+      // 模拟 adaptive 已经过 backoff 降到 currentLimit=3, probeActive=false
       ctrl["entries"].get("p1")!.state.currentLimit = 3;
+      ctrl["entries"].get("p1")!.state.probeActive = false;
       sem.updateConfig.mockClear();
     });
 
@@ -73,7 +76,7 @@ describe("AdaptiveConcurrencyController", () => {
     });
 
     it("resets failure counter on success", () => {
-      ctrl.onRequestComplete("p1", { success: false });
+      ctrl.onRequestComplete("p1", { success: false, statusCode: 500 });
       ctrl.onRequestComplete("p1", { success: true });
       expect(ctrl.getStatus("p1")!.consecutiveFailures).toBe(0);
       expect(ctrl.getStatus("p1")!.consecutiveSuccesses).toBe(1);
@@ -112,14 +115,14 @@ describe("AdaptiveConcurrencyController", () => {
     });
   });
 
-  describe("non-429 failures", () => {
+  describe("non-429 failures (5xx)", () => {
     beforeEach(() => {
       ctrl.init("p1", { max: 20 }, { queueTimeoutMs: 0, maxQueueSize: 0 });
       ctrl["entries"].get("p1")!.state.currentLimit = 6;
       sem.updateConfig.mockClear();
     });
 
-    it("decreases by 2 after 3 consecutive failures", () => {
+    it("decreases by 2 after 3 consecutive 5xx failures", () => {
       for (let i = 0; i < 3; i++) ctrl.onRequestComplete("p1", { success: false, statusCode: 500 });
       expect(ctrl.getStatus("p1")!.currentLimit).toBe(4);
       expect(ctrl.getStatus("p1")!.probeActive).toBe(false);
@@ -137,6 +140,49 @@ describe("AdaptiveConcurrencyController", () => {
       ctrl["entries"].get("p1")!.state.currentLimit = 2;
       for (let i = 0; i < 3; i++) ctrl.onRequestComplete("p1", { success: false, statusCode: 500 });
       expect(ctrl.getStatus("p1")!.currentLimit).toBe(1);
+    });
+
+    it("decreases on 502, 503, 504", () => {
+      ctrl.onRequestComplete("p1", { success: false, statusCode: 502 });
+      ctrl.onRequestComplete("p1", { success: false, statusCode: 503 });
+      ctrl.onRequestComplete("p1", { success: false, statusCode: 504 });
+      expect(ctrl.getStatus("p1")!.currentLimit).toBe(4);
+    });
+
+    it("decreases on network error (undefined statusCode)", () => {
+      for (let i = 0; i < 3; i++) ctrl.onRequestComplete("p1", { success: false });
+      expect(ctrl.getStatus("p1")!.currentLimit).toBe(4);
+    });
+  });
+
+  describe("non-concurrency failures (2xx/4xx)", () => {
+    beforeEach(() => {
+      ctrl.init("p1", { max: 20 }, { queueTimeoutMs: 0, maxQueueSize: 0 });
+      ctrl["entries"].get("p1")!.state.currentLimit = 6;
+      sem.updateConfig.mockClear();
+    });
+
+    it("ignores stream_error with upstream 200 (body error)", () => {
+      for (let i = 0; i < 5; i++) ctrl.onRequestComplete("p1", { success: false, statusCode: 200 });
+      expect(ctrl.getStatus("p1")!.currentLimit).toBe(6);
+      expect(ctrl.getStatus("p1")!.consecutiveFailures).toBe(0);
+    });
+
+    it("ignores 4xx client errors", () => {
+      ctrl.onRequestComplete("p1", { success: false, statusCode: 400 });
+      ctrl.onRequestComplete("p1", { success: false, statusCode: 401 });
+      ctrl.onRequestComplete("p1", { success: false, statusCode: 403 });
+      ctrl.onRequestComplete("p1", { success: false, statusCode: 404 });
+      expect(ctrl.getStatus("p1")!.currentLimit).toBe(6);
+      expect(ctrl.getStatus("p1")!.consecutiveFailures).toBe(0);
+    });
+
+    it("does not reset success counter on 2xx/4xx failures", () => {
+      ctrl.onRequestComplete("p1", { success: true });
+      ctrl.onRequestComplete("p1", { success: true });
+      ctrl.onRequestComplete("p1", { success: false, statusCode: 200 });
+      expect(ctrl.getStatus("p1")!.consecutiveSuccesses).toBe(2); // not reset
+      expect(ctrl.getStatus("p1")!.consecutiveFailures).toBe(0); // not incremented
     });
   });
 
@@ -161,22 +207,24 @@ describe("AdaptiveConcurrencyController", () => {
       expect(ctrl.getStatus("p1")).toBeUndefined();
     });
 
-    it("re-inits from scratch", () => {
+    it("re-inits from scratch at max", () => {
       ctrl.init("p1", { max: 20 }, { queueTimeoutMs: 0, maxQueueSize: 0 });
       ctrl["entries"].get("p1")!.state.currentLimit = 6;
       ctrl.remove("p1");
       ctrl.init("p1", { max: 20 }, { queueTimeoutMs: 0, maxQueueSize: 0 });
-      expect(ctrl.getStatus("p1")!.currentLimit).toBe(1);
+      expect(ctrl.getStatus("p1")!.currentLimit).toBe(20);
+      expect(ctrl.getStatus("p1")!.probeActive).toBe(true);
     });
   });
 
   describe("syncProvider", () => {
-    it("initializes on enable", () => {
+    it("initializes on enable at max", () => {
       ctrl.syncProvider("p1", {
         adaptive_enabled: 1, max_concurrency: 20,
         queue_timeout_ms: 5000, max_queue_size: 10,
       });
-      expect(ctrl.getStatus("p1")!.currentLimit).toBe(1);
+      expect(ctrl.getStatus("p1")!.currentLimit).toBe(20);
+      expect(ctrl.getStatus("p1")!.probeActive).toBe(true);
     });
 
     it("removes on disable", () => {


### PR DESCRIPTION
## 问题

自适应并发控制器存在两个 Bug 导致 `zhipu-coding-plan` 的并发度降到 1 后无法恢复，后续请求全部卡在信号量队列中。

### Bug 1：冷启动从 1 开始太保守

`init()` 将 `currentLimit` 设为 `ADAPTIVE_MIN = 1`，需要 **6 次连续成功** 才能升到 2。对于用户配置 `max_concurrency = 3` 的场景，实际吞吐量在启动后极长时间内只有 1。

### Bug 2：upstream 200 body 含 error 被误判为并发故障

上游返回 HTTP 200 但 body 中包含 error 内容时（`stream_error`），`transport.statusCode = 200` 传给 adaptive，adaptive 将其视为失败并触发退避。但这不是并发问题——上游已经接受了请求，错误是内容层面的。

实际时间线：
- 08:42~09:45 UTC：7 次 `stream_error`(upstream 200) → `consecutiveFailures` 累积 → `currentLimit -= 2` × 2 次
- 08:57 UTC：1 次 429 → `currentLimit` 减半 + 30s cooldown
- 结果：`currentLimit` 被压到 1，恢复极慢，所有后续请求排队

## 修复

### 修复 1：乐观启动

```diff
- currentLimit: ADAPTIVE_MIN,    // 1
- probeActive: false,
+ currentLimit: config.max,      // 用户配置的上限
+ probeActive: true,             // 已处于探测模式
```

`max_concurrency` 是用户认为安全的上限。从这个值开始可立即提供最大吞吐量。如果过高，429 和 5xx 会自然降下来。

### 修复 2：过滤非并发错误

```diff
+ // 只对明确的并发相关错误做退避：
+ // - 429: 限流 / - 5xx: 服务端错误 / - undefined: 网络异常
+ // 2xx（upstream 200 body 含 error）和 4xx（客户端错误）不是并发问题
+ if (statusCode !== undefined && statusCode !== 429 && statusCode < 500) {
+   return;
+ }
```

## 验证

- 23 个单元测试全部通过（新增 7 个覆盖修复逻辑）
- 全量 603 个测试通过
- 部署后新 router（9980 端口）运行 7 分钟：60+ 请求全部 200，零错误，adaptive 稳定在 max=3