### PR TITLE
fix: 修复关闭卡住 + 工具调用轮数限制 + 日志文件时区

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -300,6 +300,7 @@ export interface ProxyEnhancementConfig {
   claude_code_enabled: boolean;
   tool_call_loop_enabled: boolean;
   stream_loop_enabled: boolean;
+  tool_round_limit_enabled: boolean;
 }
 
 export interface UpgradeStatus {

--- a/frontend/src/views/ProxyEnhancement.vue
+++ b/frontend/src/views/ProxyEnhancement.vue
@@ -111,6 +111,26 @@
       <TabsContent value="loop-detection">
         <Card>
           <CardHeader>
+            <CardTitle>工具调用轮数限制</CardTitle>
+            <CardDescription>
+              检测 AI 连续进行工具调用的轮数（assistant → tool_use → user → tool_result 算一轮），超过 5 轮时自动注入提示词提醒 AI 不要陷入无限循环。
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div class="flex items-center gap-3">
+              <Switch
+                id="tool-round-limit-toggle"
+                v-model="toolRoundLimitEnabled"
+              />
+              <Label for="tool-round-limit-toggle">
+                {{ toolRoundLimitEnabled ? '已启用' : '已禁用' }}
+              </Label>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card class="mt-4">
+          <CardHeader>
             <CardTitle>工具调用循环检测</CardTitle>
             <CardDescription>
               检测模型重复调用同一工具的行为，超过阈值时自动中断请求或注入提示词。
@@ -178,6 +198,7 @@ import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
 import SessionTable from '@/components/proxy-enhancement/SessionTable.vue'
 
 const claudeCodeEnabled = ref(false)
+const toolRoundLimitEnabled = ref(true)
 const toolCallLoopEnabled = ref(false)
 const streamLoopEnabled = ref(false)
 const selectModelInstruction = '---\ndescription: 切换代理路由模型\n---\n\n[router-command: select-model $ARGUMENTS]'
@@ -192,6 +213,7 @@ async function loadConfig() {
   try {
     const data = await api.getProxyEnhancement()
     claudeCodeEnabled.value = data.claude_code_enabled
+    toolRoundLimitEnabled.value = data.tool_round_limit_enabled
     toolCallLoopEnabled.value = data.tool_call_loop_enabled
     streamLoopEnabled.value = data.stream_loop_enabled
   } catch (e: unknown) {
@@ -207,6 +229,7 @@ async function handleSave() {
       claude_code_enabled: claudeCodeEnabled.value,
       tool_call_loop_enabled: toolCallLoopEnabled.value,
       stream_loop_enabled: streamLoopEnabled.value,
+      tool_round_limit_enabled: toolRoundLimitEnabled.value,
     })
     toast.success('保存成功')
   } catch (e: unknown) {

--- a/src/admin/proxy-enhancement.ts
+++ b/src/admin/proxy-enhancement.ts
@@ -8,6 +8,7 @@ const UpdateProxyEnhancementSchema = Type.Object({
   claude_code_enabled: Type.Boolean(),
   tool_call_loop_enabled: Type.Boolean(),
   stream_loop_enabled: Type.Boolean(),
+  tool_round_limit_enabled: Type.Boolean(),
 });
 
 const SessionParamsSchema = Type.Object({
@@ -28,7 +29,7 @@ export const adminProxyEnhancementRoutes: FastifyPluginCallback<ProxyEnhancement
   const { db, stateRegistry } = options;
 
   app.get("/admin/api/proxy-enhancement", async (_request, reply) => {
-    const config = stateRegistry?.getEnhancementConfig() ?? { claude_code_enabled: false, tool_call_loop_enabled: false, stream_loop_enabled: false };
+    const config = stateRegistry?.getEnhancementConfig() ?? { claude_code_enabled: false, tool_call_loop_enabled: false, stream_loop_enabled: false, tool_round_limit_enabled: true };
     return reply.send(config);
   });
 
@@ -38,6 +39,7 @@ export const adminProxyEnhancementRoutes: FastifyPluginCallback<ProxyEnhancement
       claude_code_enabled: body.claude_code_enabled,
       tool_call_loop_enabled: body.tool_call_loop_enabled,
       stream_loop_enabled: body.stream_loop_enabled,
+      tool_round_limit_enabled: body.tool_round_limit_enabled,
     };
     setSetting(db, "proxy_enhancement", JSON.stringify(config));
     return reply.send({ success: true });

--- a/src/index.ts
+++ b/src/index.ts
@@ -341,6 +341,8 @@ export async function buildApp(
     logCleanup.stop();
     dbSizeMonitor.stop();
     tracker.stopPushInterval();
+    // 关闭所有 SSE 长连接，防止 app.close() 因 hijack 的连接无限等待
+    tracker.closeAllClients();
     modelState.clearAll();
     semaphoreManager.removeAll();
     const sessionTracker = container.resolve<SessionTracker>(SERVICE_KEYS.sessionTracker);
@@ -402,7 +404,25 @@ export async function main() {
   });
 
   // 优雅关闭：SIGTERM（systemd/docker stop）和 SIGINT（Ctrl+C）
+  let isShuttingDown = false;
+  const GRACEFUL_SHUTDOWN_TIMEOUT_MS = 10_000;
+
   const shutdown = async (signal: string) => {
+    // 防止重复触发：多次 Ctrl+C 只执行一次关闭
+    if (isShuttingDown) {
+      app.log.info(`Received ${signal} again, already shutting down...`);
+      return;
+    }
+    isShuttingDown = true;
+
+    // 强制退出兜底：优雅关闭超过 N 秒则强制退出
+    const forceTimer = setTimeout(() => {
+      app.log.error("Graceful shutdown timed out, forcing exit");
+      process.exit(1);
+    }, GRACEFUL_SHUTDOWN_TIMEOUT_MS);
+    // 不阻止进程退出
+    forceTimer.unref();
+
     try {
       app.log.info(`Received ${signal}, shutting down gracefully...`);
       await close();
@@ -410,6 +430,7 @@ export async function main() {
     } catch (err) {
       app.log.error({ err }, "Error during shutdown");
     }
+    clearTimeout(forceTimer);
     process.exit(0);
   };
   process.on("SIGTERM", () => shutdown("SIGTERM"));

--- a/src/monitor/request-tracker.ts
+++ b/src/monitor/request-tracker.ts
@@ -259,6 +259,18 @@ export class RequestTracker {
     this.clients.delete(res);
   }
 
+  /** 主动关闭所有 SSE 客户端连接，确保 app.close() 不会因长连接阻塞 */
+  closeAllClients(): void {
+    for (const client of this.clients) {
+      try {
+        if (!client.writableEnded) client.end();
+      } catch {
+        // 忽略已关闭的连接
+      }
+    }
+    this.clients.clear();
+  }
+
   // --- Push interval ---
 
   startPushInterval(): void {

--- a/src/proxy/handler/proxy-handler.ts
+++ b/src/proxy/handler/proxy-handler.ts
@@ -29,6 +29,7 @@ import { applyOverflowRedirect } from "../routing/overflow.js";
 import { applyProviderPatches } from "../patch/index.js";
 import { PipelineSnapshot, type StageRecord } from "../pipeline-snapshot.js";
 import { maybeInjectModelInfoTag } from "../response-transform.js";
+import { applyToolRoundLimit } from "../patch/tool-round-limiter.js";
 import { loadEnhancementConfig } from "../routing/enhancement-config.js";
 import { getTransportStatusCode, serializeBlocksForStorage, extractLastToolUse } from "./proxy-handler-utils.js";
 
@@ -147,8 +148,18 @@ export async function handleProxyRequest(
   );
   snapshot.add({ stage: "enhancement", router_tags_stripped: enhMeta.router_tags_stripped, directive: enhMeta.directive });
 
-  // tool guard 阶段 — 使用 enhancedBody
+  // tool round limiter 阶段 — 检测连续工具调用轮数，超阈值时注入提示词
   let pipelineBody = enhancedBody;
+  if (enhancementConfig.tool_round_limit_enabled) {
+    const roundResult = applyToolRoundLimit(enhancedBody, apiType);
+    if (roundResult.injected) {
+      pipelineBody = roundResult.body;
+      snapshot.add({ stage: "tool_round_limit", action: "inject_warning", rounds: roundResult.rounds });
+      request.log.info({ sessionId, rounds: roundResult.rounds }, "Tool round limit reached, injecting warning prompt");
+    }
+  }
+
+  // tool guard 阶段 — 使用 pipelineBody（可能已被 round limiter 修改）
   const sessionTracker = deps.container.resolve<import("../loop-prevention/session-tracker.js").SessionTracker>(SERVICE_KEYS.sessionTracker);
   if (enhancementConfig.tool_call_loop_enabled && sessionTracker && sessionId) {
     const routerKeyId = (request.routerKey as { id?: string } | undefined)?.id ?? null;

--- a/src/proxy/patch/tool-round-limiter.ts
+++ b/src/proxy/patch/tool-round-limiter.ts
@@ -1,0 +1,147 @@
+/**
+ * 工具调用轮数限制器。
+ *
+ * 检测 messages 中连续的 "assistant(tool_use) → user(tool_result)" 轮次数量，
+ * 超过阈值时注入提示词提醒 AI 不要陷入无限循环。
+ *
+ * 与 loop-prevention/tool-loop-guard 不同：
+ * - tool-loop-guard 关注"同一工具重复调用"（N-gram 检测 input 重复）
+ * - 本模块关注"工具调用轮数过多"（不管是否同一工具，反映 AI 反复操作却无法完成）
+ */
+
+/** Anthropic 格式的 content block */
+interface AnthropicContentBlock {
+  type?: string;
+  id?: string;
+  name?: string;
+  input?: unknown;
+  text?: string;
+}
+
+/** OpenAI 格式的 tool_call */
+interface OpenAIToolCall {
+  type?: string;
+  function?: { name?: string };
+}
+
+interface Message {
+  role?: string;
+  content?: unknown;
+  tool_calls?: OpenAIToolCall[];
+}
+
+const DEFAULT_MAX_ROUNDS = 5;
+const LOOP_WARNING_PROMPT = "[系统提醒] 你已经连续进行了多轮工具调用但似乎还没有完成任务。请注意不要陷入无限循环，停下来总结当前进展，如果无法继续请直接告知用户。";
+
+/**
+ * 统计 messages 中连续的"工具调用轮数"。
+ *
+ * 一轮定义：assistant 消息包含 tool_use → 后面紧接 user 消息包含 tool_result。
+ * 从最后一条消息向前扫描，遇到非工具轮即停止。
+ */
+export function countConsecutiveToolRounds(messages: Message[]): number {
+  let rounds = 0;
+  let i = messages.length - 1;
+
+  while (i >= 1) {
+    const msg = messages[i];
+    // 期望：user 消息包含 tool_result（Anthropic）或 role=tool（OpenAI）
+    if (msg.role === "user" || msg.role === "tool") {
+      const hasToolResult = hasToolResultContent(msg);
+      if (hasToolResult || msg.role === "tool") {
+        // 向前找对应的 assistant 消息
+        let j = i - 1;
+        while (j >= 0 && messages[j].role !== "assistant") j--;
+        if (j >= 0 && hasToolUseContent(messages[j])) {
+          rounds++;
+          i = j - 1;
+          continue;
+        }
+      }
+    }
+    // assistant 消息本身可能包含 tool_use（最后一轮可能还没 tool_result）
+    if (msg.role === "assistant" && hasToolUseContent(msg)) {
+      rounds++;
+      i--;
+      continue;
+    }
+    break;
+  }
+
+  return rounds;
+}
+
+/**
+ * 检测并注入提示词。返回可能修改后的 body（浅拷贝），未超阈值时原样返回。
+ */
+export function applyToolRoundLimit(
+  body: Record<string, unknown>,
+  apiType: "openai" | "anthropic",
+  maxRounds: number = DEFAULT_MAX_ROUNDS,
+): { body: Record<string, unknown>; injected: boolean; rounds: number } {
+  const messages = (body.messages as Message[]) ?? [];
+  if (messages.length === 0) return { body, injected: false, rounds: 0 };
+
+  const rounds = countConsecutiveToolRounds(messages);
+  if (rounds <= maxRounds) return { body, injected: false, rounds };
+
+  const cloned: Record<string, unknown> = { ...body, messages: [...messages] };
+  const clonedMessages = cloned.messages as Message[];
+
+  // 在尾部注入：修改最后一条消息的 content，不插入新消息到头部
+  // 这样不会使 LLM 的 KV cache 失效（前面的 messages 保持不变）
+  if (apiType === "anthropic") {
+    // Anthropic：将提示词作为 text block 追加到最后一条消息的 content 末尾
+    const lastMsg = clonedMessages[clonedMessages.length - 1];
+    if (lastMsg && Array.isArray(lastMsg.content)) {
+      const patched = [...(lastMsg.content as AnthropicContentBlock[])];
+      patched.push({ type: "text", text: LOOP_WARNING_PROMPT });
+      lastMsg.content = patched;
+    } else if (lastMsg && typeof lastMsg.content === "string") {
+      lastMsg.content = [
+        { type: "text", text: lastMsg.content },
+        { type: "text", text: LOOP_WARNING_PROMPT },
+      ];
+    } else {
+      // fallback：追加 user 消息
+      clonedMessages.push({ role: "user", content: [{ type: "text", text: LOOP_WARNING_PROMPT }] });
+    }
+  } else {
+    // OpenAI 格式：将提示词追加到最后一条消息的 content 末尾
+    const lastMsg = clonedMessages[clonedMessages.length - 1];
+    if (lastMsg && typeof lastMsg.content === "string") {
+      lastMsg.content = lastMsg.content + "\n\n" + LOOP_WARNING_PROMPT;
+    } else if (lastMsg && lastMsg.content != null) {
+      lastMsg.content = JSON.stringify(lastMsg.content) + "\n\n" + LOOP_WARNING_PROMPT;
+    } else {
+      // fallback：追加 user 消息
+      clonedMessages.push({ role: "user", content: LOOP_WARNING_PROMPT });
+    }
+  }
+
+  return { body: cloned, injected: true, rounds };
+}
+
+// --- helpers ---
+
+/** Anthropic 格式：检查 content 数组中是否包含 tool_use */
+function hasToolUseContent(msg: Message): boolean {
+  if (Array.isArray(msg.content)) {
+    return (msg.content as AnthropicContentBlock[]).some(
+      (block) => block.type === "tool_use",
+    );
+  }
+  // OpenAI 格式
+  if (msg.tool_calls && msg.tool_calls.length > 0) return true;
+  return false;
+}
+
+/** Anthropic 格式：检查 content 数组中是否包含 tool_result */
+function hasToolResultContent(msg: Message): boolean {
+  if (Array.isArray(msg.content)) {
+    return (msg.content as AnthropicContentBlock[]).some(
+      (block) => block.type === "tool_result",
+    );
+  }
+  return false;
+}

--- a/src/proxy/pipeline-snapshot.ts
+++ b/src/proxy/pipeline-snapshot.ts
@@ -5,6 +5,7 @@ export interface DirectiveMeta {
 
 export type StageRecord =
   | { stage: "enhancement"; router_tags_stripped: number; directive: DirectiveMeta | null }
+  | { stage: "tool_round_limit"; action: string; rounds: number }
   | { stage: "tool_guard"; action: string; tool: string }
   | { stage: "routing"; client_model: string; backend_model: string; provider_id: string; strategy: string }
   | { stage: "overflow"; triggered: boolean; redirect_to?: string; redirect_provider?: string }

--- a/src/proxy/routing/enhancement-config.ts
+++ b/src/proxy/routing/enhancement-config.ts
@@ -5,12 +5,14 @@ export interface EnhancementConfig {
   claude_code_enabled: boolean;
   tool_call_loop_enabled: boolean;
   stream_loop_enabled: boolean;
+  tool_round_limit_enabled: boolean;
 }
 
 const DEFAULT_CONFIG: EnhancementConfig = {
   claude_code_enabled: false,
   tool_call_loop_enabled: false,
   stream_loop_enabled: false,
+  tool_round_limit_enabled: true,
 };
 
 /** 集中加载 proxy_enhancement 配置，避免多处重复 getSetting + JSON.parse */
@@ -23,6 +25,7 @@ export function loadEnhancementConfig(db: Database.Database): EnhancementConfig 
       claude_code_enabled: parsed.claude_code_enabled ?? false,
       tool_call_loop_enabled: parsed.tool_call_loop_enabled ?? false,
       stream_loop_enabled: parsed.stream_loop_enabled ?? false,
+      tool_round_limit_enabled: parsed.tool_round_limit_enabled ?? true,
     };
   } catch {
     return { ...DEFAULT_CONFIG };

--- a/src/storage/log-file-compressor.ts
+++ b/src/storage/log-file-compressor.ts
@@ -1,7 +1,7 @@
 import { readdirSync, readFileSync, writeFileSync, unlinkSync, rmSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { gzipSync } from "node:zlib";
-import { WINDOW_MINUTES, TIME_PAD_WIDTH, ISO_DATE_LENGTH } from "./types.js";
+import { WINDOW_MINUTES, TIME_PAD_WIDTH, localDateStr } from "./types.js";
 
 const SECONDS_PER_MINUTE = 60;
 const MS_PER_SECOND = 1000;
@@ -28,8 +28,9 @@ export function compressFinishedFiles(baseDir: string, now: Date): number {
       const fileHour = parseInt(match[1], 10);
       const fileMinute = parseInt(match[2], 10);
 
-      const windowEnd = new Date(`${dayDir.name}T${String(fileHour).padStart(TIME_PAD_WIDTH, "0")}:${String(fileMinute).padStart(TIME_PAD_WIDTH, "0")}:00Z`);
-      windowEnd.setUTCMinutes(windowEnd.getUTCMinutes() + WINDOW_MINUTES);
+      // 使用本地时间构建窗口结束时间
+      const windowEnd = new Date(`${dayDir.name}T${String(fileHour).padStart(TIME_PAD_WIDTH, "0")}:${String(fileMinute).padStart(TIME_PAD_WIDTH, "0")}:00`);
+      windowEnd.setMinutes(windowEnd.getMinutes() + WINDOW_MINUTES);
 
       if (now >= windowEnd) {
         const filePath = join(dirPath, file);
@@ -53,9 +54,7 @@ export function compressFinishedFiles(baseDir: string, now: Date): number {
 export function cleanExpiredDirs(baseDir: string, retentionDays: number, now: Date): number {
   if (!existsSync(baseDir)) return 0;
 
-  const cutoff = new Date(now);
-  cutoff.setUTCDate(cutoff.getUTCDate() - retentionDays);
-  const cutoffStr = cutoff.toISOString().slice(0, ISO_DATE_LENGTH);
+  const cutoffStr = localDateStr(new Date(now.getFullYear(), now.getMonth(), now.getDate() - retentionDays));
 
   let deleted = 0;
   const dayDirs = readdirSync(baseDir, { withFileTypes: true })

--- a/src/storage/log-file-writer.ts
+++ b/src/storage/log-file-writer.ts
@@ -1,7 +1,16 @@
 import { appendFileSync, mkdirSync, existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { gunzipSync } from "node:zlib";
-import { type LogFileEntry, WINDOW_MINUTES, TIME_PAD_WIDTH, ISO_DATE_LENGTH } from "./types.js";
+import { type LogFileEntry, WINDOW_MINUTES, TIME_PAD_WIDTH, localDateStr } from "./types.js";
+
+/** 从日期对象生成本地时区的日志文件路径片段 */
+function localFilePathParts(d: Date): { dateStr: string; fileName: string } {
+  const dateStr = localDateStr(d);
+  const hour = d.getHours().toString().padStart(TIME_PAD_WIDTH, "0");
+  const minute = Math.floor(d.getMinutes() / WINDOW_MINUTES) * WINDOW_MINUTES;
+  const minuteStr = minute.toString().padStart(TIME_PAD_WIDTH, "0");
+  return { dateStr, fileName: `${hour}-${minuteStr}.jsonl` };
+}
 
 export interface LogFileWriterOptions {
   enabled?: boolean;
@@ -23,12 +32,7 @@ export class LogFileWriter {
   write(entry: LogFileEntry): void {
     if (!this.enabled) return;
 
-    const date = new Date(entry.created_at);
-    const dateStr = date.toISOString().slice(0, ISO_DATE_LENGTH);
-    const hour = date.getUTCHours().toString().padStart(TIME_PAD_WIDTH, "0");
-    const minute = Math.floor(date.getUTCMinutes() / WINDOW_MINUTES) * WINDOW_MINUTES;
-    const minuteStr = minute.toString().padStart(TIME_PAD_WIDTH, "0");
-    const fileName = `${hour}-${minuteStr}.jsonl`;
+    const { dateStr, fileName } = localFilePathParts(new Date(entry.created_at));
 
     const dayDir = join(this.baseDir, dateStr);
     if (!existsSync(dayDir)) {
@@ -54,12 +58,7 @@ export class LogFileWriter {
   read(id: string, createdAt: string): LogFileEntry | null {
     if (!this.enabled) return null;
 
-    const date = new Date(createdAt);
-    const dateStr = date.toISOString().slice(0, ISO_DATE_LENGTH);
-    const hour = date.getUTCHours().toString().padStart(TIME_PAD_WIDTH, "0");
-    const minute = Math.floor(date.getUTCMinutes() / WINDOW_MINUTES) * WINDOW_MINUTES;
-    const minuteStr = minute.toString().padStart(TIME_PAD_WIDTH, "0");
-    const fileName = `${hour}-${minuteStr}.jsonl`;
+    const { dateStr, fileName } = localFilePathParts(new Date(createdAt));
     const dayDir = join(this.baseDir, dateStr);
 
     // 尝试未压缩文件

--- a/src/storage/types.ts
+++ b/src/storage/types.ts
@@ -4,6 +4,14 @@ export const TIME_PAD_WIDTH = 2;
 /** ISO 日期字符串长度（"YYYY-MM-DD"） */
 export const ISO_DATE_LENGTH = 10;
 
+/** 格式化本地日期为 YYYY-MM-DD */
+export function localDateStr(d: Date): string {
+  const y = d.getFullYear().toString();
+  const m = (d.getMonth() + 1).toString().padStart(TIME_PAD_WIDTH, "0");
+  const day = d.getDate().toString().padStart(TIME_PAD_WIDTH, "0");
+  return `${y}-${m}-${day}`;
+}
+
 export interface LogFileEntry {
   id: string;
   created_at: string;


### PR DESCRIPTION
## 变更内容

### 1. 修复 Ctrl+C 关闭卡住
- **根因**: SSE 长连接（/admin/api/monitor/stream）使用 reply.hijack()，app.close() 等待连接关闭时无限挂起
- RequestTracker 新增 closeAllClients()，在 app.close() 前主动关闭所有 SSE 连接
- shutdown 添加防重入（isShuttingDown）+ 10s 强制退出兜底

### 2. 工具调用轮数限制（新功能）
- 新增 src/proxy/patch/tool-round-limiter.ts
- 检测 messages 中连续 tool_use 轮数，超过 5 轮时注入提示词
- 提示词注入到尾部（最后一条消息的 content 末尾），不影响 KV cache
- 代理增强页面循环检测 Tab 新增开关，默认开启

### 3. 日志文件时区修复
- log-file-writer.ts 和 log-file-compressor.ts 使用 UTC 时间（getUTCHours/toISOString）
- 改为使用本地时区（getHours/getFullYear/getMonth/getDate）
- 文件路径和压缩窗口判断均与本地时间一致