### PR TITLE
fix: improve dark mode contrast for request detail content blocks

### DIFF
--- a/docs/plans/2026-05-01-dark-theme-design.md
+++ b/docs/plans/2026-05-01-dark-theme-design.md
@@ -1,0 +1,61 @@
+# 暗色主题支持 — 设计文档
+
+## 概述
+
+为 LLM Simple Router 管理后台添加暗色主题支持，采用亮/暗双档切换，覆盖全部页面。
+
+## 设计决策
+
+| 决策项 | 选择 | 理由 |
+|--------|------|------|
+| 切换模式 | 亮/暗双档 | 简洁直观，避免三档困惑 |
+| 视觉风格 | 沿用 shadcn dark 色板 | 已精心调好，覆盖全面 |
+| 持久化 | localStorage | 纯前端体验，与设备环境相关 |
+| 切换交互 | Sidebar 底部图标按钮（Moon/Sun） | 简洁紧凑，一目了然 |
+| Chart.js | MutationObserver 监听 html class 变化 | 最可靠，主题变化时动态更新图表配色 |
+| 实施范围 | 全量页面验证 | 一次到位，避免用户发现残缺暗色 |
+
+## 实现方案
+
+### 1. 主题切换机制
+
+新建 `composables/useTheme.ts`：
+
+- 状态：`'light' | 'dark'`
+- localStorage key：`llm-router-theme`
+- 初始化：读取 localStorage，无值默认 `'light'`
+- 切换：更新 localStorage + 在 `<html>` 上添加/移除 `.dark` class
+- 暴露 `isDark` boolean 和 `toggleTheme()` 方法
+
+Sidebar 底部添加图标按钮：
+- 亮色时显示 Moon 图标，暗色时显示 Sun 图标
+- 点击即切换
+
+### 2. Chart.js 暗色适配
+
+- 使用 `MutationObserver` 监听 `<html>` 的 class 变化
+- 暗色模式调整：网格线颜色、tick 文字颜色、图例文字颜色
+- 折线颜色不变（Teal 在两种背景下均可见）
+- 在 `useDashboard` 和 Monitor 中使用
+
+### 3. 全量页面验证
+
+核心原则：所有颜色使用 Tailwind 语义 class（`text-foreground`、`bg-card`、`border-border`），不硬编码。
+
+逐页检查并修复硬编码颜色。
+
+## 文件变更清单
+
+| 操作 | 文件 | 说明 |
+|------|------|------|
+| 新建 | `composables/useTheme.ts` | 主题切换 composable |
+| 修改 | `components/layout/Sidebar.vue` | 底部添加主题切换按钮 |
+| 修改 | `composables/useDashboard.ts` | 图表监听主题变化 |
+| 修改 | `views/metrics-helpers.ts` | Chart.js 配置支持暗色参数 |
+| 修改 | 所有 views 页面 | 修复硬编码颜色 |
+
+## 实施顺序
+
+1. 建 `useTheme.ts` + Sidebar 按钮 → 主题可切换
+2. 逐页扫描硬编码颜色并修复 → 全量暗色适配
+3. 处理 Chart.js 动态更新 → 图表暗色适配

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -15,6 +15,10 @@ import { useRouter, useRoute } from 'vue-router'
 import Sidebar from '@/components/layout/Sidebar.vue'
 import { Toaster } from '@/components/ui/sonner'
 import { api } from '@/api/client'
+import { useTheme } from '@/composables/useTheme'
+
+// Initialize theme ASAP to avoid flash of wrong theme
+useTheme()
 
 const router = useRouter()
 const route = useRoute()

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -15,10 +15,6 @@ import { useRouter, useRoute } from 'vue-router'
 import Sidebar from '@/components/layout/Sidebar.vue'
 import { Toaster } from '@/components/ui/sonner'
 import { api } from '@/api/client'
-import { useTheme } from '@/composables/useTheme'
-
-// Initialize theme ASAP to avoid flash of wrong theme
-useTheme()
 
 const router = useRouter()
 const route = useRoute()

--- a/frontend/src/components/layout/Sidebar.vue
+++ b/frontend/src/components/layout/Sidebar.vue
@@ -96,7 +96,16 @@
         {{ item.label }}
       </router-link>
     </nav>
-    <div class="p-3 border-t border-sidebar-border">
+    <div class="p-3 border-t border-sidebar-border space-y-1">
+      <Button
+        variant="ghost"
+        class="w-full justify-start text-sidebar-foreground hover:text-sidebar-foreground hover:bg-sidebar-accent"
+        @click="toggleTheme"
+      >
+        <Moon v-if="!isDark" class="w-4 h-4" />
+        <Sun v-else class="w-4 h-4" />
+        {{ isDark ? '浅色模式' : '深色模式' }}
+      </Button>
       <Button
         variant="ghost"
         class="w-full justify-start text-sidebar-foreground hover:text-sidebar-foreground hover:bg-sidebar-accent"
@@ -159,6 +168,8 @@ import {
   Settings,
   LogOut,
   CalendarClock,
+  Moon,
+  Sun,
 } from 'lucide-vue-next'
 import { api, getApiMessage } from '@/api/client'
 import { Button } from '@/components/ui/button'
@@ -172,6 +183,9 @@ import {
 import { toast } from 'vue-sonner'
 import type { AcceptableValue } from 'reka-ui'
 import type { UpgradeStatus } from '@/api/client'
+import { useTheme } from '@/composables/useTheme'
+
+const { isDark, toggleTheme } = useTheme()
 
 const appVersion = __APP_VERSION__
 

--- a/frontend/src/components/logs/LogTableRow.vue
+++ b/frontend/src/components/logs/LogTableRow.vue
@@ -76,7 +76,7 @@ function enhancementLabel(raw: string | null): string {
                 class="shrink-0"
                 @click.stop="copy(log.id)"
               >
-                <CheckIcon v-if="copied" class="size-3 text-green-500" />
+                <CheckIcon v-if="copied" class="size-3 text-success" />
                 <CopyIcon v-else class="size-3" />
               </Button>
             </TooltipTrigger>

--- a/frontend/src/components/monitor/ProviderStatsTable.vue
+++ b/frontend/src/components/monitor/ProviderStatsTable.vue
@@ -21,13 +21,13 @@
         <TableCell class="font-medium">{{ entry.name }}</TableCell>
         <TableCell class="text-right">{{ entry.stats.totalRequests }}</TableCell>
         <TableCell class="text-right">
-          <span :class="entry.successRate >= 95 ? 'text-green-600' : entry.successRate >= 80 ? 'text-yellow-600' : 'text-red-500'">
+          <span :class="entry.successRate >= 95 ? 'text-green-600 dark:text-green-400' : entry.successRate >= 80 ? 'text-yellow-600 dark:text-yellow-400' : 'text-red-500 dark:text-red-400'">
             {{ entry.successRate.toFixed(1) }}%
           </span>
         </TableCell>
         <TableCell class="text-right">{{ entry.stats.avgLatencyMs.toFixed(0) }}ms</TableCell>
         <TableCell class="text-right">
-          <span :class="entry.retryRate > 10 ? 'text-yellow-600' : ''">
+          <span :class="entry.retryRate > 10 ? 'text-yellow-600 dark:text-yellow-400' : ''">
             {{ entry.retryRate.toFixed(1) }}%
           </span>
         </TableCell>

--- a/frontend/src/components/monitor/RuntimePanel.vue
+++ b/frontend/src/components/monitor/RuntimePanel.vue
@@ -23,7 +23,7 @@
       </div>
       <div class="h-2 bg-muted rounded-full overflow-hidden mt-1">
         <div
-          class="h-full bg-blue-500 rounded-full transition-all duration-300"
+          class="h-full bg-primary rounded-full transition-all duration-300"
           :style="{ width: `${heapPercent}%` }"
         />
       </div>

--- a/frontend/src/components/request-detail/UnifiedRequestDialog.vue
+++ b/frontend/src/components/request-detail/UnifiedRequestDialog.vue
@@ -32,7 +32,7 @@
             class="shrink-0"
             @click="handleCopyId"
           >
-            <CheckIcon v-if="copied" class="size-3 text-green-500" />
+            <CheckIcon v-if="copied" class="size-3 text-success" />
             <CopyIcon v-else class="size-3" />
           </Button>
         </DialogTitle>

--- a/frontend/src/composables/useDashboard.ts
+++ b/frontend/src/composables/useDashboard.ts
@@ -1,10 +1,11 @@
-import { ref, computed, watch, onMounted } from 'vue'
+import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
 import type { ChartData } from 'chart.js'
 import { api, getApiMessage } from '@/api/client'
 import { toast } from 'vue-sonner'
 import { fillTimeseries } from '@/views/metrics-helpers'
 import { CHART_COLORS } from '@/styles/design-tokens'
 import { formatTimeShort } from '@/utils/format'
+import { watchTheme } from '@/composables/useTheme'
 import type { Provider } from '@/types/mapping'
 
 export interface DashboardStats {
@@ -298,6 +299,9 @@ export function useDashboard() {
     }
   })
 
+  // --- Watch theme changes to re-render charts ---
+  let stopWatchTheme: (() => void) | null = null
+
   onMounted(async () => {
     await loadProviders()
     await loadFilterOptions()
@@ -305,6 +309,12 @@ export function useDashboard() {
       await loadProviderOutputTokens()
     }
     await refresh()
+    // Re-render charts when theme changes (Chart.js doesn't support CSS vars)
+    stopWatchTheme = watchTheme(() => refresh())
+  })
+
+  onUnmounted(() => {
+    if (stopWatchTheme) stopWatchTheme()
   })
 
   return {

--- a/frontend/src/composables/useTheme.ts
+++ b/frontend/src/composables/useTheme.ts
@@ -57,3 +57,11 @@ export function useTheme() {
     toggleTheme,
   }
 }
+
+/**
+ * Call before Vue mount to apply .dark class and prevent flash.
+ * Safe to call multiple times — no-op after first call.
+ */
+export function initThemeEarly() {
+  initTheme()
+}

--- a/frontend/src/composables/useTheme.ts
+++ b/frontend/src/composables/useTheme.ts
@@ -1,0 +1,59 @@
+import { ref } from 'vue'
+
+export type Theme = 'light' | 'dark'
+
+const STORAGE_KEY = 'llm-router-theme'
+
+const isDark = ref(false)
+let initialized = false
+
+function applyTheme(dark: boolean) {
+  isDark.value = dark
+  document.documentElement.classList.toggle('dark', dark)
+}
+
+function initTheme() {
+  if (initialized) return
+  initialized = true
+
+  const stored = localStorage.getItem(STORAGE_KEY) as Theme | null
+  if (stored === 'dark') {
+    applyTheme(true)
+  } else {
+    applyTheme(false)
+  }
+}
+
+function toggleTheme() {
+  const next: Theme = isDark.value ? 'light' : 'dark'
+  localStorage.setItem(STORAGE_KEY, next)
+  applyTheme(next)
+}
+
+/**
+ * Watch for `.dark` class changes on <html> and invoke callback.
+ * Used by Chart.js consumers to re-render with correct colors.
+ */
+export function watchTheme(callback: () => void): () => void {
+  const observer = new MutationObserver((mutations) => {
+    for (const mutation of mutations) {
+      if (mutation.attributeName === 'class') {
+        callback()
+        return
+      }
+    }
+  })
+  observer.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] })
+
+  const stop = () => observer.disconnect()
+  return stop
+}
+
+export function useTheme() {
+  initTheme()
+
+  return {
+    isDark,
+    toggleTheme,
+  }
+}

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -3,6 +3,14 @@ import App from './App.vue'
 import router from './router'
 import './style.css'
 
+// Initialize theme before mount to avoid flash
+;(function initTheme() {
+  const stored = localStorage.getItem('llm-router-theme')
+  if (stored === 'dark') {
+    document.documentElement.classList.add('dark')
+  }
+})()
+
 const app = createApp(App)
 app.use(router)
 app.mount('#app')

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -2,14 +2,10 @@ import { createApp } from 'vue'
 import App from './App.vue'
 import router from './router'
 import './style.css'
+import { initThemeEarly } from './composables/useTheme'
 
-// Initialize theme before mount to avoid flash
-;(function initTheme() {
-  const stored = localStorage.getItem('llm-router-theme')
-  if (stored === 'dark') {
-    document.documentElement.classList.add('dark')
-  }
-})()
+// Apply theme before mount to avoid flash of wrong theme
+initThemeEarly()
 
 const app = createApp(App)
 app.use(router)

--- a/frontend/src/styles/components.css
+++ b/frontend/src/styles/components.css
@@ -8,9 +8,9 @@
   .block-thinking { background-color: var(--color-role-thinking-bg); }
   .block-tool-use { background-color: var(--color-role-tool-bg); }
   .block-tool-result { background-color: var(--color-role-user-bg); }
-  .block-thinking-content { background-color: oklch(from var(--color-role-thinking-bg) l c h / 0.5); color: var(--muted-foreground); }
-  .block-tool-use-content { background-color: oklch(from var(--color-role-tool-bg) l c h / 0.5); }
-  .block-tool-result-content { background-color: oklch(from var(--color-role-user-bg) l c h / 0.5); }
+  .block-thinking-content { background-color: oklch(from var(--color-role-thinking-bg) l c h / 0.7); color: var(--muted-foreground); }
+  .block-tool-use-content { background-color: oklch(from var(--color-role-tool-bg) l c h / 0.7); }
+  .block-tool-result-content { background-color: oklch(from var(--color-role-user-bg) l c h / 0.7); }
 
   /* === Diff 标记 === */
   .diff-modified { background-color: var(--color-warning-light); border-color: var(--color-warning); }

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -88,20 +88,20 @@
 }
 
 .dark {
-  --color-success-light: oklch(0.30 0.05 150);
-  --color-warning-light: oklch(0.32 0.06 80);
-  --color-danger-light: oklch(0.28 0.08 25);
-  --color-info-light: oklch(0.28 0.06 250);
+  --color-success-light: oklch(0.32 0.05 150);
+  --color-warning-light: oklch(0.35 0.06 80);
+  --color-danger-light: oklch(0.30 0.08 25);
+  --color-info-light: oklch(0.30 0.06 250);
 
   /* 语义色通过 var() 引用 shadcn 变量，暗色模式自动跟随 shadcn .dark 覆盖 */
   --color-bg-sidebar: oklch(0.145 0 0);
   --color-text-tertiary: oklch(0.556 0 0);
-  --color-role-user-bg:     oklch(0.28 0.04 175);
+  --color-role-user-bg:     oklch(0.32 0.05 175);
   --color-role-user:        oklch(0.72 0.08 175);
-  --color-role-assistant-bg:oklch(0.25 0.05 260);
+  --color-role-assistant-bg:oklch(0.30 0.06 260);
   --color-role-assistant:   oklch(0.60 0.10 260);
-  --color-role-tool-bg:     oklch(0.22 0.03 30);
+  --color-role-tool-bg:     oklch(0.28 0.04 30);
   --color-role-tool:        oklch(0.65 0.06 30);
-  --color-role-thinking-bg: oklch(0.23 0.04 290);
+  --color-role-thinking-bg: oklch(0.28 0.05 290);
   --color-role-thinking:    oklch(0.55 0.09 290);
 }

--- a/frontend/src/views/Login.vue
+++ b/frontend/src/views/Login.vue
@@ -1,6 +1,15 @@
 <!-- eslint-disable vue/multi-word-component-names -->
 <template>
-  <div class="min-h-screen flex items-center justify-center bg-background">
+  <div class="min-h-screen flex items-center justify-center bg-background relative">
+    <Button
+      variant="ghost"
+      size="icon"
+      class="absolute top-4 right-4 text-muted-foreground hover:text-foreground"
+      @click="toggleTheme"
+    >
+      <Moon v-if="!isDark" class="w-4 h-4" />
+      <Sun v-else class="w-4 h-4" />
+    </Button>
     <Card class="w-full max-w-sm shadow-lg">
       <CardContent class="pt-6">
         <div class="text-center mb-6">
@@ -44,6 +53,10 @@ import { Card, CardContent } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
 import { Label } from '@/components/ui/label'
+import { Moon, Sun } from 'lucide-vue-next'
+import { useTheme } from '@/composables/useTheme'
+
+const { isDark, toggleTheme } = useTheme()
 
 const router = useRouter()
 const password = ref('')

--- a/frontend/src/views/Monitor.vue
+++ b/frontend/src/views/Monitor.vue
@@ -51,7 +51,7 @@
                 <Tooltip>
                   <TooltipTrigger as-child>
                     <Button variant="ghost" size="icon-xs" class="shrink-0" @click.stop="copy(req.id)">
-                      <CheckIcon v-if="copied" class="size-3 text-green-500" />
+                      <CheckIcon v-if="copied" class="size-3 text-success" />
                       <CopyIcon v-else class="size-3" />
                     </Button>
                   </TooltipTrigger>
@@ -93,7 +93,7 @@
                 <Tooltip>
                   <TooltipTrigger as-child>
                     <Button variant="ghost" size="icon-xs" class="shrink-0" @click.stop="copy(req.id)">
-                      <CheckIcon v-if="copied" class="size-3 text-green-500" />
+                      <CheckIcon v-if="copied" class="size-3 text-success" />
                       <CopyIcon v-else class="size-3" />
                     </Button>
                   </TooltipTrigger>
@@ -136,7 +136,7 @@
                 <Tooltip>
                   <TooltipTrigger as-child>
                     <Button variant="ghost" size="icon-xs" class="shrink-0" @click.stop="copy(req.id)">
-                      <CheckIcon v-if="copied" class="size-3 text-green-500" />
+                      <CheckIcon v-if="copied" class="size-3 text-success" />
                       <CopyIcon v-else class="size-3" />
                     </Button>
                   </TooltipTrigger>

--- a/frontend/src/views/Providers.vue
+++ b/frontend/src/views/Providers.vue
@@ -39,7 +39,7 @@
               <div class="flex items-center gap-1">
                 <span class="font-mono text-xs text-muted-foreground">{{ maskKey(p.api_key) }}</span>
                 <Button variant="ghost" size="sm" class="h-6 w-6 p-0" @click="copyKey(p.api_key, p.id)">
-                  <component :is="copiedId === p.id ? Check : Copy" class="w-3.5 h-3.5" :class="{ 'text-green-500': copiedId === p.id }" />
+                  <component :is="copiedId === p.id ? Check : Copy" class="w-3.5 h-3.5" :class="{ 'text-success': copiedId === p.id }" />
                 </Button>
               </div>
             </TableCell>

--- a/frontend/src/views/Setup.vue
+++ b/frontend/src/views/Setup.vue
@@ -1,6 +1,15 @@
 <!-- eslint-disable vue/multi-word-component-names -->
 <template>
-  <div class="min-h-screen flex items-center justify-center bg-background">
+  <div class="min-h-screen flex items-center justify-center bg-background relative">
+    <Button
+      variant="ghost"
+      size="icon"
+      class="absolute top-4 right-4 text-muted-foreground hover:text-foreground"
+      @click="toggleTheme"
+    >
+      <Moon v-if="!isDark" class="w-4 h-4" />
+      <Sun v-else class="w-4 h-4" />
+    </Button>
     <Card class="w-full max-w-sm shadow-lg">
       <CardContent class="pt-6">
         <div class="text-center mb-6">
@@ -53,6 +62,10 @@ import { Card, CardContent } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
 import { Label } from '@/components/ui/label'
+import { Moon, Sun } from 'lucide-vue-next'
+import { useTheme } from '@/composables/useTheme'
+
+const { isDark, toggleTheme } = useTheme()
 
 const router = useRouter()
 const password = ref('')

--- a/frontend/src/views/metrics-helpers.ts
+++ b/frontend/src/views/metrics-helpers.ts
@@ -117,8 +117,23 @@ function makeXTickCallback(ticks: Set<number>) {
   }
 }
 
+/** Detect if dark mode is active */
+function isDarkMode(): boolean {
+  return document.documentElement.classList.contains('dark')
+}
+
+/** Grid/tick colors that adapt to the current theme */
+function chartThemeColors() {
+  const dark = isDarkMode()
+  return {
+    gridColor: dark ? 'oklch(1 0 0 / 10%)' : 'oklch(0.922 0 0)',
+    tickColor: dark ? 'oklch(0.708 0 0)' : 'oklch(0.556 0 0)',
+  }
+}
+
 export function lineOptions(unit: string, labels: string[]): ChartOptions<'line'> {
   const ticks = tickIndices(labels.length)
+  const colors = chartThemeColors()
   return {
     responsive: true,
     maintainAspectRatio: false,
@@ -133,27 +148,28 @@ export function lineOptions(unit: string, labels: string[]): ChartOptions<'line'
       x: {
         display: true,
         grid: { display: false },
-        ticks: { maxRotation: 0, autoSkip: false, callback: makeXTickCallback(ticks) },
+        ticks: { maxRotation: 0, autoSkip: false, callback: makeXTickCallback(ticks), color: colors.tickColor },
       },
-      y: { display: true, beginAtZero: true },
+      y: { display: true, beginAtZero: true, grid: { color: colors.gridColor }, ticks: { color: colors.tickColor } },
     },
   }
 }
 
 export function stackedAreaOptions(labels: string[]): ChartOptions<'line'> {
   const ticks = tickIndices(labels.length)
+  const colors = chartThemeColors()
   return {
     responsive: true,
     maintainAspectRatio: false,
     interaction: { mode: 'index', intersect: false },
-    plugins: { legend: { position: 'bottom' } },
+    plugins: { legend: { position: 'bottom', labels: { color: colors.tickColor } } },
     scales: {
       x: {
         stacked: true,
         grid: { display: false },
-        ticks: { maxRotation: 0, autoSkip: false, callback: makeXTickCallback(ticks) },
+        ticks: { maxRotation: 0, autoSkip: false, callback: makeXTickCallback(ticks), color: colors.tickColor },
       },
-      y: { stacked: true, beginAtZero: true },
+      y: { stacked: true, beginAtZero: true, grid: { color: colors.gridColor }, ticks: { color: colors.tickColor } },
     },
   }
 }


### PR DESCRIPTION
- Raise role background lightness in dark mode (0.22-0.28 → 0.28-0.32)
- Increase content block opacity from 0.5 to 0.7 for better visibility
- Slightly raise status light color lightness (success/warning/danger/info)