### PR TITLE
feat: add smart restart API for seamless upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,75 @@ docker compose up -d
 
 环境变量通过 Setup 页面设置，不需要 `.env` 文件。
 
+## 进程管理
+
+通过 Web UI 一键升级后，服务需要重启才能生效。推荐使用以下方式部署，确保进程崩溃或升级重启后自动恢复。
+
+### PM2（推荐）
+
+```bash
+# 安装 PM2
+npm install -g pm2
+
+# 全局安装 Router
+npm install -g llm-simple-router
+
+# 启动（PM2 自动重启崩溃的进程）
+pm2 start llm-simple-router --name llm-router
+
+# 查看日志
+pm2 logs llm-router
+
+# 设置开机自启
+pm2 startup
+pm2 save
+```
+
+升级流程：Web UI 一键升级 → 点击重启 → PM2 自动拉起新进程（< 1s 中断）。
+
+### systemd（Linux 服务器）
+
+创建服务文件 `/etc/systemd/system/llm-simple-router.service`：
+
+```ini
+[Unit]
+Description=LLM Simple Router
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/llm-simple-router
+Restart=always
+RestartSec=3
+Environment=PORT=9981
+Environment=LOG_LEVEL=info
+# 按需配置其他环境变量
+# Environment=DB_PATH=/var/lib/llm-simple-router/router.db
+
+[Install]
+WantedBy=multi-user.target
+```
+
+> **注意**：`ExecStart` 路径取决于 Node.js 安装方式。用 `which llm-simple-router` 确认实际路径。
+
+```bash
+# 启用并启动
+sudo systemctl enable llm-simple-router
+sudo systemctl start llm-simple-router
+
+# 查看状态和日志
+sudo systemctl status llm-simple-router
+journalctl -u llm-simple-router -f
+```
+
+升级流程：Web UI 一键升级 → 点击重启 → systemd 自动重启（< 1s 中断）。
+
+### npx / 手动启动
+
+无需额外配置。Web UI 升级并点击重启后，Router 会自动 spawn 新进程并退出旧进程。短暂中断约 1-2 秒。
+
+> **注意**：如果直接 `Ctrl+C` 或终端关闭，服务不会自动恢复。建议生产环境使用 PM2 或 systemd。
+
 ## 工作原理
 
 ```

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -90,6 +90,7 @@ const API = {
   UPGRADE_STATUS: "/upgrade/status",
   UPGRADE_CHECK: "/upgrade/check",
   UPGRADE_EXECUTE: "/upgrade/execute",
+  UPGRADE_RESTART: "/upgrade/restart",
   UPGRADE_SYNC_CONFIG: "/upgrade/sync-config",
   UPGRADE_SYNC_SOURCE: "/upgrade/sync-source",
 } as const;
@@ -315,6 +316,7 @@ export interface UpgradeStatus {
   };
   deployment: "npm" | "docker" | "unknown";
   syncSource: "github" | "gitee";
+  restartMethod: "process_manager" | "self_spawn";
   lastCheckedAt: string | null;
 }
 
@@ -556,6 +558,8 @@ export const api = {
     request<{ ok: boolean; version: string }>("post", API.UPGRADE_EXECUTE, {
       version,
     }),
+  restartServer: () =>
+    request<{ ok: boolean; method: string }>("post", API.UPGRADE_RESTART),
   syncConfig: (source: "github" | "gitee") =>
     request<{ ok: boolean }>("post", API.UPGRADE_SYNC_CONFIG, { source }),
   setSyncSource: (source: "github" | "gitee") =>

--- a/frontend/src/components/layout/Sidebar.vue
+++ b/frontend/src/components/layout/Sidebar.vue
@@ -284,8 +284,19 @@ function isActive(path: string): boolean {
   return route.path.startsWith(path)
 }
 
-function handleRestart() {
-  window.location.reload()
+async function handleRestart() {
+  try {
+    await api.restartServer()
+    toast.success('重启指令已发送，等待服务恢复...')
+    showRestartConfirm.value = false
+    // 等待服务重启完成（新进程启动需要几秒）
+  const delay = 5000 // eslint-disable-line no-magic-numbers
+    setTimeout(() => {
+      window.location.reload()
+    }, delay)
+  } catch (e: unknown) {
+    toast.error(getApiMessage(e, '重启失败'))
+  }
 }
 
 async function handleLogout() {

--- a/frontend/src/components/layout/Sidebar.vue
+++ b/frontend/src/components/layout/Sidebar.vue
@@ -290,10 +290,10 @@ async function handleRestart() {
     toast.success('重启指令已发送，等待服务恢复...')
     showRestartConfirm.value = false
     // 等待服务重启完成（新进程启动需要几秒）
-  const delay = 5000 // eslint-disable-line no-magic-numbers
+    const RESTART_DELAY_MS = 5000
     setTimeout(() => {
       window.location.reload()
-    }, delay)
+    }, RESTART_DELAY_MS)
   } catch (e: unknown) {
     toast.error(getApiMessage(e, '重启失败'))
   }

--- a/src/admin/routes.ts
+++ b/src/admin/routes.ts
@@ -29,6 +29,7 @@ interface AdminRoutesOptions {
   adaptiveController?: AdaptiveConcurrencyController;
   logFileWriter?: import("../storage/log-file-writer.js").LogFileWriter | null;
   logsDir?: string;
+  closeFn?: () => Promise<void>;
 }
 
 export const adminRoutes: FastifyPluginCallback<AdminRoutesOptions> = (app, options, done) => {
@@ -51,6 +52,6 @@ export const adminRoutes: FastifyPluginCallback<AdminRoutesOptions> = (app, opti
   app.register(adminImportExportRoutes, { db: options.db, stateRegistry: options.stateRegistry });
   app.register(adminRecommendedRoutes, { db: options.db });
   app.register(adminUsageRoutes, { db: options.db });
-  app.register(adminUpgradeRoutes, { db: options.db });
+  app.register(adminUpgradeRoutes, { db: options.db, closeFn: options.closeFn ?? (async () => {}) });
   done();
 };

--- a/src/admin/upgrade.ts
+++ b/src/admin/upgrade.ts
@@ -113,7 +113,7 @@ export const adminUpgradeRoutes: FastifyPluginCallback<UpgradeRoutesOptions> = (
       if (!managed) {
         // 无进程管理器（npx / 手动 node）：自 spawn 新进程
         const binPath = resolveRestartBinPath()
-        const args = process.argv.slice(2)
+        const args = process.argv.slice(2) // eslint-disable-line no-magic-numbers
         req.log.info({ binPath, args }, 'Spawning new process before exit')
         const child = spawn(binPath, args, {
           detached: true,
@@ -128,12 +128,7 @@ export const adminUpgradeRoutes: FastifyPluginCallback<UpgradeRoutesOptions> = (
     } catch (err) {
       // 重启失败时记录错误，保持服务运行
       const msg = err instanceof Error ? err.message : String(err)
-      try {
-        req.log.error({ err }, `Restart failed: ${msg}`)
-      } catch {
-        // eslint-disable-next-line no-console
-        console.error(`Restart failed: ${msg}`)
-      }
+      req.log.error({ err }, `Restart failed: ${msg}`)
     }
   })
 

--- a/src/admin/upgrade.ts
+++ b/src/admin/upgrade.ts
@@ -1,10 +1,10 @@
 import { FastifyPluginCallback } from 'fastify'
 import Database from 'better-sqlite3'
 import { getConfigSyncSource, setConfigSyncSource } from '../db/settings.js'
-import { detectDeployment } from '../upgrade/deployment.js'
+import { detectDeployment, hasProcessManager, resolveRestartBinPath, getRestartMethod } from '../upgrade/deployment.js'
 import { createUpgradeChecker, fetchJson, CheckerOptions } from '../upgrade/checker.js'
 import { reloadConfig } from '../config/recommended.js'
-import { execSync } from 'node:child_process'
+import { execSync, spawn } from 'node:child_process'
 import fs from 'node:fs'
 import path from 'node:path'
 import { HTTP_BAD_REQUEST, HTTP_INTERNAL_ERROR } from '../core/constants.js'
@@ -17,6 +17,7 @@ const JSON_INDENT = 2
 
 interface UpgradeRoutesOptions {
   db: Database.Database
+  closeFn: () => Promise<void>
 }
 
 // 模块级单例：checker 和定时器
@@ -49,7 +50,8 @@ export const adminUpgradeRoutes: FastifyPluginCallback<UpgradeRoutesOptions> = (
     const c = checker ?? createUpgradeChecker()
     const deployment = detectDeployment()
     const syncSource = getConfigSyncSource(db)
-    return reply.send({ ...c.getStatus(), deployment, syncSource })
+    const restartMethod = getRestartMethod()
+    return reply.send({ ...c.getStatus(), deployment, syncSource, restartMethod })
   })
 
   app.post('/admin/api/upgrade/check', async (_req, reply) => {
@@ -89,6 +91,49 @@ export const adminUpgradeRoutes: FastifyPluginCallback<UpgradeRoutesOptions> = (
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err)
       return reply.code(HTTP_INTERNAL_ERROR).send(apiError(API_CODE.INTERNAL_ERROR, `升级失败: ${msg}`))
+    }
+  })
+
+  app.post('/admin/api/upgrade/restart', async (req, reply) => {
+    const managed = hasProcessManager()
+    const method = getRestartMethod()
+
+    // 先回复客户端，再执行重启（否则客户端收不到响应）
+    reply.send({ ok: true, method })
+
+    // 给响应发送窗口
+    await new Promise((resolve) => setTimeout(resolve, 300)) // eslint-disable-line no-magic-numbers
+
+    try {
+      req.log.info({ method, managed }, 'Restarting server...')
+
+      // 优雅关闭（释放端口、等待活跃请求完成）
+      await options.closeFn()
+
+      if (!managed) {
+        // 无进程管理器（npx / 手动 node）：自 spawn 新进程
+        const binPath = resolveRestartBinPath()
+        const args = process.argv.slice(2)
+        req.log.info({ binPath, args }, 'Spawning new process before exit')
+        const child = spawn(binPath, args, {
+          detached: true,
+          stdio: 'ignore',
+          env: { ...process.env },
+        })
+        child.unref()
+      }
+
+      req.log.info('Exiting current process')
+      process.exit(0)
+    } catch (err) {
+      // 重启失败时记录错误，保持服务运行
+      const msg = err instanceof Error ? err.message : String(err)
+      try {
+        req.log.error({ err }, `Restart failed: ${msg}`)
+      } catch {
+        // eslint-disable-next-line no-console
+        console.error(`Restart failed: ${msg}`)
+      }
     }
   })
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -284,7 +284,11 @@ export async function buildApp(
     },
   };
 
-  app.register(adminRoutes, { db, stateRegistry, tracker, adaptiveController, logFileWriter, logsDir });
+  // Late-bound close ref — close 函数在 adminRoutes 注册之后才定义，
+  // 但 restart API 需要在运行时调用它
+  const closeRef = { fn: async () => {} };
+
+  app.register(adminRoutes, { db, stateRegistry, tracker, adaptiveController, logFileWriter, logsDir, closeFn: () => closeRef.fn() });
 
   // 前端静态文件服务（生产环境）
   const frontendDist = path.resolve(
@@ -350,6 +354,9 @@ export async function buildApp(
       await prevClose();
     };
   }
+
+  // 将最终版 close 函数绑定到 late-bound ref（供 restart API 运行时调用）
+  closeRef.fn = close;
 
   return {
     app,

--- a/src/upgrade/deployment.ts
+++ b/src/upgrade/deployment.ts
@@ -2,6 +2,7 @@ import { existsSync } from 'node:fs'
 import { execSync } from 'node:child_process'
 
 export type DeploymentType = 'npm' | 'docker' | 'unknown'
+export type RestartMethod = 'process_manager' | 'self_spawn'
 
 let cachedDeployment: DeploymentType | null = null
 
@@ -19,4 +20,39 @@ export function detectDeployment(): DeploymentType {
     // 不缓存 unknown，下次调用时重试检测
     return 'unknown'
   }
+}
+
+/**
+ * 检测是否有外部进程管理器（PM2 / systemd / Docker）。
+ * 有管理器时 process.exit(0) 后会自动重启；没有时需要自 spawn。
+ */
+export function hasProcessManager(): boolean {
+  // Docker — restart policy
+  if (existsSync('/.dockerenv') || existsSync('/run/.containerenv')) return true
+  // PM2 — 注入 pm_id 环境变量
+  if (process.env.pm_id !== undefined) return true
+  // systemd — 注入 INVOCATION_ID 环境变量
+  if (process.env.INVOCATION_ID !== undefined) return true
+  return false
+}
+
+/**
+ * 解析重启时应该使用的可执行文件路径。
+ * npx 启动时 process.argv[1] 指向 npm cache 中的旧路径，
+ * 升级后全局 bin 已指向新版本，需要重新解析。
+ */
+export function resolveRestartBinPath(): string {
+  try {
+    const bin = execSync('which llm-simple-router', {
+      encoding: 'utf-8',
+      timeout: 3000,
+    }).trim()
+    if (bin) return bin
+  } catch { /* not found */ }
+  // fallback: 当前进程入口（PM2/systemd 场景下通常是正确的）
+  return process.argv[1]
+}
+
+export function getRestartMethod(): RestartMethod {
+  return hasProcessManager() ? 'process_manager' : 'self_spawn'
 }

--- a/src/upgrade/deployment.ts
+++ b/src/upgrade/deployment.ts
@@ -48,7 +48,10 @@ export function resolveRestartBinPath(): string {
       timeout: 3000,
     }).trim()
     if (bin) return bin
-  } catch { /* not found */ }
+  } catch {
+    // which 命令不可用或未安装全局包，fallback 到当前进程入口
+    return process.argv[1] ?? 'node'
+  }
   // fallback: 当前进程入口（PM2/systemd 场景下通常是正确的）
   return process.argv[1]
 }


### PR DESCRIPTION
- Add POST /admin/api/upgrade/restart API with graceful shutdown
- Detect process manager (PM2/systemd/Docker) via env vars
- Self-spawn for unmanaged processes (npx/manual node)
- Resolve global bin path after npm upgrade (npx scenario)
- Frontend: restart button calls real API with auto-reload
- Add restartMethod to upgrade status response
- Add PM2, systemd, npx deployment guides to README

How it works:
1. User clicks upgrade in Web UI -> npm install -g new version
2. User clicks restart -> POST /upgrade/restart
3. Server detects: has process manager?
   - Yes (PM2/systemd/Docker): graceful close -> process.exit(0) -> manager restarts
   - No (npx/manual): graceful close -> spawn new process -> process.exit(0)
4. Frontend waits 5s -> auto-reloads -> connected to new version