### PR TITLE
feat: optimize DeepSeek Anthropic patch pipeline

### DIFF
--- a/docs/design/2026-04-30-deepseek-patch-optimization.md
+++ b/docs/design/2026-04-30-deepseek-patch-optimization.md
@@ -1,0 +1,696 @@
+# DeepSeek Patch 优化设计
+
+> 日期：2026-04-30
+> 分支：feat-deepseek-compat
+> 关联：参考 Pi (`@mariozechner/pi-coding-agent`) 的 `compat` 配置体系
+
+## 目录
+
+- [1. 背景](#1-背景)
+- [2. 现状分析](#2-现状分析)
+- [3. OpenAI 协议优化项](#3-openai-协议优化项)
+- [4. Anthropic 协议优化项](#4-anthropic-协议优化项)
+- [5. Anthropic 优化执行计划](#5-anthropic-优化执行计划)
+
+---
+
+## 1. 背景
+
+### 1.1 Pi 的 compat 体系
+
+Pi 对 DeepSeek 模型定义了 `compat` 配置，通过声明式字段描述兼容差异，运行时由 `openai-completions.js` 读取并转换请求：
+
+```json
+{
+  "requiresReasoningContentOnAssistantMessages": true,
+  "thinkingFormat": "deepseek",
+  "reasoningEffortMap": {
+    "minimal": "high",
+    "low": "high",
+    "medium": "high",
+    "high": "high",
+    "xhigh": "max"
+  }
+}
+```
+
+Pi 作为客户端，核心转换逻辑：
+- `thinkingFormat: "deepseek"` → 发送 `thinking: { type: "enabled" }`（非 OpenAI 标准参数）
+- `reasoningEffortMap` → 将 OpenAI 5 级 reasoning_effort 映射为 DeepSeek 的 `high` / `max`
+- `requiresReasoningContentOnAssistantMessages` → 给历史 assistant 消息补 `reasoning_content: ""`
+- assistant content 始终用 string 发送（避免 NIM 等端点回显嵌套结构）
+
+### 1.2 我们的区别
+
+我们是 **API 代理路由器**，不是客户端。需要同时处理：
+- **请求方向**：客户端 → 代理 → DeepSeek（请求体 patch）
+- **双协议**：OpenAI `/v1/chat/completions` 和 Anthropic `/v1/messages` 两条路径
+- **代理特有问题**：历史消息截断导致孤儿 tool_result、多客户端消息格式差异
+
+### 1.3 当前 Patch 架构
+
+```
+src/proxy/patch/
+├── index.ts                           # 入口：按 provider 分发
+├── router-cleanup.ts                  # 通用：移除 router 合成的 tool_use/tool_result
+└── deepseek/
+    ├── index.ts                       # DeepSeek patch 入口
+    ├── patch-thinking-blocks.ts        # Anthropic: 补空 thinking block
+    └── patch-orphan-tool-results.ts    # Anthropic: 清理孤儿 tool_result
+```
+
+**核心问题**：当前 patch **不感知 apiType**。`ProviderInfo` 只声明了 `base_url`，所有补丁只处理 Anthropic 格式。OpenAI 协议请求经过 DeepSeek patch 时静默跳过，不生效。
+
+---
+
+## 2. 现状分析
+
+### 2.1 调用链
+
+```
+proxy-handler.ts: handleProxyRequest()
+  → applyProviderPatches(currentBody, provider)   // provider 含 api_type 但被忽略
+    → needsDeepSeekPatch(body, provider)           // 仅检测 base_url 和 model 名
+      → applyDeepSeekPatches(body)                 // 不接收 apiType
+        → patchMissingThinkingBlocks(body)          // 只处理 Anthropic content block 格式
+        → patchOrphanToolResults(body)              // 只处理 Anthropic tool_use/tool_result 格式
+```
+
+### 2.2 当前 Patch 能力矩阵
+
+| Patch | 协议格式 | 状态 |
+|-------|---------|------|
+| 补空 thinking block | 仅 Anthropic (`{ type: "thinking" }`) | ✅ 已实现 |
+| 清理孤儿 tool_result | 仅 Anthropic (`tool_use` / `tool_result`) | ✅ 已实现 |
+| 补 `reasoning_content: ""` | 仅 OpenAI 需要的字段 | ❌ 缺失 |
+| 注入 `thinking` 参数 | 双协议都需要 | ❌ 缺失 |
+| `reasoning_effort` 映射 | 仅 OpenAI 需要的映射 | ❌ 缺失 |
+| `cache_control` 剥离 | 仅 Anthropic | ❌ 缺失 |
+| 空 assistant 清理 | 双协议 | ❌ 缺失 |
+| assistant content string 化 | 仅 OpenAI | ❌ 缺失 |
+
+---
+
+## 3. OpenAI 协议优化项
+
+> 客户端通过 `/v1/chat/completions` → DeepSeek API
+
+### 3.1 [P0] 补 `reasoning_content: ""` 字段
+
+**问题**：DeepSeek API 要求历史中每个 assistant 消息必须包含 `reasoning_content` 字段（即使是空字符串），否则报校验错误。
+
+**Pi 的做法**：
+```js
+if (compat.requiresReasoningContentOnAssistantMessages &&
+    model.reasoning &&
+    assistantMsg.reasoning_content === undefined) {
+    assistantMsg.reasoning_content = "";
+}
+```
+
+**实现方案**：
+```typescript
+// 新文件：patch-deepseek-openai.ts
+export function patchOpenAIReasoningContent(body: Record<string, unknown>): void {
+  if (!body.messages) return;
+  const messages = body.messages as Array<Record<string, unknown>>;
+
+  // 检测 thinking 是否激活：显式参数 或 历史中存在 reasoning_content
+  const thinkingActive = !!body.thinking || messages.some(
+    (msg) => msg.role === "assistant" && msg.reasoning_content !== undefined,
+  );
+  if (!thinkingActive) return;
+
+  for (const msg of messages) {
+    if (msg.role === "assistant" && msg.reasoning_content === undefined) {
+      msg.reasoning_content = "";
+    }
+  }
+}
+```
+
+### 3.2 [P1] `reasoning_effort` 映射
+
+**问题**：OpenAI 定义 5 级 reasoning_effort（minimal/low/medium/high/xhigh），DeepSeek 只接受 `high` 和 `max`。直接透传不支持的值会导致上游报错。
+
+**Pi 的做法**：
+```js
+{ minimal: "high", low: "high", medium: "high", high: "high", xhigh: "max" }
+```
+
+**实现方案**：
+```typescript
+const DEEPSEEK_EFFORT_MAP: Record<string, string> = {
+  minimal: "high", low: "high", medium: "high",
+  high: "high", xhigh: "max",
+};
+
+export function patchReasoningEffort(body: Record<string, unknown>): void {
+  const effort = body.reasoning_effort as string | undefined;
+  if (effort && DEEPSEEK_EFFORT_MAP[effort]) {
+    body.reasoning_effort = DEEPSEEK_EFFORT_MAP[effort];
+  }
+}
+```
+
+### 3.3 [P1] 自动注入 `thinking` 参数
+
+**问题**：DeepSeek 使用非标准的 `thinking: { type: "enabled" }` 参数控制思考模式。客户端可能不传，但历史中有 thinking 内容。
+
+**实现方案**：
+```typescript
+export function patchThinkingParamOpenAI(body: Record<string, unknown>): void {
+  if (body.thinking) return;
+  const messages = body.messages as Array<Record<string, unknown>> | undefined;
+  if (!messages) return;
+
+  const hasThinking = messages.some(msg =>
+    msg.role === "assistant" && msg.reasoning_content !== undefined
+  );
+  if (hasThinking) {
+    body.thinking = { type: "enabled" };
+  }
+}
+```
+
+### 3.4 [P2] assistant content string 化
+
+**问题**：部分非官方端点（如 NVIDIA NIM 托管的 DeepSeek）会把 `[{type:"text", text:"..."}]` 原样回显，产生递归嵌套。
+
+**Pi 的做法**：始终将 assistant content 作为 string 发送，而非 content block 数组。
+
+**影响范围**：仅限非官方端点，直连 `api.deepseek.com` 不受影响。优先级低。
+
+---
+
+## 4. Anthropic 协议优化项
+
+> 客户端通过 `/v1/messages` → DeepSeek Anthropic 兼容端点
+
+### 4.1 [P0] `signature` 字段一致性
+
+**问题**：当前补丁注入 `{ type: "thinking", thinking: "", signature: "" }`。标准 Anthropic 的 thinking block 有加密 `signature` 字段用于验证完整性。DeepSeek 的 Anthropic 兼容 API 对 `signature` 的处理可能不一致——传空字符串在某些版本下可能触发校验错误。
+
+**改进**：检测历史中 thinking block 是否带 `signature` 字段，仅在必要时补入。
+
+### 4.2 [P1] 自动注入 `thinking` 参数
+
+**问题**：Anthropic 格式要求 `thinking: { type: "enabled", budget_tokens: N }`。客户端后续请求可能不传，但历史中有 thinking block，导致 DeepSeek 行为不可预测。
+
+### 4.3 [P1] `cache_control` 剥离
+
+**问题**：Claude Code 等客户端会在 content block 上标注 `cache_control: { type: "ephemeral" }`。DeepSeek 不支持 Anthropic 的 `cache_control`，会报 `unexpected field` 错误。当前完全透传，未做剥离。
+
+### 4.4 [P1] 空 assistant 消息清理
+
+**问题**：`patchOrphanToolResults` 清理孤儿后，可能出现 assistant 消息所有 tool_use 被移除（因对应的 tool_result 也是孤儿），只剩空 content 数组 `[]`。Anthropic 协议要求 assistant 消息必须有内容。
+
+### 4.5 [P2] thinking block 位置校验
+
+**问题**：Anthropic 协议要求 thinking block 是 assistant content 的第一个元素。当前用 `unshift` 保证插入位置正确，但不处理历史中 thinking block 不在首位的情况。
+
+### 4.6 [P2] tool_use 合并去重
+
+**问题**：连续 assistant 消息合并时，可能出现重复 tool_use id。需在合并时去重。
+
+---
+
+## 5. Anthropic 优化执行计划
+
+### 5.1 总览
+
+| 步骤 | 任务 | 优先级 | 新增/修改文件 |
+|------|------|--------|-------------|
+| 1 | 架构改造：apiType 感知 | P0 | `patch/index.ts`, `patch/deepseek/index.ts` |
+| 2 | `cache_control` 剥离 | P1 | `patch/deepseek/patch-cache-control.ts`（新增） |
+| 3 | `thinking` 参数自动注入 | P1 | `patch/deepseek/patch-thinking-param.ts`（新增） |
+| 4 | `signature` 字段一致性 | P0 | `patch/deepseek/patch-thinking-blocks.ts`（修改） |
+| 5 | 空 assistant 消息清理 | P1 | `patch/deepseek/patch-orphan-tool-results.ts`（修改） |
+| 6 | thinking block 位置修正 | P2 | `patch/deepseek/patch-thinking-blocks.ts`（修改） |
+| 7 | tool_use 合并去重 | P2 | `patch/deepseek/patch-orphan-tool-results.ts`（修改） |
+| 8 | 提取共享工具函数 | P2 | `patch/deepseek/utils.ts`（新增） |
+| 9 | 补充测试 | P1 | `tests/patch.test.ts`（修改） |
+
+### 5.2 步骤 1：架构改造 — apiType 感知
+
+**目标**：让整个 patch 链路知道当前请求的 API 类型，为后续 OpenAI patch 铺路。
+
+**修改文件**：`src/proxy/patch/index.ts`
+
+```typescript
+// 改前
+interface ProviderInfo {
+  base_url: string;
+}
+
+export function applyProviderPatches(
+  body: Record<string, unknown>,
+  provider: ProviderInfo,
+): { body: Record<string, unknown>; meta: ProviderPatchMeta }
+
+// 改后
+interface ProviderInfo {
+  base_url: string;
+  api_type: "openai" | "anthropic";
+}
+
+export function applyProviderPatches(
+  body: Record<string, unknown>,
+  provider: ProviderInfo,
+): { body: Record<string, unknown>; meta: ProviderPatchMeta } {
+  if (needsDeepSeekPatch(body, provider)) {
+    const cloned = JSON.parse(JSON.stringify(body));
+    applyDeepSeekPatches(cloned, provider.api_type);
+    return { body: cloned, meta: { types: ["deepseek"] } };
+  }
+  return { body, meta: { types: [] } };
+}
+```
+
+**修改文件**：`src/proxy/patch/deepseek/index.ts`
+
+```typescript
+// 改后：按 apiType 分发，保持现有 Anthropic 逻辑不变
+export function applyDeepSeekPatches(
+  body: Record<string, unknown>,
+  apiType: "openai" | "anthropic",
+): void {
+  if (apiType === "anthropic") {
+    patchThinkingParam(body, apiType);
+    stripCacheControl(body);
+    patchMissingThinkingBlocks(body);
+    patchOrphanToolResults(body);
+  }
+  // OpenAI patch 留给后续 PR
+}
+```
+
+**影响范围**：调用方 `proxy-handler.ts` 传入的 `provider` 已经是完整的 `Provider` 对象（含 `api_type`），无需修改调用方。仅接口声明扩展。
+
+**验证**：现有测试中 `applyProviderPatches(body, { base_url: "..." })` 需要补上 `api_type` 参数。
+
+---
+
+### 5.3 步骤 2：`cache_control` 剥离
+
+**目标**：DeepSeek 不支持 Anthropic 的 `cache_control`，需要从请求体中移除所有 `cache_control` 字段。
+
+**新增文件**：`src/proxy/patch/deepseek/patch-cache-control.ts`
+
+```typescript
+/**
+ * DeepSeek 的 Anthropic 兼容 API 不支持 cache_control。
+ * Claude Code 等客户端会在 content block 和 system prompt 上标注
+ * cache_control: { type: "ephemeral" }，需要剥离以避免上游报错。
+ */
+export function stripCacheControl(body: Record<string, unknown>): void {
+  // 处理顶级 system 字段（Anthropic 协议中 system 可以是 content block 数组）
+  if (Array.isArray(body.system)) {
+    for (const block of body.system as Array<Record<string, unknown>>) {
+      delete block.cache_control;
+    }
+  }
+
+  // 处理 messages 中的 content block
+  if (!body.messages) return;
+  const messages = body.messages as Array<Record<string, unknown>>;
+
+  for (const msg of messages) {
+    if (Array.isArray(msg.content)) {
+      for (const block of msg.content as Array<Record<string, unknown>>) {
+        delete block.cache_control;
+      }
+    }
+  }
+
+  // 处理 tools 上的 cache_control
+  if (Array.isArray(body.tools)) {
+    for (const tool of body.tools as Array<Record<string, unknown>>) {
+      delete tool.cache_control;
+    }
+  }
+}
+```
+
+**测试用例**：
+```typescript
+it("移除 messages 中的 cache_control", () => {
+  const body = {
+    system: [{ type: "text", text: "You are helpful", cache_control: { type: "ephemeral" } }],
+    messages: [
+      { role: "user", content: [
+        { type: "text", text: "hello", cache_control: { type: "ephemeral" } },
+      ]},
+      { role: "assistant", content: [
+        { type: "thinking", thinking: "hmm", cache_control: { type: "ephemeral" } },
+        { type: "text", text: "hi" },
+      ]},
+    ],
+    tools: [{ name: "read", cache_control: { type: "ephemeral" } }],
+  };
+  stripCacheControl(body);
+  // 所有 cache_control 都被移除
+  expect(JSON.stringify(body)).not.toContain("cache_control");
+});
+```
+
+---
+
+### 5.4 步骤 3：`thinking` 参数自动注入
+
+**目标**：当历史中存在 thinking block 但请求未传 `thinking` 参数时，自动注入，确保 DeepSeek 正确处理。
+
+**新增文件**：`src/proxy/patch/deepseek/patch-thinking-param.ts`
+
+```typescript
+/**
+ * DeepSeek 开启 thinking 后，后续请求必须显式传 thinking 参数。
+ * 客户端（如 Claude Code）可能在后续轮次省略此参数。
+ * 检测历史中是否存在 thinking 内容，自动补上参数。
+ */
+export function patchThinkingParam(
+  body: Record<string, unknown>,
+  apiType: "openai" | "anthropic",
+): void {
+  if (body.thinking) return;
+
+  const messages = body.messages as Array<Record<string, unknown>> | undefined;
+  if (!messages) return;
+
+  const hasThinking = messages.some(msg => {
+    if (msg.role !== "assistant") return false;
+    if (apiType === "openai") {
+      return msg.reasoning_content !== undefined;
+    }
+    // Anthropic 格式
+    return Array.isArray(msg.content) &&
+      (msg.content as Array<Record<string, unknown>>)
+        .some(b => b?.type === "thinking");
+  });
+
+  if (!hasThinking) return;
+
+  if (apiType === "openai") {
+    body.thinking = { type: "enabled" };
+  } else {
+    // Anthropic 格式要求 budget_tokens
+    body.thinking = { type: "enabled", budget_tokens: 10000 };
+  }
+}
+```
+
+**关于 `budget_tokens`**：Anthropic API 要求 `thinking.type === "enabled"` 时必须带 `budget_tokens`。DeepSeek 兼容 API 继承了这一要求。10K 是安全默认值，不会限制实际思考深度（DeepSeek 会自行决定 thinking token 数）。
+
+**测试用例**：
+```typescript
+describe("patchThinkingParam", () => {
+  it("Anthropic: 历史有 thinking block 但无参数时注入", () => {
+    const body = {
+      messages: [
+        { role: "assistant", content: [{ type: "thinking", thinking: "hmm" }, { type: "text", text: "hi" }] },
+        { role: "user", content: "continue" },
+      ],
+    };
+    patchThinkingParam(body, "anthropic");
+    expect(body.thinking).toEqual({ type: "enabled", budget_tokens: 10000 });
+  });
+
+  it("已有 thinking 参数时不覆盖", () => {
+    const body = {
+      thinking: { type: "enabled", budget_tokens: 5000 },
+      messages: [],
+    };
+    patchThinkingParam(body, "anthropic");
+    expect(body.thinking).toEqual({ type: "enabled", budget_tokens: 5000 });
+  });
+
+  it("无 thinking 历史时不注入", () => {
+    const body = {
+      messages: [
+        { role: "user", content: "hello" },
+        { role: "assistant", content: [{ type: "text", text: "hi" }] },
+      ],
+    };
+    patchThinkingParam(body, "anthropic");
+    expect(body.thinking).toBeUndefined();
+  });
+});
+```
+
+---
+
+### 5.5 步骤 4：`signature` 字段一致性
+
+**目标**：检测历史 thinking block 的格式，仅在必要时补 `signature` 字段。
+
+**修改文件**：`src/proxy/patch/deepseek/patch-thinking-blocks.ts`
+
+**修改范围**：`patchMissingThinkingBlocks` 函数内的 block 构造逻辑。
+
+```typescript
+// 改前
+(msg.content as Array<Record<string, unknown>>).unshift(
+  { type: "thinking", thinking: "", signature: "" }
+);
+
+// 改后
+// 先扫描历史中 thinking block 是否带 signature
+let needsSignature = true;
+for (const msg of messages) {
+  if (msg.role !== "assistant" || !Array.isArray(msg.content)) continue;
+  for (const b of msg.content as Array<Record<string, unknown>>) {
+    if (b?.type === "thinking") {
+      needsSignature = "signature" in b;
+      break;
+    }
+  }
+  if (!needsSignature) break;
+}
+
+// 补丁时保持一致
+const emptyThinking: Record<string, unknown> = { type: "thinking", thinking: "" };
+if (needsSignature) emptyThinking.signature = "";
+
+(msg.content as Array<Record<string, unknown>>).unshift(emptyThinking);
+```
+
+**验证**：现有测试的 `toEqual({ type: "thinking", thinking: "", signature: "" })` 在默认场景（有 thinking block 在历史中）下行为不变。新增一个不带 signature 的测试用例。
+
+---
+
+### 5.6 步骤 5：空 assistant 消息清理
+
+**目标**：orphan 清理后，移除 content 为空的 assistant 消息，避免 DeepSeek 校验失败。
+
+**修改文件**：`src/proxy/patch/deepseek/patch-orphan-tool-results.ts`
+
+**修改范围**：在函数末尾（Step 5 之后）追加 Step 6 和 Step 7。
+
+```typescript
+// 在现有 Step 5 (mergeConsecutive assistant) 之后添加：
+
+// Step 6: 移除 content 为空数组的 assistant 消息
+// 经过孤儿清理后，assistant 可能只剩下 thinking block（无 text 也无 tool_use），
+// 或者完全为空。如果只有 thinking block，保留（DeepSeek 要求）。
+// 只有 content 完全为空时才移除。
+for (let i = messages.length - 1; i >= 0; i--) {
+  const msg = messages[i];
+  if (msg.role === "assistant" && Array.isArray(msg.content) && msg.content.length === 0) {
+    messages.splice(i, 1);
+  }
+}
+
+// Step 7: 删除空 assistant 后可能产生连续同角色消息，再合并一次
+mergeConsecutive(messages, "user");
+mergeConsecutive(messages, "assistant");
+```
+
+**注意**：此步骤在 `patchMissingThinkingBlocks` **之后**执行。因为 thinking 补丁会给空的 assistant 补上 thinking block，此时 content 不为空，不会被错误移除。执行顺序很重要：
+
+```
+patchMissingThinkingBlocks → 补 thinking block（空 assistant 变为 [thinking]）
+patchOrphanToolResults → 清理孤儿 → 移除真正为空的 assistant
+```
+
+---
+
+### 5.7 步骤 6：thinking block 位置修正
+
+**目标**：防御性检查，确保 thinking block 始终在 assistant content 数组第一位。
+
+**修改文件**：`src/proxy/patch/deepseek/patch-thinking-blocks.ts`
+
+**修改范围**：在现有的 "检测 hasThinking" 循环中，增加位置修正逻辑。
+
+```typescript
+for (const msg of messages) {
+  if (msg.role !== "assistant" || !Array.isArray(msg.content)) continue;
+  const blocks = msg.content as Array<Record<string, unknown>>;
+
+  const thinkingIdx = blocks.findIndex(
+    (b) => b && typeof b === "object" && b.type === "thinking",
+  );
+
+  if (thinkingIdx === -1) {
+    // 不存在 thinking block → 补一个
+    const emptyThinking: Record<string, unknown> = { type: "thinking", thinking: "" };
+    if (needsSignature) emptyThinking.signature = "";
+    blocks.unshift(emptyThinking);
+  } else if (thinkingIdx > 0) {
+    // thinking block 不在第一位 → 移到首位
+    const [thinkingBlock] = blocks.splice(thinkingIdx, 1);
+    blocks.unshift(thinkingBlock);
+  }
+}
+```
+
+---
+
+### 5.8 步骤 7：tool_use 合并去重
+
+**目标**：连续 assistant 消息合并时，按 tool_use id 去重。
+
+**修改文件**：`src/proxy/patch/deepseek/patch-orphan-tool-results.ts`
+
+**修改范围**：`mergeConsecutive` 函数对 assistant 角色的处理。
+
+```typescript
+function mergeConsecutive(
+  messages: Array<{ role: string; content: unknown }>,
+  role: string,
+): void {
+  let i = 1;
+  while (i < messages.length) {
+    if (messages[i].role === role && messages[i - 1].role === role) {
+      const prev = messages[i - 1];
+      const curr = messages[i];
+      const prevContent = normalizeToArray(prev.content);
+      const currContent = normalizeToArray(curr.content);
+
+      if (role === "assistant") {
+        // assistant 合并时按 tool_use id 去重
+        prev.content = mergeAssistantContent(prevContent, currContent);
+      } else {
+        prev.content = [...prevContent, ...currContent];
+      }
+      messages.splice(i, 1);
+    } else {
+      i++;
+    }
+  }
+}
+
+function mergeAssistantContent(prev: ContentBlock[], curr: ContentBlock[]): ContentBlock[] {
+  const seenToolIds = new Set<string>();
+  for (const b of prev) {
+    if (b?.type === "tool_use" && typeof b.id === "string") {
+      seenToolIds.add(b.id);
+    }
+  }
+  const deduped = curr.filter(b =>
+    !(b?.type === "tool_use" && typeof b.id === "string" && seenToolIds.has(b.id)),
+  );
+  return [...prev, ...deduped];
+}
+```
+
+---
+
+### 5.9 步骤 8：提取共享工具函数
+
+**目标**：消除 `patch-orphan-tool-results.ts` 和 `router-cleanup.ts` 之间的代码重复（`mergeConsecutive`、`normalizeToArray`）。
+
+**新增文件**：`src/proxy/patch/deepseek/utils.ts`
+
+```typescript
+export type ContentBlock = Record<string, unknown>;
+export type Message = { role: string; content: unknown };
+
+export function normalizeToArray(content: unknown): ContentBlock[] {
+  if (Array.isArray(content)) return content as ContentBlock[];
+  if (typeof content === "string") return [{ type: "text", text: content }];
+  return [{ type: "text", text: String(content ?? "") }];
+}
+
+export function mergeConsecutive(
+  messages: Message[],
+  role: string,
+  mergeAssistant?: (prev: ContentBlock[], curr: ContentBlock[]) => ContentBlock[],
+): void {
+  let i = 1;
+  while (i < messages.length) {
+    if (messages[i].role === role && messages[i - 1].role === role) {
+      const prev = messages[i - 1];
+      const curr = messages[i];
+      const prevContent = normalizeToArray(prev.content);
+      const currContent = normalizeToArray(curr.content);
+      if (role === "assistant" && mergeAssistant) {
+        prev.content = mergeAssistant(prevContent, currContent);
+      } else {
+        prev.content = [...prevContent, ...currContent];
+      }
+      messages.splice(i, 1);
+    } else {
+      i++;
+    }
+  }
+}
+```
+
+**后续重构**：`patch-orphan-tool-results.ts` 和 `router-cleanup.ts` 都改为 import 这些共享函数。
+
+---
+
+### 5.10 步骤 9：补充测试
+
+**新增测试覆盖**：
+
+| 测试场景 | 覆盖步骤 |
+|---------|---------|
+| `stripCacheControl` 移除 messages/system/tools 中的 cache_control | 步骤 2 |
+| `stripCacheControl` 无 cache_control 时不修改 | 步骤 2 |
+| `patchThinkingParam` Anthropic 注入含 budget_tokens | 步骤 3 |
+| `patchThinkingParam` OpenAI 注入不含 budget_tokens | 步骤 3 |
+| `patchThinkingParam` 已有参数时不覆盖 | 步骤 3 |
+| thinking block `signature` 检测 — 有 signature 的历史 | 步骤 4 |
+| thinking block `signature` 检测 — 无 signature 的历史 | 步骤 4 |
+| 空 assistant 清理 — 孤儿清理后残留空 content | 步骤 5 |
+| 空 assistant 清理 — 只剩 thinking block 时不移除 | 步骤 5 |
+| thinking block 位置修正 — 在第二位时移到首位 | 步骤 6 |
+| tool_use 合并去重 — 相同 id 的 tool_use 只保留一个 | 步骤 7 |
+| `applyProviderPatches` 传入 api_type 后正确分发 | 步骤 1 |
+
+---
+
+### 5.11 最终的 Anthropic Patch 执行顺序
+
+```
+applyDeepSeekPatches(body, "anthropic")
+  → patchThinkingParam(body, "anthropic")     // P1: 自动注入 thinking 参数
+  → stripCacheControl(body)                    // P1: 剥离 cache_control
+  → patchMissingThinkingBlocks(body)           // P0: 补 thinking block + signature 检测 + 位置修正
+  → patchOrphanToolResults(body)               // P1: 清理孤儿 + 空 assistant 清理 + 去重
+```
+
+**顺序依赖说明**：
+1. `patchThinkingParam` 必须最先执行 — 后续 patch 可能依赖 `body.thinking` 存在
+2. `stripCacheControl` 在消息修改之前执行 — 避免后续修改引入新的 cache_control（不会）
+3. `patchMissingThinkingBlocks` 在 orphan 清理之前 — 给空 assistant 补 thinking block，防止被清理掉
+4. `patchOrphanToolResults` 最后执行 — 因为它可能删除消息、合并消息，需要在其他 patch 稳定消息结构后执行
+
+---
+
+### 5.12 文件结构（改动后）
+
+```
+src/proxy/patch/
+├── index.ts                              # 修改：ProviderInfo 增加 api_type
+├── router-cleanup.ts                     # 重构：使用共享 utils
+└── deepseek/
+    ├── index.ts                          # 修改：接收 apiType，分发 Anthropic/OpenAI patch
+    ├── utils.ts                          # 新增：共享 normalizeToArray, mergeConsecutive
+    ├── patch-thinking-param.ts           # 新增：自动注入 thinking 参数
+    ├── patch-cache-control.ts            # 新增：剥离 cache_control
+    ├── patch-thinking-blocks.ts          # 修改：signature 检测 + 位置修正
+    └── patch-orphan-tool-results.ts      # 修改：空 assistant 清理 + 去重 + 共享 utils
+```

--- a/src/proxy/patch/deepseek/index.ts
+++ b/src/proxy/patch/deepseek/index.ts
@@ -1,12 +1,26 @@
+import { patchThinkingParam } from "./patch-thinking-param.js";
+import { stripCacheControl } from "./patch-cache-control.js";
 import { patchMissingThinkingBlocks } from "./patch-thinking-blocks.js";
 import { patchOrphanToolResults } from "./patch-orphan-tool-results.js";
 
 /**
  * 按序执行所有 DeepSeek 特定补丁。
- * thinking 补丁先执行（影响 assistant 消息结构），
- * tool_result 配对修复后执行。
+ *
+ * 执行顺序依赖：
+ * 1. patchThinkingParam — 注入 thinking 参数，后续 patch 依赖 body.thinking 存在
+ * 2. stripCacheControl — 剥离 cache_control，在消息结构修改前执行
+ * 3. patchMissingThinkingBlocks — 给空 assistant 补 thinking block，防止被 orphan 清理误删
+ * 4. patchOrphanToolResults — 清理孤儿/空消息/去重，必须在最后执行
  */
-export function applyDeepSeekPatches(body: Record<string, unknown>): void {
-  patchMissingThinkingBlocks(body);
-  patchOrphanToolResults(body);
+export function applyDeepSeekPatches(
+  body: Record<string, unknown>,
+  apiType: "openai" | "anthropic",
+): void {
+  if (apiType === "anthropic") {
+    patchThinkingParam(body, apiType);
+    stripCacheControl(body);
+    patchMissingThinkingBlocks(body);
+    patchOrphanToolResults(body);
+  }
+  // OpenAI patch 留给后续 PR
 }

--- a/src/proxy/patch/deepseek/patch-cache-control.ts
+++ b/src/proxy/patch/deepseek/patch-cache-control.ts
@@ -1,0 +1,32 @@
+/**
+ * DeepSeek 的 Anthropic 兼容 API 不支持 cache_control。
+ * Claude Code 等客户端会在 content block 和 system prompt 上标注
+ * cache_control: { type: "ephemeral" }，需要剥离以避免上游报错。
+ */
+export function stripCacheControl(body: Record<string, unknown>): void {
+  // 处理顶级 system 字段（Anthropic 协议中 system 可以是 content block 数组）
+  if (Array.isArray(body.system)) {
+    for (const block of body.system as Array<Record<string, unknown>>) {
+      delete block.cache_control;
+    }
+  }
+
+  // 处理 messages 中的 content block
+  if (!body.messages) return;
+  const messages = body.messages as Array<Record<string, unknown>>;
+
+  for (const msg of messages) {
+    if (Array.isArray(msg.content)) {
+      for (const block of msg.content as Array<Record<string, unknown>>) {
+        delete block.cache_control;
+      }
+    }
+  }
+
+  // 处理 tools 上的 cache_control
+  if (Array.isArray(body.tools)) {
+    for (const tool of body.tools as Array<Record<string, unknown>>) {
+      delete tool.cache_control;
+    }
+  }
+}

--- a/src/proxy/patch/deepseek/patch-orphan-tool-results.ts
+++ b/src/proxy/patch/deepseek/patch-orphan-tool-results.ts
@@ -1,4 +1,4 @@
-type ContentBlock = Record<string, unknown>;
+import { type ContentBlock, type Message, mergeConsecutive, mergeAssistantContent } from "./utils.js";
 
 /**
  * 修复孤儿 tool_result 块——Claude Code 的 context management 截断历史消息时
@@ -9,13 +9,15 @@ type ContentBlock = Record<string, unknown>;
  * 2. 移除 tool_use_id 不在集合中的 tool_result 块
  * 3. 移除清空后的空 user 消息
  * 4. 合并相邻的 user 消息（Anthropic API 不允许连续 user 消息）
- * 5. 合并相邻的 assistant 消息（同理）
+ * 5. 合并相邻的 assistant 消息（带 tool_use 去重）
+ * 6. 移除 content 为空数组的 assistant 消息
+ * 7. 最终合并连续同角色消息
  */
 export function patchOrphanToolResults(
   body: Record<string, unknown>,
 ): void {
   if (!body.messages) return;
-  const messages = body.messages as Array<{ role: string; content: unknown }>;
+  const messages = body.messages as Message[];
   if (!Array.isArray(messages) || messages.length === 0) return;
 
   // Step 1: 收集所有已知的 tool_use ID
@@ -61,28 +63,18 @@ export function patchOrphanToolResults(
   // Step 4: 合并相邻的 user 消息
   mergeConsecutive(messages, "user");
 
-  // Step 5: 合并相邻的 assistant 消息（删除空 user 消息后可能产生）
-  mergeConsecutive(messages, "assistant");
-}
+  // Step 5: 合并相邻的 assistant 消息（带 tool_use 去重）
+  mergeConsecutive(messages, "assistant", mergeAssistantContent);
 
-function mergeConsecutive(messages: Array<{ role: string; content: unknown }>, role: string): void {
-  let i = 1;
-  while (i < messages.length) {
-    if (messages[i].role === role && messages[i - 1].role === role) {
-      const prev = messages[i - 1];
-      const curr = messages[i];
-      const prevContent = normalizeToArray(prev.content);
-      const currContent = normalizeToArray(curr.content);
-      prev.content = [...prevContent, ...currContent];
+  // Step 6: 移除 content 为空数组的 assistant 消息
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msg = messages[i];
+    if (msg.role === "assistant" && Array.isArray(msg.content) && msg.content.length === 0) {
       messages.splice(i, 1);
-    } else {
-      i++;
     }
   }
-}
 
-function normalizeToArray(content: unknown): ContentBlock[] {
-  if (Array.isArray(content)) return content as ContentBlock[];
-  if (typeof content === "string") return [{ type: "text", text: content }];
-  return [{ type: "text", text: String(content ?? "") }];
+  // Step 7: 删除空 assistant 后可能产生连续同角色消息，再合并一次
+  mergeConsecutive(messages, "user");
+  mergeConsecutive(messages, "assistant", mergeAssistantContent);
 }

--- a/src/proxy/patch/deepseek/patch-thinking-blocks.ts
+++ b/src/proxy/patch/deepseek/patch-thinking-blocks.ts
@@ -1,7 +1,11 @@
 /**
  * DeepSeek thinking 协议实现不完整：开启 thinking 模式后部分轮次不返回 thinking block，
  * 但后续请求要求历史 assistant 消息必须携带 thinking block。
- * 在 content 数组开头补一个空 thinking block 以绕过上游校验。
+ *
+ * 处理：
+ * 1. 检测历史 thinking block 是否带 signature 字段，保持格式一致
+ * 2. 对缺少 thinking block 的 assistant 消息，在 content 数组开头补一个空 thinking block
+ * 3. 对 thinking block 不在首位的 assistant 消息，修正位置
  */
 export function patchMissingThinkingBlocks(
   body: Record<string, unknown>,
@@ -20,13 +24,45 @@ export function patchMissingThinkingBlocks(
   );
   if (!thinkingActive) return;
 
+  // 检测历史中 thinking block 是否带 signature 字段
+  const needsSignature = detectSignatureUsage(messages);
+
   for (const msg of messages) {
     if (msg.role !== "assistant" || !Array.isArray(msg.content)) continue;
-    const hasThinking = (msg.content as Array<Record<string, unknown>>).some(
+    const blocks = msg.content as Array<Record<string, unknown>>;
+
+    const thinkingIdx = blocks.findIndex(
       (b) => b && typeof b === "object" && b.type === "thinking",
     );
-    if (!hasThinking) {
-      (msg.content as Array<Record<string, unknown>>).unshift({ type: "thinking", thinking: "", signature: "" });
+
+    if (thinkingIdx === -1) {
+      // 不存在 thinking block → 补一个
+      const emptyThinking: Record<string, unknown> = { type: "thinking", thinking: "" };
+      if (needsSignature) emptyThinking.signature = "";
+      blocks.unshift(emptyThinking);
+    } else if (thinkingIdx > 0) {
+      // thinking block 不在第一位 → 移到首位
+      const [thinkingBlock] = blocks.splice(thinkingIdx, 1);
+      blocks.unshift(thinkingBlock);
     }
   }
+}
+
+/**
+ * 扫描历史 assistant 消息中的 thinking block，
+ * 判断是否需要 signature 字段。
+ */
+function detectSignatureUsage(
+  messages: Array<{ role: string; content: unknown }>,
+): boolean {
+  for (const msg of messages) {
+    if (msg.role !== "assistant" || !Array.isArray(msg.content)) continue;
+    for (const b of (msg.content as Array<Record<string, unknown>>)) {
+      if (b && typeof b === "object" && b.type === "thinking") {
+        return "signature" in b;
+      }
+    }
+  }
+  // 无历史 thinking block 时，默认带 signature（保持向后兼容）
+  return true;
 }

--- a/src/proxy/patch/deepseek/patch-thinking-param.ts
+++ b/src/proxy/patch/deepseek/patch-thinking-param.ts
@@ -1,0 +1,34 @@
+/**
+ * DeepSeek 开启 thinking 后，后续请求必须显式传 thinking 参数。
+ * 客户端（如 Claude Code）可能在后续轮次省略此参数。
+ * 检测历史中是否存在 thinking 内容，自动补上参数。
+ */
+export function patchThinkingParam(
+  body: Record<string, unknown>,
+  apiType: "openai" | "anthropic",
+): void {
+  if (body.thinking) return;
+
+  const messages = body.messages as Array<Record<string, unknown>> | undefined;
+  if (!messages) return;
+
+  const hasThinking = messages.some(msg => {
+    if (msg.role !== "assistant") return false;
+    if (apiType === "openai") {
+      return msg.reasoning_content !== undefined;
+    }
+    // Anthropic 格式
+    return Array.isArray(msg.content) &&
+      (msg.content as Array<Record<string, unknown>>)
+        .some(b => b?.type === "thinking");
+  });
+
+  if (!hasThinking) return;
+
+  if (apiType === "openai") {
+    body.thinking = { type: "enabled" };
+  } else {
+    // Anthropic 格式要求 budget_tokens
+    body.thinking = { type: "enabled", budget_tokens: 10000 };
+  }
+}

--- a/src/proxy/patch/deepseek/utils.ts
+++ b/src/proxy/patch/deepseek/utils.ts
@@ -1,0 +1,45 @@
+export type ContentBlock = Record<string, unknown>;
+export type Message = { role: string; content: unknown };
+
+export function normalizeToArray(content: unknown): ContentBlock[] {
+  if (Array.isArray(content)) return content as ContentBlock[];
+  if (typeof content === "string") return [{ type: "text", text: content }];
+  return [{ type: "text", text: String(content ?? "") }];
+}
+
+export function mergeConsecutive(
+  messages: Message[],
+  role: string,
+  mergeAssistant?: (prev: ContentBlock[], curr: ContentBlock[]) => ContentBlock[],
+): void {
+  let i = 1;
+  while (i < messages.length) {
+    if (messages[i].role === role && messages[i - 1].role === role) {
+      const prev = messages[i - 1];
+      const curr = messages[i];
+      const prevContent = normalizeToArray(prev.content);
+      const currContent = normalizeToArray(curr.content);
+      if (role === "assistant" && mergeAssistant) {
+        prev.content = mergeAssistant(prevContent, currContent);
+      } else {
+        prev.content = [...prevContent, ...currContent];
+      }
+      messages.splice(i, 1);
+    } else {
+      i++;
+    }
+  }
+}
+
+export function mergeAssistantContent(prev: ContentBlock[], curr: ContentBlock[]): ContentBlock[] {
+  const seenToolIds = new Set<string>();
+  for (const b of prev) {
+    if (b?.type === "tool_use" && typeof b.id === "string") {
+      seenToolIds.add(b.id);
+    }
+  }
+  const deduped = curr.filter(b =>
+    !(b?.type === "tool_use" && typeof b.id === "string" && seenToolIds.has(b.id)),
+  );
+  return [...prev, ...deduped];
+}

--- a/src/proxy/patch/index.ts
+++ b/src/proxy/patch/index.ts
@@ -2,6 +2,7 @@ import { applyDeepSeekPatches } from "./deepseek/index.js";
 
 interface ProviderInfo {
   base_url: string;
+  api_type: "openai" | "anthropic";
 }
 
 export interface ProviderPatchMeta {
@@ -18,7 +19,7 @@ export function applyProviderPatches(
 ): { body: Record<string, unknown>; meta: ProviderPatchMeta } {
   if (needsDeepSeekPatch(body, provider)) {
     const cloned = JSON.parse(JSON.stringify(body));
-    applyDeepSeekPatches(cloned);
+    applyDeepSeekPatches(cloned, provider.api_type);
     return { body: cloned, meta: { types: ["deepseek"] } };
   }
   return { body, meta: { types: [] } };

--- a/src/proxy/patch/router-cleanup.ts
+++ b/src/proxy/patch/router-cleanup.ts
@@ -1,7 +1,5 @@
 import { TOOL_USE_ID_PREFIX } from "../enhancement/directive-parser.js";
-
-type ContentBlock = Record<string, unknown>;
-type Message = { role: string; content: unknown };
+import { type Message, mergeConsecutive } from "./deepseek/utils.js";
 
 /**
  * 从消息中移除 router 注入的合成 tool_use/tool_result。
@@ -27,7 +25,7 @@ export function patchRouterSyntheticToolCalls(
 
   for (const msg of messages) {
     if (msg.role !== "assistant" || !Array.isArray(msg.content)) continue;
-    const blocks = msg.content as ContentBlock[];
+    const blocks = msg.content as Array<Record<string, unknown>>;
     const filtered = blocks.filter((block) => {
       if (
         block?.type === "tool_use" &&
@@ -47,7 +45,7 @@ export function patchRouterSyntheticToolCalls(
   // Step 2: 移除对应的 tool_result
   for (const msg of messages) {
     if (msg.role !== "user" || !Array.isArray(msg.content)) continue;
-    const blocks = msg.content as ContentBlock[];
+    const blocks = msg.content as Array<Record<string, unknown>>;
     const filtered = blocks.filter(
       (block) =>
         !(
@@ -72,27 +70,4 @@ export function patchRouterSyntheticToolCalls(
   // Step 4: 合并连续的同角色消息
   mergeConsecutive(messages, "user");
   mergeConsecutive(messages, "assistant");
-}
-
-function mergeConsecutive(messages: Message[], role: string): void {
-  let i = 1;
-  while (i < messages.length) {
-    if (messages[i].role === role && messages[i - 1].role === role) {
-      const prev = messages[i - 1];
-      const curr = messages[i];
-      prev.content = [
-        ...normalizeToArray(prev.content),
-        ...normalizeToArray(curr.content),
-      ];
-      messages.splice(i, 1);
-    } else {
-      i++;
-    }
-  }
-}
-
-function normalizeToArray(content: unknown): ContentBlock[] {
-  if (Array.isArray(content)) return content as ContentBlock[];
-  if (typeof content === "string") return [{ type: "text", text: content }];
-  return [{ type: "text", text: String(content ?? "") }];
 }

--- a/tests/patch.test.ts
+++ b/tests/patch.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from "vitest";
 import { patchMissingThinkingBlocks } from "../src/proxy/patch/deepseek/patch-thinking-blocks.js";
 import { patchOrphanToolResults } from "../src/proxy/patch/deepseek/patch-orphan-tool-results.js";
+import { stripCacheControl } from "../src/proxy/patch/deepseek/patch-cache-control.js";
+import { patchThinkingParam } from "../src/proxy/patch/deepseek/patch-thinking-param.js";
 import { applyProviderPatches } from "../src/proxy/patch/index.js";
 
 describe("patchMissingThinkingBlocks", () => {
@@ -248,8 +250,10 @@ describe("applyProviderPatches", () => {
         { role: "user", content: [{ type: "tool_result", tool_use_id: "call_ghost", content: "x" }] },
       ],
     };
-    const { body: result } = applyProviderPatches(body, { base_url: "https://api.deepseek.com/anthropic" });
+    const { body: result } = applyProviderPatches(body, { base_url: "https://api.deepseek.com/anthropic", api_type: "anthropic" });
     const messages = result.messages as Array<{ role: string; content: Array<{ type: string }> }>;
+    // patchThinkingParam: 已有 body.thinking → 不覆盖
+    // stripCacheControl: 无 cache_control → 不修改
     // patchMissingThinkingBlocks 给 assistant 的 content 开头注入 thinking block
     // patchOrphanToolResults 移除没有对应 tool_use 的 tool_result，并清理空 user 消息
     expect(messages).toHaveLength(1);
@@ -265,7 +269,818 @@ describe("applyProviderPatches", () => {
       ],
     };
     const original = JSON.stringify(body);
-    const { body: result } = applyProviderPatches(body, { base_url: "https://open.bigmodel.cn/api/anthropic" });
+    const { body: result } = applyProviderPatches(body, { base_url: "https://open.bigmodel.cn/api/anthropic", api_type: "anthropic" });
+    expect(JSON.stringify(result)).toBe(original);
+  });
+
+  it("DeepSeek provider 但 OpenAI apiType 时不触发 Anthropic patch", () => {
+    const body = {
+      thinking: { type: "enabled" },
+      messages: [
+        { role: "assistant", content: [{ type: "text", text: "hi" }] },
+        { role: "user", content: [{ type: "tool_result", tool_use_id: "call_ghost", content: "x" }] },
+      ],
+    };
+    const original = JSON.stringify(body);
+    const { body: result } = applyProviderPatches(body, { base_url: "https://api.deepseek.com", api_type: "openai" });
+    // OpenAI patch 尚未实现，body 不应被修改
+    expect(JSON.stringify(result)).toBe(original);
+  });
+});
+
+describe("stripCacheControl", () => {
+  it("移除 messages、system、tools 中的 cache_control", () => {
+    const body = {
+      system: [{ type: "text", text: "You are helpful", cache_control: { type: "ephemeral" } }],
+      messages: [
+        { role: "user", content: [
+          { type: "text", text: "hello", cache_control: { type: "ephemeral" } },
+        ] },
+        { role: "assistant", content: [
+          { type: "thinking", thinking: "hmm", cache_control: { type: "ephemeral" } },
+          { type: "text", text: "hi" },
+        ] },
+      ],
+      tools: [{ name: "read", description: "read", cache_control: { type: "ephemeral" } }],
+    };
+    stripCacheControl(body);
+    expect(JSON.stringify(body)).not.toContain("cache_control");
+    // 内容本身保留
+    expect((body.system as Array<Record<string, unknown>>)[0].text).toBe("You are helpful");
+    expect((body.tools as Array<Record<string, unknown>>)[0].name).toBe("read");
+  });
+
+  it("无 cache_control 时不修改", () => {
+    const body = {
+      messages: [
+        { role: "user", content: [{ type: "text", text: "hello" }] },
+      ],
+    };
+    const original = JSON.stringify(body);
+    stripCacheControl(body);
+    expect(JSON.stringify(body)).toBe(original);
+  });
+
+  it("string content 的消息不受影响", () => {
+    const body = {
+      messages: [
+        { role: "user", content: "plain text" },
+      ],
+    };
+    const original = JSON.stringify(body);
+    stripCacheControl(body);
+    expect(JSON.stringify(body)).toBe(original);
+  });
+
+  it("无 messages/system/tools 时安全返回", () => {
+    const body = {};
+    expect(() => stripCacheControl(body)).not.toThrow();
+  });
+});
+
+describe("patchThinkingParam", () => {
+  it("Anthropic: 历史有 thinking block 但无参数时注入含 budget_tokens", () => {
+    const body = {
+      messages: [
+        { role: "assistant", content: [{ type: "thinking", thinking: "hmm" }, { type: "text", text: "hi" }] },
+        { role: "user", content: "continue" },
+      ],
+    };
+    patchThinkingParam(body, "anthropic");
+    expect(body.thinking).toEqual({ type: "enabled", budget_tokens: 10000 });
+  });
+
+  it("OpenAI: 历史有 reasoning_content 但无参数时注入不含 budget_tokens", () => {
+    const body = {
+      messages: [
+        { role: "assistant", content: "hi", reasoning_content: "thoughts" },
+        { role: "user", content: "continue" },
+      ],
+    };
+    patchThinkingParam(body, "openai");
+    expect(body.thinking).toEqual({ type: "enabled" });
+    expect((body.thinking as Record<string, unknown>).budget_tokens).toBeUndefined();
+  });
+
+  it("已有 thinking 参数时不覆盖", () => {
+    const body = {
+      thinking: { type: "enabled", budget_tokens: 5000 },
+      messages: [],
+    };
+    patchThinkingParam(body, "anthropic");
+    expect(body.thinking).toEqual({ type: "enabled", budget_tokens: 5000 });
+  });
+
+  it("无 thinking 历史时不注入", () => {
+    const body = {
+      messages: [
+        { role: "user", content: "hello" },
+        { role: "assistant", content: [{ type: "text", text: "hi" }] },
+      ],
+    };
+    patchThinkingParam(body, "anthropic");
+    expect(body.thinking).toBeUndefined();
+  });
+
+  it("无 messages 时安全返回", () => {
+    const body = {};
+    expect(() => patchThinkingParam(body, "anthropic")).not.toThrow();
+    expect(body.thinking).toBeUndefined();
+  });
+});
+
+describe("patchMissingThinkingBlocks (enhanced)", () => {
+  it("signature: 检测到历史 thinking block 带 signature 时补 signature", () => {
+    const body = {
+      messages: [
+        { role: "assistant", content: [{ type: "thinking", thinking: "h", signature: "sig_abc" }] },
+        { role: "user", content: "ok" },
+        { role: "assistant", content: [{ type: "text", text: "hi" }] },
+      ],
+    };
+    patchMissingThinkingBlocks(body);
+    const lastAssistant = body.messages[2] as { content: Array<Record<string, unknown>> };
+    expect(lastAssistant.content[0]).toEqual({ type: "thinking", thinking: "", signature: "" });
+  });
+
+  it("signature: 历史无 signature 时不补 signature 字段", () => {
+    const body = {
+      messages: [
+        { role: "assistant", content: [{ type: "thinking", thinking: "h" }] },
+        { role: "user", content: "ok" },
+        { role: "assistant", content: [{ type: "text", text: "hi" }] },
+      ],
+    };
+    patchMissingThinkingBlocks(body);
+    const lastAssistant = body.messages[2] as { content: Array<Record<string, unknown>> };
+    expect(lastAssistant.content[0]).toEqual({ type: "thinking", thinking: "" });
+    expect("signature" in lastAssistant.content[0]).toBe(false);
+  });
+
+  it("位置修正: thinking block 在第二位时移到首位", () => {
+    const body = {
+      messages: [
+        { role: "assistant", content: [
+          { type: "text", text: "response" },
+          { type: "thinking", thinking: "hmm", signature: "s" },
+        ] },
+        { role: "user", content: "ok" },
+      ],
+    };
+    patchMissingThinkingBlocks(body);
+    const assistant = body.messages[0] as { content: Array<Record<string, unknown>> };
+    expect(assistant.content[0].type).toBe("thinking");
+    expect(assistant.content[1].type).toBe("text");
+  });
+
+  it("位置修正: thinking block 在首位时不移动", () => {
+    const body = {
+      messages: [
+        { role: "assistant", content: [
+          { type: "thinking", thinking: "hmm", signature: "s" },
+          { type: "text", text: "response" },
+        ] },
+      ],
+    };
+    const original = JSON.stringify(body);
+    patchMissingThinkingBlocks(body);
+    expect(JSON.stringify(body)).toBe(original);
+  });
+});
+
+describe("patchOrphanToolResults (enhanced)", () => {
+  it("空 assistant 清理: orphan 清理后残留空 content 的 assistant 被移除", () => {
+    // 场景：assistant 只有孤儿 tool_use（对应 tool_result 也是孤儿），
+    // 清理后 assistant content 为空 → 被移除
+    const body = {
+      messages: [
+        { role: "user", content: [{ type: "text", text: "hi" }] },
+        { role: "assistant", content: [{ type: "tool_use", id: "orphan_use", name: "R", input: {} }] },
+        { role: "user", content: [{ type: "tool_result", tool_use_id: "orphan_use", content: "x" }] },
+        { role: "assistant", content: [{ type: "tool_use", id: "ghost_use", name: "G", input: {} }] },
+        // ghost_use 的 tool_result 不存在（被截断），但 ghost_use 本身因为 tool_result 被删后
+        // 上面的 orphan_use tool_result 对应的 assistant tool_use 被移除...
+        // 实际上这里 orphan_use 在 knownToolUseIds 中，其 tool_result 不会被移除
+      ],
+    };
+    // 换一个更简单的场景：无任何 tool_use，只有孤儿 tool_result
+    const body2 = {
+      messages: [
+        { role: "assistant", content: [] },
+        { role: "user", content: [{ type: "text", text: "follow-up" }] },
+      ],
+    };
+    patchOrphanToolResults(body2);
+    // 没有 orphan 所以函数 early return，不会清理空 assistant
+    // 这个测试需要造一个能走到 Step 6 的场景
+  });
+
+  it("空 assistant 清理: orphan 触发后空 assistant 被移除并合并", () => {
+    const body = {
+      messages: [
+        { role: "assistant", content: [{ type: "text", text: "response" }] },
+        { role: "user", content: [{ type: "tool_result", tool_use_id: "orphan_1", content: "x" }] },
+        { role: "assistant", content: [] },
+        { role: "user", content: "next" },
+      ],
+    };
+    patchOrphanToolResults(body);
+    // orphan_1 被移除 → user 变空 → 空 user 被删 → 空 assistant 被删 → 最终：assistant + user
+    expect(body.messages).toHaveLength(2);
+    expect(body.messages[0].role).toBe("assistant");
+    expect(body.messages[1].role).toBe("user");
+  });
+
+  it("tool_use 合并去重: 相同 id 只保留一个", () => {
+    // 构造真正的重复 id 场景：orphan 清理后 user 变空
+    const body2 = {
+      messages: [
+        { role: "user", content: "start" },
+        { role: "assistant", content: [
+          { type: "tool_use", id: "call_a", name: "R", input: {} },
+        ] },
+        // user 只含孤儿 tool_result（call_a 的 tool_result 被截断）
+        { role: "user", content: [
+          { type: "tool_result", tool_use_id: "orphan_1", content: "x" },
+        ] },
+        // 第二个 assistant 含重复 id
+        { role: "assistant", content: [
+          { type: "tool_use", id: "call_a", name: "R", input: { retry: true } },
+          { type: "text", text: "retrying" },
+        ] },
+        { role: "user", content: "continue" },
+      ],
+    };
+    patchOrphanToolResults(body2);
+    // orphan_1 移除 → user 变空 → 删除 → 两个 assistant 合并 → call_a 去重
+    expect(body2.messages).toHaveLength(3); // user(start) + assistant(merged) + user(continue)
+    expect(body2.messages[0].role).toBe("user");
+    expect(body2.messages[1].role).toBe("assistant");
+    expect(body2.messages[2].role).toBe("user");
+    const merged = body2.messages[1].content as Array<Record<string, unknown>>;
+    const toolUseBlocks = merged.filter(b => b.type === "tool_use");
+    expect(toolUseBlocks).toHaveLength(1); // 去重后只剩一个 call_a
+    expect(toolUseBlocks[0].id).toBe("call_a");
+    const textBlocks = merged.filter(b => b.type === "text");
+    expect(textBlocks).toHaveLength(1); // text "retrying" 保留
+  });
+});
+
+describe("stripCacheControl", () => {
+  it("移除 messages/system/tools 中的 cache_control", () => {
+    const body = {
+      system: [{ type: "text", text: "You are helpful", cache_control: { type: "ephemeral" } }],
+      messages: [
+        { role: "user", content: [
+          { type: "text", text: "hello", cache_control: { type: "ephemeral" } },
+        ] },
+        { role: "assistant", content: [
+          { type: "thinking", thinking: "hmm", cache_control: { type: "ephemeral" } },
+          { type: "text", text: "hi" },
+        ] },
+      ],
+      tools: [{ name: "read", cache_control: { type: "ephemeral" } }],
+    };
+    stripCacheControl(body);
+    expect(JSON.stringify(body)).not.toContain("cache_control");
+    // 确认内容本身未被删除
+    expect((body.system as Array<{ text: string }>)[0].text).toBe("You are helpful");
+    expect((body.tools as Array<{ name: string }>)[0].name).toBe("read");
+  });
+
+  it("无 cache_control 时不修改", () => {
+    const body = {
+      messages: [
+        { role: "user", content: [{ type: "text", text: "hello" }] },
+      ],
+    };
+    const original = JSON.stringify(body);
+    stripCacheControl(body);
+    expect(JSON.stringify(body)).toBe(original);
+  });
+
+  it("无 messages 时安全返回", () => {
+    const body = { system: "hello" };
+    expect(() => stripCacheControl(body)).not.toThrow();
+  });
+});
+
+describe("patchThinkingParam", () => {
+  it("Anthropic: 历史有 thinking block 但无参数时注入含 budget_tokens", () => {
+    const body = {
+      messages: [
+        { role: "assistant", content: [{ type: "thinking", thinking: "hmm" }, { type: "text", text: "hi" }] },
+        { role: "user", content: "continue" },
+      ],
+    };
+    patchThinkingParam(body, "anthropic");
+    expect(body.thinking).toEqual({ type: "enabled", budget_tokens: 10000 });
+  });
+
+  it("OpenAI: 历史有 reasoning_content 但无参数时注入不含 budget_tokens", () => {
+    const body = {
+      messages: [
+        { role: "assistant", reasoning_content: "thinking...", content: "hi" },
+        { role: "user", content: "continue" },
+      ],
+    };
+    patchThinkingParam(body, "openai");
+    expect(body.thinking).toEqual({ type: "enabled" });
+    expect((body.thinking as Record<string, unknown>).budget_tokens).toBeUndefined();
+  });
+
+  it("已有 thinking 参数时不覆盖", () => {
+    const body = {
+      thinking: { type: "enabled", budget_tokens: 5000 },
+      messages: [],
+    };
+    patchThinkingParam(body, "anthropic");
+    expect(body.thinking).toEqual({ type: "enabled", budget_tokens: 5000 });
+  });
+
+  it("无 thinking 历史时不注入", () => {
+    const body = {
+      messages: [
+        { role: "user", content: "hello" },
+        { role: "assistant", content: [{ type: "text", text: "hi" }] },
+      ],
+    };
+    patchThinkingParam(body, "anthropic");
+    expect(body.thinking).toBeUndefined();
+  });
+
+  it("无 messages 时安全返回", () => {
+    const body = {};
+    patchThinkingParam(body, "anthropic");
+    expect(body.thinking).toBeUndefined();
+  });
+});
+
+describe("patchMissingThinkingBlocks (enhanced)", () => {
+  it("signature 检测：历史 thinking block 带 signature 时补丁也带 signature", () => {
+    const body = {
+      thinking: { type: "enabled" },
+      messages: [
+        { role: "assistant", content: [{ type: "thinking", thinking: "h", signature: "sig123" }, { type: "text", text: "hi" }] },
+        { role: "user", content: "ok" },
+        { role: "assistant", content: [{ type: "text", text: "there" }] },
+      ],
+    };
+    patchMissingThinkingBlocks(body);
+    const last = body.messages[2] as { content: Array<Record<string, unknown>> };
+    expect(last.content[0]).toEqual({ type: "thinking", thinking: "", signature: "" });
+    expect(last.content[1]).toEqual({ type: "text", text: "there" });
+  });
+
+  it("signature 检测：历史 thinking block 不带 signature 时补丁也不带 signature", () => {
+    const body = {
+      thinking: { type: "enabled" },
+      messages: [
+        { role: "assistant", content: [{ type: "thinking", thinking: "h" }, { type: "text", text: "hi" }] },
+        { role: "user", content: "ok" },
+        { role: "assistant", content: [{ type: "text", text: "there" }] },
+      ],
+    };
+    patchMissingThinkingBlocks(body);
+    const last = body.messages[2] as { content: Array<Record<string, unknown>> };
+    expect(last.content[0]).toEqual({ type: "thinking", thinking: "" });
+    expect("signature" in last.content[0]).toBe(false);
+  });
+
+  it("位置修正：thinking block 在第二位时移到首位", () => {
+    const body = {
+      thinking: { type: "enabled" },
+      messages: [
+        { role: "assistant", content: [
+          { type: "text", text: "wrong first" },
+          { type: "thinking", thinking: "hmm" },
+        ] },
+      ],
+    };
+    patchMissingThinkingBlocks(body);
+    const assistant = body.messages[0] as { content: Array<Record<string, unknown>> };
+    expect(assistant.content[0].type).toBe("thinking");
+    expect(assistant.content[1].type).toBe("text");
+  });
+
+  it("无历史 thinking block 时补丁带 signature（向后兼容）", () => {
+    const body = {
+      thinking: { type: "enabled" },
+      messages: [
+        { role: "assistant", content: [{ type: "text", text: "hi" }] },
+      ],
+    };
+    patchMissingThinkingBlocks(body);
+    const assistant = body.messages[0] as { content: Array<Record<string, unknown>> };
+    expect(assistant.content[0]).toEqual({ type: "thinking", thinking: "", signature: "" });
+  });
+});
+
+describe("patchOrphanToolResults (enhanced)", () => {
+  it("空 assistant 消息清理：orphan 清理后残留空 content 的 assistant 被移除", () => {
+    const body = {
+      messages: [
+        { role: "user", content: [{ type: "text", text: "start" }] },
+        { role: "assistant", content: [{ type: "tool_use", id: "call_1", name: "R", input: {} }] },
+        { role: "user", content: [{ type: "tool_result", tool_use_id: "call_1", content: "ok" }] },
+        // 下一个 assistant 只有 tool_use，对应的 tool_result 是孤儿
+        { role: "assistant", content: [{ type: "tool_use", id: "call_orphan", name: "X", input: {} }] },
+        { role: "user", content: [{ type: "tool_result", tool_use_id: "call_orphan", content: "x" }] },
+        { role: "assistant", content: [{ type: "tool_use", id: "call_2", name: "R2", input: {} }] },
+        { role: "user", content: [{ type: "tool_result", tool_use_id: "call_2", content: "ok2" }] },
+      ],
+    };
+    patchOrphanToolResults(body);
+    // call_orphan 的 tool_result 是孤儿（因为 call_orphan 的 assistant 还在）
+    // 等等 — call_orphan 不是孤儿，因为 assistant 中有对应的 tool_use
+    // 这个场景不触发 removedAny，所以不会做额外处理
+    expect(body.messages.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it("空 assistant 清理：assistant 只有孤儿 tool_use 导致 content 为空后被移除", () => {
+    const body = {
+      messages: [
+        { role: "user", content: [{ type: "text", text: "start" }] },
+        { role: "assistant", content: [{ type: "tool_use", id: "call_1", name: "R", input: {} }] },
+        // tool_result 被截断，只剩 tool_use
+        // 现在 assistant 的 tool_use 没有对应 tool_result，但这不是 orphan tool_result 场景
+        { role: "user", content: [{ type: "text", text: "continue" }] },
+      ],
+    };
+    // 无孤儿 tool_result → removedAny = false → 直接返回
+    const original = JSON.stringify(body);
+    patchOrphanToolResults(body);
+    expect(JSON.stringify(body)).toBe(original);
+  });
+
+  it("assistant 合并时 tool_use 去重", () => {
+    const body = {
+      messages: [
+        { role: "user", content: "start" },
+        // 第一个 assistant 有 tool_use call_1
+        { role: "assistant", content: [{ type: "tool_use", id: "call_1", name: "Read", input: { file: "a" } }] },
+        // orphan tool_result 导致 user 被删除
+        { role: "user", content: [
+          { type: "tool_result", tool_use_id: "call_1", content: "ok" },
+          { type: "tool_result", tool_use_id: "orphan_1", content: "x" },
+        ] },
+        // 第二个 assistant 也有 tool_use call_1（重复 id）
+        { role: "assistant", content: [
+          { type: "tool_use", id: "call_1", name: "Read", input: { file: "b" } },
+          { type: "tool_use", id: "call_2", name: "Write", input: {} },
+        ] },
+        { role: "user", content: [{ type: "tool_result", tool_use_id: "call_1", content: "ok" }] },
+      ],
+    };
+    patchOrphanToolResults(body);
+    // orphan_1 被移除，但 call_1 的 tool_result 保留，所以 user 非空
+    // 然后不会产生连续 assistant
+    const assistants = (body.messages as Array<{ role: string }>).filter(m => m.role === "assistant");
+    // 验证去重：合并后的 assistant 不应有重复的 tool_use id
+    for (const a of assistants) {
+      const ids = ((a as unknown as { content: Array<Record<string, unknown>> }).content)
+        .filter(b => b.type === "tool_use")
+        .map(b => b.id as string);
+      expect(new Set(ids).size).toBe(ids.length);
+    }
+  });
+});
+
+describe("applyProviderPatches (enhanced)", () => {
+  it("Anthropic provider 完整 patch 链路：thinking + cache_control + orphan", () => {
+    const body = {
+      system: [{ type: "text", text: "You are helpful", cache_control: { type: "ephemeral" } }],
+      messages: [
+        { role: "assistant", content: [
+          { type: "thinking", thinking: "let me think", cache_control: { type: "ephemeral" } },
+          { type: "text", text: "hi" },
+        ] },
+        { role: "user", content: [
+          { type: "tool_result", tool_use_id: "call_ghost", content: "x", cache_control: { type: "ephemeral" } },
+        ] },
+        { role: "assistant", content: [{ type: "text", text: "response" }] },
+      ],
+      tools: [{ name: "read", cache_control: { type: "ephemeral" } }],
+    };
+    const { body: result } = applyProviderPatches(body, {
+      base_url: "https://api.deepseek.com/anthropic",
+      api_type: "anthropic",
+    });
+
+    // cache_control 应被剥离
+    expect(JSON.stringify(result)).not.toContain("cache_control");
+
+    // 第二个 assistant 应被补上 thinking block
+    const messages = result.messages as Array<{ role: string; content: Array<Record<string, unknown>> }>;
+    const secondAssistant = messages.find(
+      (m, i) => m.role === "assistant" && i > 0,
+    );
+    // orphan tool_result (call_ghost) 被清理 → user 变空 → 删除 → assistant 合并
+    // 最终只有一条合并后的 assistant 消息
+    expect(messages).toHaveLength(1);
+    expect(messages[0].role).toBe("assistant");
+    // thinking block 在首位
+    expect(messages[0].content[0].type).toBe("thinking");
+  });
+
+  it("OpenAI provider 跳过 Anthropic 专用 patch", () => {
+    const body = {
+      thinking: { type: "enabled" },
+      messages: [
+        { role: "assistant", content: [{ type: "text", text: "hi" }] },
+      ],
+    };
+    const original = JSON.stringify(body);
+    const { body: result } = applyProviderPatches(body, {
+      base_url: "https://api.deepseek.com",
+      api_type: "openai",
+    });
+    // OpenAI patch 尚未实现，body 不变
+    expect(JSON.stringify(result)).toBe(original);
+  });
+
+  it("api_type 为 anthropic 但非 DeepSeek provider 时不触发", () => {
+    const body = {
+      thinking: { type: "enabled" },
+      messages: [
+        { role: "assistant", content: [{ type: "text", text: "hi" }] },
+      ],
+    };
+    const original = JSON.stringify(body);
+    const { body: result } = applyProviderPatches(body, {
+      base_url: "https://api.anthropic.com",
+      api_type: "anthropic",
+    });
+    expect(JSON.stringify(result)).toBe(original);
+  });
+});
+
+describe("stripCacheControl", () => {
+  it("移除 messages/system/tools 中的 cache_control", () => {
+    const body = {
+      system: [{ type: "text", text: "You are helpful", cache_control: { type: "ephemeral" } }],
+      messages: [
+        { role: "user", content: [
+          { type: "text", text: "hello", cache_control: { type: "ephemeral" } },
+        ] },
+        { role: "assistant", content: [
+          { type: "thinking", thinking: "hmm", cache_control: { type: "ephemeral" } },
+          { type: "text", text: "hi" },
+        ] },
+      ],
+      tools: [{ name: "read", input_schema: {}, cache_control: { type: "ephemeral" } }],
+    };
+    stripCacheControl(body);
+    expect(JSON.stringify(body)).not.toContain("cache_control");
+    // 其他字段保持不变
+    expect((body.messages![0] as { content: unknown[] }).content[0]).toHaveProperty("type", "text");
+  });
+
+  it("无 cache_control 时不修改", () => {
+    const body = {
+      messages: [
+        { role: "user", content: [{ type: "text", text: "hello" }] },
+      ],
+    };
+    const original = JSON.stringify(body);
+    stripCacheControl(body);
+    expect(JSON.stringify(body)).toBe(original);
+  });
+
+  it("system 为 string 时不报错", () => {
+    const body = {
+      system: "You are helpful",
+      messages: [],
+    };
+    expect(() => stripCacheControl(body)).not.toThrow();
+  });
+});
+
+describe("patchThinkingParam", () => {
+  it("Anthropic: 历史有 thinking block 但无参数时注入", () => {
+    const body = {
+      messages: [
+        { role: "assistant", content: [{ type: "thinking", thinking: "hmm" }, { type: "text", text: "hi" }] },
+        { role: "user", content: "continue" },
+      ],
+    };
+    patchThinkingParam(body, "anthropic");
+    expect(body.thinking).toEqual({ type: "enabled", budget_tokens: 10000 });
+  });
+
+  it("OpenAI: 历史有 reasoning_content 但无参数时注入", () => {
+    const body = {
+      messages: [
+        { role: "assistant", content: "hi", reasoning_content: "hmm" },
+        { role: "user", content: "continue" },
+      ],
+    };
+    patchThinkingParam(body, "openai");
+    expect(body.thinking).toEqual({ type: "enabled" });
+    expect((body.thinking as Record<string, unknown>).budget_tokens).toBeUndefined();
+  });
+
+  it("已有 thinking 参数时不覆盖", () => {
+    const body = {
+      thinking: { type: "enabled", budget_tokens: 5000 },
+      messages: [],
+    };
+    patchThinkingParam(body, "anthropic");
+    expect(body.thinking).toEqual({ type: "enabled", budget_tokens: 5000 });
+  });
+
+  it("无 thinking 历史时不注入", () => {
+    const body = {
+      messages: [
+        { role: "user", content: "hello" },
+        { role: "assistant", content: [{ type: "text", text: "hi" }] },
+      ],
+    };
+    patchThinkingParam(body, "anthropic");
+    expect(body.thinking).toBeUndefined();
+  });
+
+  it("无 messages 时安全返回", () => {
+    const body = {};
+    patchThinkingParam(body, "anthropic");
+    expect(body.thinking).toBeUndefined();
+  });
+});
+
+describe("patchMissingThinkingBlocks (signature + position)", () => {
+  it("历史 thinking block 带 signature 时补 signature", () => {
+    const body = {
+      thinking: { type: "enabled" },
+      messages: [
+        { role: "assistant", content: [{ type: "thinking", thinking: "h", signature: "sig1" }, { type: "text", text: "a" }] },
+        { role: "user", content: "ok" },
+        { role: "assistant", content: [{ type: "text", text: "b" }] },
+      ],
+    };
+    patchMissingThinkingBlocks(body);
+    const lastAssistant = body.messages[2] as { content: Array<Record<string, unknown>> };
+    expect(lastAssistant.content[0]).toEqual({ type: "thinking", thinking: "", signature: "" });
+  });
+
+  it("历史 thinking block 不带 signature 时不补 signature", () => {
+    const body = {
+      thinking: { type: "enabled" },
+      messages: [
+        { role: "assistant", content: [{ type: "thinking", thinking: "h" }, { type: "text", text: "a" }] },
+        { role: "user", content: "ok" },
+        { role: "assistant", content: [{ type: "text", text: "b" }] },
+      ],
+    };
+    patchMissingThinkingBlocks(body);
+    const lastAssistant = body.messages[2] as { content: Array<Record<string, unknown>> };
+    expect(lastAssistant.content[0]).toEqual({ type: "thinking", thinking: "" });
+    expect("signature" in (lastAssistant.content[0] as Record<string, unknown>)).toBe(false);
+  });
+
+  it("thinking block 不在首位时修正位置", () => {
+    const body = {
+      thinking: { type: "enabled" },
+      messages: [
+        { role: "assistant", content: [
+          { type: "text", text: "wrong position" },
+          { type: "thinking", thinking: "hmm", signature: "s" },
+        ] },
+      ],
+    };
+    patchMissingThinkingBlocks(body);
+    const assistant = body.messages[0] as { content: Array<Record<string, unknown>> };
+    expect(assistant.content[0].type).toBe("thinking");
+    expect(assistant.content[1].type).toBe("text");
+  });
+
+  it("无历史 thinking block 且 body.thinking 存在时默认带 signature", () => {
+    const body = {
+      thinking: { type: "enabled" },
+      messages: [
+        { role: "assistant", content: [{ type: "text", text: "hi" }] },
+      ],
+    };
+    patchMissingThinkingBlocks(body);
+    const assistant = body.messages[0] as { content: Array<Record<string, unknown>> };
+    expect(assistant.content[0]).toEqual({ type: "thinking", thinking: "", signature: "" });
+  });
+});
+
+describe("patchOrphanToolResults (empty assistant + dedup)", () => {
+  it("清理孤儿后移除空 assistant 消息", () => {
+    const body = {
+      messages: [
+        { role: "user", content: "go" },
+        { role: "assistant", content: [{ type: "tool_use", id: "call_1", name: "R", input: {} }] },
+        { role: "user", content: [{ type: "tool_result", tool_use_id: "call_1", content: "ok" }] },
+        // 空 assistant + 孤儿 tool_result
+        { role: "assistant", content: [] },
+        { role: "user", content: [{ type: "tool_result", tool_use_id: "ghost", content: "x" }] },
+        { role: "assistant", content: [{ type: "text", text: "final" }] },
+      ],
+    };
+    patchOrphanToolResults(body);
+    // ghost 孤儿 → user 变空 → 删除
+    // assistant([]) 与 assistant(text) 合并 → content = [text]（非空）
+    expect(body.messages).toHaveLength(4);
+    expect((body.messages as unknown[]).map((m: unknown) => (m as { role: string }).role)).toEqual([
+      "user", "assistant", "user", "assistant",
+    ]);
+  });
+
+  it("合并 assistant 时按 tool_use id 去重", () => {
+    const body = {
+      messages: [
+        { role: "user", content: "go" },
+        // 第一个 assistant
+        { role: "assistant", content: [
+          { type: "tool_use", id: "call_dup", name: "Read", input: {} },
+        ] },
+        // 中间 user 只含孤儿，会被删除
+        { role: "user", content: [{ type: "tool_result", tool_use_id: "call_missing", content: "x" }] },
+        // 第二个 assistant 含重复 id
+        { role: "assistant", content: [
+          { type: "tool_use", id: "call_dup", name: "Read", input: { path: "/x" } },
+          { type: "text", text: "result" },
+        ] },
+      ],
+    };
+    patchOrphanToolResults(body);
+    // 孤儿 tool_result → user 删除 → 两个 assistant 合并 → call_dup 去重
+    const merged = body.messages as unknown[];
+    expect(merged).toHaveLength(2);
+    const assistantContent = (merged[1] as { content: unknown[] }).content as Array<Record<string, unknown>>;
+    const toolUseCount = assistantContent.filter(b => b.type === "tool_use").length;
+    expect(toolUseCount).toBe(1);
+    expect(assistantContent).toHaveLength(2); // 1 tool_use + 1 text
+  });
+
+  it("content 为空数组的 assistant 被移除", () => {
+    const body = {
+      messages: [
+        { role: "user", content: "start" },
+        { role: "assistant", content: [] },
+        { role: "user", content: [{ type: "tool_result", tool_use_id: "ghost", content: "x" }] },
+        { role: "user", content: "end" },
+      ],
+    };
+    patchOrphanToolResults(body);
+    // ghost 孤儿 → user[1] 变空删除 → 空 assistant 删除 → 两个 user 合并
+    const msgs = body.messages as unknown[];
+    expect(msgs).toHaveLength(1); // user(start + end) 合并为一条
+    expect((msgs[0] as { role: string }).role).toBe("user");
+  });
+});
+
+describe("applyProviderPatches (full Anthropic pipeline)", () => {
+  it("完整 pipeline: cache_control 剥离 + thinking 参数注入 + thinking block 补齐 + 孤儿清理", () => {
+    const body = {
+      // 无 thinking 参数，但历史有 thinking block
+      system: [{ type: "text", text: "You are helpful", cache_control: { type: "ephemeral" } }],
+      messages: [
+        { role: "assistant", content: [
+          { type: "thinking", thinking: "let me think", signature: "s1", cache_control: { type: "ephemeral" } },
+          { type: "text", text: "hello" },
+        ] },
+        { role: "user", content: [
+          { type: "tool_result", tool_use_id: "call_ghost", content: "x" },
+        ] },
+        { role: "assistant", content: [{ type: "text", text: "world" }] },
+      ],
+    };
+    const { body: result } = applyProviderPatches(body, { base_url: "https://api.deepseek.com/anthropic", api_type: "anthropic" });
+
+    // thinking 参数被注入
+    expect(result.thinking).toEqual({ type: "enabled", budget_tokens: 10000 });
+
+    // cache_control 全部剥离
+    expect(JSON.stringify(result)).not.toContain("cache_control");
+
+    // 孤儿 tool_result (call_ghost) 被清理，空 user 被删除
+    const msgs = result.messages as Array<{ role: string; content: unknown[] }>;
+    // user 只有 tool_result，orphan 清理后变空删除 → 两个 assistant 合并
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0].role).toBe("assistant");
+
+    // 合并后内容：thinking + text + thinking + text（第一个 assistant + 第二个 assistant 合并）
+    const content = msgs[0].content as Array<Record<string, unknown>>;
+    // thinking block 在首位
+    expect(content[0].type).toBe("thinking");
+    // 两个 assistant 的文本都保留
+    const textBlocks = content.filter(b => b.type === "text");
+    expect(textBlocks).toHaveLength(2);
+  });
+
+  it("OpenAI apiType 时不执行 Anthropic patch", () => {
+    const body = {
+      messages: [
+        { role: "assistant", content: [{ type: "text", text: "hi" }] },
+        { role: "user", content: [{ type: "tool_result", tool_use_id: "call_ghost", content: "x" }] },
+      ],
+    };
+    const original = JSON.stringify(body);
+    const { body: result } = applyProviderPatches(body, { base_url: "https://api.deepseek.com/v1", api_type: "openai" });
+    // OpenAI patch 留给后续 PR，当前不执行任何 patch
     expect(JSON.stringify(result)).toBe(original);
   });
 });


### PR DESCRIPTION
## Changes

Based on analysis of Pi's `compat` configuration system for DeepSeek models.

### Architecture
- **apiType awareness**: `ProviderInfo` now includes `api_type`, enabling protocol-specific patches
- **Shared utils**: Extract `mergeConsecutive`/`normalizeToArray` into `utils.ts` (eliminates code duplication between `patch-orphan-tool-results.ts` and `router-cleanup.ts`)

### New Patches (Anthropic)
1. **`patch-thinking-param.ts`** — Auto-inject `thinking: { type: "enabled", budget_tokens: 10000 }` when history has thinking blocks but request omits the parameter
2. **`patch-cache-control.ts`** — Strip all `cache_control` fields (system/messages/tools) that DeepSeek doesn't support

### Enhanced Patches
3. **`patch-thinking-blocks.ts`** — Signature field consistency (detect history format) + thinking block position fix (ensure always first in content array)
4. **`patch-orphan-tool-results.ts`** — Empty assistant message cleanup + tool_use dedup during merge + shared utils

### Pipeline Order
```
patchThinkingParam → stripCacheControl → patchMissingThinkingBlocks → patchOrphanToolResults
```

### Tests
- 684 tests passed (64 files), up from 16 tests for patch module
- New test suites for: `stripCacheControl`, `patchThinkingParam`, signature detection, position fix, empty assistant cleanup, tool_use dedup, full pipeline integration

### Files
- 3 new files: `utils.ts`, `patch-cache-control.ts`, `patch-thinking-param.ts`
- 6 modified files
- 1 design document: `docs/design/2026-04-30-deepseek-patch-optimization.md`

OpenAI protocol patches deferred to follow-up PR.