### PR TITLE
feat: add OpenAI Responses API (/v1/responses) endpoint support

### DIFF
--- a/docs/api-research.md
+++ b/docs/api-research.md
@@ -1,0 +1,384 @@
+# LLM API 格式转换调研报告
+
+## 一、三大 API 格式对比
+
+### 1.1 OpenAI Chat Completions (`/v1/chat/completions`)
+
+```jsonc
+// 请求
+{
+  "model": "gpt-4o",
+  "messages": [
+    {"role": "system", "content": "You are helpful."},
+    {"role": "user", "content": "Hello"},
+    {"role": "assistant", "content": "Hi!", "tool_calls": [
+      {"id": "call_xxx", "type": "function", "function": {"name": "get_weather", "arguments": "{\"city\":\"SF\"}"}}
+    ]},
+    {"role": "tool", "tool_call_id": "call_xxx", "content": "{\"temp\": 72}"}
+  ],
+  "max_tokens": 4096,
+  "temperature": 0.7,
+  "tools": [{"type": "function", "function": {"name": "get_weather", "parameters": {...}}}],
+  "stream": true
+}
+
+// 非流式响应
+{
+  "id": "chatcmpl-xxx",
+  "choices": [{
+    "message": {"role": "assistant", "content": "...", "tool_calls": [...]},
+    "finish_reason": "stop"
+  }],
+  "usage": {"prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30}
+}
+
+// 流式 SSE 事件
+data: {"id":"chatcmpl-xxx","choices":[{"delta":{"role":"assistant"},"index":0}]}
+data: {"choices":[{"delta":{"content":"Hello"},"index":0}]}
+data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_xxx","function":{"name":"get_weather","arguments":""}}]},"index":0}]}
+data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"ci"}}]},"index":0}]}
+data: {"choices":[{"delta":{},"finish_reason":"stop","index":0}]}
+data: [DONE]
+```
+
+### 1.2 OpenAI Responses (`/v1/responses`)
+
+```jsonc
+// 请求
+{
+  "model": "gpt-4o",
+  "instructions": "You are helpful.",     // ← 替代 system message
+  "input": [                               // ← 替代 messages
+    {"type": "message", "role": "user", "content": "Hello"},
+    {"type": "function_call", "id": "fc_xxx", "call_id": "call_xxx", "name": "get_weather", "arguments": "{\"city\":\"SF\"}"},
+    {"type": "function_call_output", "call_id": "call_xxx", "output": "{\"temp\": 72}"}
+  ],
+  "max_output_tokens": 4096,               // ← 替代 max_tokens
+  "temperature": 0.7,
+  "tools": [{"type": "function", "name": "get_weather", "parameters": {...}}],  // ← 结构不同
+  "stream": true,
+  "previous_response_id": "resp_xxx"       // ← 新增：多轮对话
+}
+
+// 非流式响应
+{
+  "id": "resp_xxx",
+  "object": "response",
+  "model": "gpt-4o",
+  "status": "completed",
+  "output": [                              // ← 替代 choices
+    {"type": "reasoning", "id": "rs_xxx", "summary": [{"type": "summary_text", "text": "..."}]},
+    {"type": "message", "id": "msg_xxx", "role": "assistant", "content": [
+      {"type": "output_text", "text": "...", "annotations": []}
+    ]},
+    {"type": "function_call", "id": "fc_xxx", "call_id": "call_xxx", "name": "get_weather", "arguments": "{...}"}
+  ],
+  "usage": {"input_tokens": 10, "output_tokens": 20, "total_tokens": 30}
+}
+
+// 流式 SSE 事件（命名事件，非匿名 data）
+event: response.created
+data: {"type":"response.created","response":{"id":"resp_xxx","status":"in_progress"}}
+
+event: response.output_item.added
+data: {"type":"response.output_item.added","output_index":0,"item":{"type":"message","role":"assistant"}}
+
+event: response.content_part.added
+data: {"type":"response.content_part.added","output_index":0,"content_index":0,"part":{"type":"output_text","text":""}}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","output_index":0,"content_index":0,"delta":"Hello"}
+
+event: response.output_item.added
+data: {"type":"response.output_item.added","output_index":1,"item":{"type":"function_call","name":"get_weather"}}
+
+event: response.function_call_arguments.delta
+data: {"type":"response.function_call_arguments.delta","output_index":1,"delta":"{\"city\""}
+
+event: response.output_text.done
+data: {"type":"response.output_text.done","output_index":0,"content_index":0,"text":"Hello!"}
+
+event: response.completed
+data: {"type":"response.completed","response":{"id":"resp_xxx","status":"completed","usage":{...}}}
+```
+
+### 1.3 Anthropic Messages (`/v1/messages`)
+
+```jsonc
+// 请求
+{
+  "model": "claude-sonnet-4-20250514",
+  "system": "You are helpful.",             // ← 独立顶层字段
+  "messages": [
+    {"role": "user", "content": "Hello"},
+    {"role": "assistant", "content": [
+      {"type": "text", "text": "Hi!"},
+      {"type": "tool_use", "id": "toolu_xxx", "name": "get_weather", "input": {"city": "SF"}}
+    ]},
+    {"role": "user", "content": [           // ← tool_result 嵌入 user 消息
+      {"type": "tool_result", "tool_use_id": "toolu_xxx", "content": "{\"temp\": 72}"}
+    ]}
+  ],
+  "max_tokens": 4096,
+  "temperature": 0.7,
+  "tools": [{"name": "get_weather", "input_schema": {...}}],  // ← input_schema 非 parameters
+  "thinking": {"type": "enabled", "budget_tokens": 10000},    // ← thinking 参数
+  "stream": true
+}
+
+// 非流式响应
+{
+  "id": "msg_xxx",
+  "type": "message",
+  "role": "assistant",
+  "content": [
+    {"type": "thinking", "thinking": "Let me think...", "signature": "..."},
+    {"type": "text", "text": "Hello!"},
+    {"type": "tool_use", "id": "toolu_xxx", "name": "get_weather", "input": {"city": "SF"}}
+  ],
+  "stop_reason": "end_turn",
+  "usage": {"input_tokens": 10, "output_tokens": 20, "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0}
+}
+
+// 流式 SSE 事件
+event: message_start
+data: {"type":"message_start","message":{"id":"msg_xxx","role":"assistant","usage":{"input_tokens":10}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"Let me..."}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"Hello!"}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":2,"content_block":{"type":"tool_use","id":"toolu_xxx","name":"get_weather"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":"{\"city\""}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":2}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":20}}
+
+event: message_stop
+data: {"type":"message_stop"}
+```
+
+## 二、三格式转换核心映射
+
+### 2.1 请求转换映射表
+
+| 概念 | Chat Completions | Responses API | Anthropic Messages |
+|------|-----------------|---------------|-------------------|
+| **系统提示** | `messages[role=system]` | `instructions` | `system` (顶层) |
+| **用户输入** | `messages[role=user]` | `input` (string/array) | `messages[role=user]` |
+| **模型回复** | `messages[role=assistant].content` | `output[type=message]` | `messages[role=assistant].content[type=text]` |
+| **工具调用** | `assistant.tool_calls[]` | `input/output[type=function_call]` | `assistant.content[type=tool_use]` |
+| **工具结果** | `messages[role=tool]` | `input[type=function_call_output]` | `user.content[type=tool_result]` |
+| **推理** | `reasoning_content` | `output[type=reasoning]` | `content[type=thinking]` |
+| **最大 token** | `max_tokens` / `max_completion_tokens` | `max_output_tokens` | `max_tokens` |
+| **工具定义** | `tools[].function.parameters` | `tools[].parameters` | `tools[].input_schema` |
+| **工具选择** | `tool_choice: "auto"/"required"/{function}` | `tool_choice: "auto"/"required"/{function}` | `tool_choice: {"type":"auto"/"any"/"tool"}` |
+| **停止原因** | `stop` / `length` / `tool_calls` | `completed` / `incomplete` / `failed` | `end_turn` / `max_tokens` / `tool_use` |
+| **多轮对话** | 传递完整 messages | `previous_response_id` | 传递完整 messages |
+| **多轮索引** | `tool_call_id` | `call_id` | `tool_use_id` |
+
+### 2.2 响应转换映射表
+
+| 概念 | Chat Completions | Responses API | Anthropic Messages |
+|------|-----------------|---------------|-------------------|
+| **文本内容** | `choices[0].message.content` | `output[type=message].content[type=output_text].text` | `content[type=text].text` |
+| **工具调用** | `choices[0].message.tool_calls[]` | `output[type=function_call]` | `content[type=tool_use]` |
+| **推理内容** | `choices[0].message.reasoning_content` | `output[type=reasoning].summary` | `content[type=thinking].thinking` |
+| **推理签名** | N/A | N/A | `content[type=thinking].signature` |
+| **Token 用量** | `usage.prompt_tokens / completion_tokens` | `usage.input_tokens / output_tokens` | `usage.input_tokens / output_tokens` |
+| **缓存用量** | `usage.prompt_tokens_details.cached_tokens` | N/A | `usage.cache_read_input_tokens` |
+| **完成原因** | `finish_reason: stop/length/tool_calls` | `status: completed/incomplete` | `stop_reason: end_turn/max_tokens/tool_use` |
+
+### 2.3 流式 SSE 事件映射
+
+#### Chat Completions ↔ Anthropic Messages
+
+| Chat Completions delta | Anthropic SSE 事件 |
+|----------------------|-------------------|
+| `delta: {role: "assistant"}` | `message_start` |
+| `delta: {content: "..."}` | `content_block_start[text]` + `content_block_delta[text_delta]` |
+| `delta: {tool_calls: [{id, name}]}` | `content_block_start[tool_use]` |
+| `delta: {tool_calls: [{arguments: "..."}]}` | `content_block_delta[input_json_delta]` |
+| `delta: {reasoning_content: "..."}` | `content_block_start[thinking]` + `content_block_delta[thinking_delta]` |
+| `finish_reason: "stop"` | `content_block_stop` + `message_delta{stop_reason: "end_turn"}` + `message_stop` |
+| `usage: {...}` | `message_start` 和 `message_delta` 中的 usage |
+
+#### Chat Completions ↔ Responses API
+
+| Chat Completions delta | Responses SSE 事件 |
+|----------------------|-------------------|
+| `delta: {role: "assistant"}` | `response.created` + `response.in_progress` |
+| `delta: {content: "..."}` | `response.output_item.added[message]` + `response.content_part.added[output_text]` + `response.output_text.delta` |
+| `delta: {tool_calls: [{id, name}]}` | `response.output_item.added[function_call]` |
+| `delta: {tool_calls: [{arguments: "..."}]}` | `response.function_call_arguments.delta` |
+| `delta: {reasoning_content: "..."}` | `response.output_item.added[reasoning]` + `response.reasoning_summary_text.delta` |
+| `finish_reason: "stop"` | `response.output_text.done` + `response.completed` |
+| `data: [DONE]` | `response.completed` (最后一个事件) |
+
+## 三、OpenAI Chat Completions 与 Responses API 的关系
+
+### 3.1 官方定位
+
+- **Chat Completions**：2023年发布，成熟稳定，广泛兼容
+- **Responses API**：2025年3月发布，**OpenAI 的未来方向**，官方推荐新项目使用
+- 两者**并行维护**，OpenAI 暂未宣布废弃 Chat Completions
+- OpenAI SDK v2+ 同时支持两种 API
+
+### 3.2 核心差异
+
+| 维度 | Chat Completions | Responses API |
+|------|-----------------|---------------|
+| **设计哲学** | 无状态，每次传完整历史 | 有状态，支持 `previous_response_id` |
+| **输入结构** | 扁平 messages 数组 | 扁平化 items 数组（混合 message/function_call/reasoning） |
+| **输出结构** | `choices` 数组 | `output` 混合类型数组 |
+| **内置工具** | 无（需自行实现 function calling） | `web_search_preview`、`file_search`、`code_interpreter`、`computer_use_preview` |
+| **流式事件** | 匿名 `data:` 行 | 命名 `event: xxx\ndata:` 行 |
+| **多轮对话** | 客户端维护完整消息列表 | 服务端存储，`previous_response_id` 引用 |
+| **后台执行** | 不支持 | `background: true` |
+| **MCP 集成** | 不支持 | `tools[type=mcp]` |
+
+### 3.3 互转可行性
+
+**Chat → Responses**（较简单）：
+- `messages[system]` → `instructions`
+- `messages[user/assistant/tool]` → `input` items（message / function_call / function_call_output）
+- `max_tokens` → `max_output_tokens`
+- `tools[].function` → `tools[]`（去掉嵌套 function 层）
+
+**Responses → Chat**（需要处理信息丢失）：
+- `instructions` → `messages[system]`
+- `input` items → `messages`（function_call → assistant.tool_calls, function_call_output → tool message）
+- `output` items → `choices[0].message`（message → content, function_call → tool_calls, reasoning → reasoning_content）
+- `previous_response_id` → 无法映射（需要服务端存储多轮状态）
+- 内置工具（web_search 等）→ 无法映射到 Chat Completions
+
+## 四、主流项目转换方案对比
+
+### 4.1 架构模式
+
+| 项目 | 语言 | 架构模式 | 中间模型 |
+|------|------|---------|---------|
+| **LiteLLM** | Python | Direct Transform（每对格式独立转换） | 无（基于 OpenAI Chat Completions ModelResponse 作为公共格式） |
+| **Octopus** | Go | Hub-and-Spoke（统一中间模型） | `InternalLLMRequest/Response`（基于 OpenAI Chat 扩展） |
+| **cc-switch** | Rust | Adapter Pattern（Provider 适配器） | 无（Anthropic 为中心，其他格式围绕 Anthropic 转换） |
+| **One Hub** | Go | OpenAI-Centric Hub | 无（以 OpenAI Chat 为中心，Claude/Gemini 各自独立转换） |
+
+### 4.2 Responses API 支持情况
+
+| 项目 | Responses API 支持 | 实现方式 |
+|------|-------------------|---------|
+| **LiteLLM** | ✅ 完整支持 | 原生支持 OpenAI/Azure/xAI 等；Anthropic 等通过 Chat 桥接转换 |
+| **Octopus** | ✅ 完整支持 | Hub-and-Spoke 中间模型，Inbound/Outbound 双向转换 |
+| **cc-switch** | ✅ 完整支持 | Anthropic 为中心，直接实现 anthropic↔responses 双向转换 |
+| **One Hub** | ✅ 完整支持 | 原生支持 OpenAI Provider；其他 Provider 自动降级到 Chat 桥接 |
+
+### 4.3 转换策略对比
+
+#### LiteLLM：桥接模式
+```
+Responses API request
+  → 转为 Chat Completions request
+  → 走标准 completion() 流程
+  → 将 Chat Completions response 转为 Responses API response
+```
+- **优点**：复用已有的 Chat Completions 转换逻辑，实现成本低
+- **缺点**：增加一层转换开销；Responses 独有特性（previous_response_id、内置工具）会丢失
+
+#### Octopus：中间模型模式
+```
+任何 Inbound → InternalLLMRequest → 任何 Outbound
+任何 Inbound ← InternalLLMResponse ← 任何 Outbound
+```
+- **优点**：M+N 而非 M×N；Internal Model 基于 OpenAI Chat 扩展，表达力强
+- **缺点**：Internal Model 需要覆盖所有格式的所有特性；新增格式需修改中间模型
+
+#### cc-switch：Anthropic 中心模式
+```
+Anthropic Messages 为中心
+  → openai_chat: anthropic_to_openai() / openai_to_anthropic()
+  → openai_responses: anthropic_to_responses() / responses_to_anthropic()
+  → gemini_native: anthropic_to_gemini() / gemini_to_anthropic()
+```
+- **优点**：直接针对 Claude Code 场景优化；流式转换状态机精细
+- **缺点**：所有转换围绕 Anthropic，如果需要 Chat↔Responses 直接转换效率低
+
+#### One Hub：OpenAI 中心 + 自动降级/升级
+```
+OpenAI Chat Completions 为中心
+  /v1/chat/completions → Chat Provider（直接转发或格式转换）
+  /v1/responses → Responses Provider（原生）或 Chat Provider（自动降级）
+  特殊模型 Chat 请求 → 自动升级为 Responses API
+```
+- **优点**：以 OpenAI 为标准，覆盖面广（35+ Provider）；自动降级/升级智能
+- **缺点**：Claude/Gemini 原生格式直通模式与 OpenAI 模式存在代码重复
+
+### 4.4 Thinking/Reasoning 处理对比
+
+| 项目 | Anthropic thinking → OpenAI | OpenAI reasoning → Anthropic |
+|------|---------------------------|------------------------------|
+| **LiteLLM** | `thinking` → `reasoning_content` + `thinking_blocks[]`；`reasoning_effort` → `thinking.budget_tokens` 映射表 | `reasoning_content` → `thinking` block；`budget_tokens` → `reasoning_effort` |
+| **Octopus** | `thinking` content block → `ReasoningContent` 字段 + `ReasoningSignature` | `ReasoningContent` → `thinking` block + `signature` |
+| **cc-switch** | `thinking` → `reasoning_content`；`output_config.effort` 优先于 `thinking.budget_tokens` | `reasoning_content` → `thinking`；自适应映射 effort level |
+| **One Hub** | `thinking` → `reasoning_content`；budget → effort 映射 | `reasoning_content` → `thinking`；使用 budget_tokens |
+
+### 4.5 流式状态机对比
+
+| 项目 | 状态管理 | 复杂度 | 特殊处理 |
+|------|---------|--------|---------|
+| **LiteLLM** | `CustomStreamWrapper` 全局状态 | 中 | JSON mode 特殊处理（tool call → content） |
+| **Octopus** | Inbound/Outbound 各自的状态机（`hasStarted`, `hasTextContentStarted` 等） | 高 | Responses Inbound 维护 `outputIndex/contentIndex/sequenceNumber` + `toolCalls` map |
+| **cc-switch** | 独立的状态机 per 转换方向 | 高 | Copilot 无限空白 bug 检测；UTF-8 跨 chunk 安全拼接 |
+| **One Hub** | `ClaudeStreamHandler` + `OpenAIResponsesStreamConverter` | 中 | 自动升级/降级时的流式格式转换 |
+
+## 五、对 llm-simple-router 的建议
+
+### 5.1 推荐架构：Hub-and-Spoke（类似 Octopus）
+
+当前项目已有 `TransformCoordinator` 处理 OpenAI Chat ↔ Anthropic 双向转换。建议扩展为统一的中间模型：
+
+```
+客户端请求 (Chat Completions / Responses / Anthropic Messages)
+  ↓
+Inbound 转换 → InternalModel (统一的请求/响应模型)
+  ↓
+Outbound 转换 → 目标 Provider 格式
+  ↓
+上游响应
+  ↓
+Outbound 转换 → InternalModel
+  ↓
+Inbound 转换 → 客户端原始格式
+```
+
+### 5.2 实现优先级
+
+1. **Phase 1**：Responses API 入站 + Chat Completions 出站（桥接模式，类似 LiteLLM）
+   - 客户端发 Responses → 转 Chat → 转发到上游
+   - 上游 Chat 响应 → 转 Responses → 返回客户端
+   
+2. **Phase 2**：Responses API 出站（原生支持）
+   - 上游如果支持 Responses（如 OpenAI），直接转发
+   
+3. **Phase 3**：完善流式状态机
+   - Responses SSE ↔ Chat SSE ↔ Anthropic SSE 双向转换
+
+### 5.3 关键技术挑战
+
+1. **Responses API 有状态特性**：`previous_response_id` 需要服务端存储多轮对话，Router 作为无状态代理需要考虑如何处理
+2. **内置工具**：`web_search_preview`、`file_search` 等内置工具在其他 Provider 不存在，需要降级或跳过
+3. **流式状态机复杂度**：Responses API 的命名事件比 Chat Completions 的匿名 delta 复杂得多
+4. **reasoning/thinking 转换**：三方的 reasoning/thinking 格式各不相同，需要精细映射

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,76 @@
+# LLM API 端点调研
+
+## 项目当前已支持的端点
+
+| API 类型 | 端点 | 方法 | 说明 |
+|----------|------|------|------|
+| **OpenAI 兼容** | `/v1/chat/completions` | POST | Chat Completions（核心） |
+| **OpenAI 兼容** | `/v1/models` | GET | 模型列表 |
+| **Anthropic 兼容** | `/v1/messages` | POST | Messages API（Claude Code 主用） |
+
+## 各主流平台端点全景
+
+### 1. OpenAI（SDK v2.24.0）
+
+| 端点 | 路径 | 优先级 | 说明 |
+|------|------|--------|------|
+| Chat Completions | `POST /v1/chat/completions` | ✅ 已支持 | 经典对话补全 |
+| **Responses** | `POST /v1/responses` | **P0 高优** | 2025年新API，替代 Chat Completions 的新范式 |
+| Models | `GET /v1/models` | ✅ 已支持 | 模型列表 |
+| Embeddings | `POST /v1/embeddings` | P1 | 向量嵌入，RAG/检索场景 |
+| Images | `POST /v1/images/generations` | P2 | DALL·E 图像生成 |
+| Audio | `POST /v1/audio/*` | P3 | TTS/STT/语音翻译 |
+| Moderations | `POST /v1/moderations` | P3 | 内容审核 |
+| Fine-tuning | `POST /v1/fine_tuning/jobs` | P3 | 微调 |
+| Batches | `POST /v1/batches` | P3 | 批量请求 |
+| Vector Stores | `/v1/vector_stores` | P3 | 向量存储 |
+| Realtime | WebSocket | P3 | 实时语音/视频 |
+| Conversations | `/v1/conversations` | P3 | 对话管理 |
+| Evals | `/v1/evals` | P3 | 评估 |
+| Containers | `/v1/containers` | P3 | 沙箱执行环境 |
+| Skills | `/v1/skills` | P3 | 技能管理 |
+| Videos | `/v1/videos` | P3 | 视频生成 |
+
+### 2. Anthropic（SDK v0.86.0）
+
+| 端点 | 路径 | 优先级 | 说明 |
+|------|------|--------|------|
+| Messages | `POST /v1/messages` | ✅ 已支持 | 核心消息 API |
+| Token Count | `POST /v1/messages/count_tokens` | P2 | Token 计数 |
+| Models | `GET /v1/models` | P3 | 模型列表 |
+| Beta: Files | `/v1/files` | P3 | 文件管理 |
+| Beta: Skills | `/v1/skills` | P3 | 技能 |
+
+### 3. Google Gemini
+
+| 端点 | 路径 | 说明 |
+|------|------|------|
+| 原生 API | `POST /v1beta/models/{model}:generateContent` | Gemini 原生 |
+| OpenAI 兼容 | `POST /v1beta/openai/chat/completions` | Google 提供的 OpenAI 兼容层 |
+
+### 4. 国产模型（智谱/Moonshot/Minimax/火山/阿里/腾讯）
+
+几乎所有厂商都提供 **OpenAI 兼容 API**（`/v1/chat/completions`），部分开始支持 `/v1/responses`。
+
+## Responses API 关键差异（vs Chat Completions）
+
+| 维度 | Chat Completions | Responses |
+|------|-----------------|-----------|
+| 输入字段 | `messages` 数组 | `input`（兼容 messages 格式） |
+| 多轮对话 | 传递完整 messages 历史 | `previous_response_id` |
+| 输出格式 | `choices` 数组 | `output` 数组，含多种 `type` |
+| 内置工具 | 无（需自行实现） | `web_search_preview`、`file_search`、`code_interpreter`、`computer_use_preview` |
+| 流式事件 | `data: {"choices": [...]}` | 多种事件类型（`response.output_item.added` 等） |
+| 后台模式 | 不支持 | `background: true` 异步执行 |
+| 工具调用 | `tool_calls` 在 choice 中 | `output` 中包含 `function_call`、`web_search_call` 等多种类型 |
+| 模型参数 | `model` | `model`（相同） |
+| Token 统计 | `usage` | `usage`（结构略有不同） |
+
+## 优先级建议
+
+| 优先级 | 端点 | 原因 |
+|--------|------|------|
+| **P0** | `POST /v1/responses` | OpenAI 新一代核心 API，SDK 已默认使用 |
+| **P1** | `POST /v1/embeddings` | RAG 场景刚需，实现简单 |
+| **P2** | `POST /v1/images/generations` | 图像生成需求增长 |
+| **P3** | Audio（TTS/STT） | 语音场景需求较小 |

--- a/docs/architecture-decision.md
+++ b/docs/architecture-decision.md
@@ -1,0 +1,93 @@
+# 架构决策：Responses ↔ Anthropic 一级转换 + Chat 桥接
+
+> 决策日期：2026-05-02
+
+## 决策
+
+新增 OpenAI Responses API 支持时，采用 **Responses ↔ Anthropic 一级转换 + Chat 二级桥接** 的架构。
+
+## 转换拓扑
+
+```
+              Responses API ←→ Anthropic Messages
+              (一级转换，近无损)          
+                    ↑                    
+                    |                    
+         Chat Completions ──────────────
+         (二级桥接，有损降级)    (保留直连优化路径)
+```
+
+## 转换优先级矩阵
+
+| 客户端格式 | → 上游 Responses | → 上游 Anthropic | → 上游 Chat |
+|-----------|-----------------|-----------------|------------|
+| **Responses** | 直通 | Responses → Anthropic（一级） | Responses → Chat（桥接） |
+| **Anthropic** | Anthropic → Responses（一级） | 直通 | Anthropic → Chat（保留现有直连） |
+| **Chat** | Chat → Responses（桥接） | Chat → Anthropic（保留现有直连） | 直通 |
+
+## 核心理由
+
+### 1. 结构相似性
+
+Responses API 和 Anthropic Messages 在结构上最近亲，Chat Completions 是异类：
+
+| 维度 | Responses ↔ Anthropic | Chat ↔ 任一 |
+|------|----------------------|------------|
+| 系统提示 | 都是顶层字段（`instructions` ↔ `system`） | Chat 嵌在 messages 数组中 |
+| 输出结构 | 都是类型化 items/blocks 数组 | Chat 是扁平 choices[].message.content |
+| 流式 | 都是命名事件（`event:` + `data:`） | Chat 是匿名 `data:` 行 |
+| 推理输出 | 都是结构化（`reasoning` ↔ `thinking`） | Chat 是扁平字符串，丢失 signature |
+| 工具调用 | 独立类型化单元 | 嵌在 choice.message.tool_calls[] |
+
+### 2. 信息保真度
+
+- **Responses ↔ Anthropic**：接近无损。thinking signature、cache_control、结构化输出都能保留
+- **Chat ↔ 任一**：有损。thinking signature 丢失、response_format 无法表达、内置工具无法映射
+
+### 3. 长远兼容性
+
+- OpenAI 方向是 Responses API（Chat Completions 不会立即废弃但不再是重点）
+- 更多 Provider 会逐步支持 Responses API
+- 新特性（MCP、内置工具、background 模式）只在 Responses 中可用
+- 一级转换路径随生态演进而越来越重要
+
+## 实现策略
+
+### 保留现有代码
+
+- `Anthropic ↔ Chat` 的现有转换代码保留不动，作为高频路径优化
+- 现有的 `TransformCoordinator` 扩展而非重写
+
+### 新增一级转换
+
+- `Responses ↔ Anthropic`：新写，核心投入
+- 请求转换：`instructions↔system`、`input items↔messages`、`function_call↔tool_use`
+- 响应转换：`output items↔content blocks`、`reasoning↔thinking`
+- 流式转换：命名事件双向映射
+
+### 新增二级桥接
+
+- `Responses ↔ Chat`：桥接代码
+- 请求：`instructions→system message`、`input items→messages`、`function_call→tool_calls`
+- 响应：`output items→choices`、`reasoning→reasoning_content`（扁平化）
+- 流式：命名事件 ↔ 匿名 delta 转换
+
+### api_type 扩展
+
+Provider 和客户端的 `api_type` 从 `"openai" | "anthropic"` 扩展为：
+
+```typescript
+type ApiType = "openai" | "openai-responses" | "anthropic";
+```
+
+- `"openai"` = OpenAI Chat Completions 兼容（智谱/Moonshot 等）
+- `"openai-responses"` = OpenAI Responses API（OpenAI 官方、Codex CLI）
+- `"anthropic"` = Anthropic Messages（Claude Code）
+
+## 风险与缓解
+
+| 风险 | 缓解 |
+|------|------|
+| 转换路径增多，维护复杂 | 一级转换是核心，桥接可简化 |
+| Anthropic → Chat 双重转换 | 保留现有直连路径 |
+| Responses API 变更 | 紧跟 OpenAI SDK 版本，保持兼容 |

--- a/docs/superpowers/plans/2026-05-02-openai-responses-api.md
+++ b/docs/superpowers/plans/2026-05-02-openai-responses-api.md
@@ -1,0 +1,2699 @@
+# OpenAI Responses API 端点支持 — 详细实现计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 为 llm-simple-router 新增 OpenAI Responses API (`/v1/responses`) 端点支持，采用 Responses ↔ Anthropic 一级转换 + Chat 桥接的架构。
+
+**Architecture:** 新增 `"openai-responses"` 作为第三种 api_type。Responses ↔ Anthropic 作为一级（近无损）转换对，Responses ↔ Chat 作为二级桥接。现有 Anthropic ↔ Chat 直连路径保留。TransformCoordinator 扩展为支持 3×3 转换矩阵。需要同步修改 patch 系统、plugin 系统、metrics 系统、monitor 系统等所有使用 api_type 的模块。
+
+**Tech Stack:** TypeScript, Fastify, SQLite (better-sqlite3), stream.Transform (SSE), Vitest
+
+**架构决策文档:** `docs/architecture-decision.md`
+**调研报告:** `docs/api-research.md`
+
+---
+
+## 文件结构
+
+### 新增文件（按职责分组）
+
+**类型定义：**
+| 文件 | 职责 |
+|------|------|
+| `src/proxy/transform/types-responses.ts` | Responses API 请求/响应/流式事件 TypeScript 类型 |
+
+**一级转换（Responses ↔ Anthropic，近无损）：**
+| 文件 | 职责 |
+|------|------|
+| `src/proxy/transform/request-transform-responses.ts` | Responses ↔ Anthropic 请求转换 |
+| `src/proxy/transform/response-transform-responses.ts` | Responses ↔ Anthropic 响应转换 |
+| `src/proxy/transform/stream-ant2resp.ts` | Anthropic SSE → Responses SSE 流式转换 |
+| `src/proxy/transform/stream-resp2ant.ts` | Responses SSE → Anthropic SSE 流式转换 |
+
+**二级桥接（Responses ↔ Chat，有损）：**
+| 文件 | 职责 |
+|------|------|
+| `src/proxy/transform/request-bridge-responses.ts` | Responses ↔ Chat 请求桥接 |
+| `src/proxy/transform/response-bridge-responses.ts` | Responses ↔ Chat 响应桥接 |
+| `src/proxy/transform/stream-bridge-resp2chat.ts` | Responses SSE → Chat SSE 桥接 |
+| `src/proxy/transform/stream-bridge-chat2resp.ts` | Chat SSE → Responses SSE 桥接 |
+
+**端点路由：**
+| 文件 | 职责 |
+|------|------|
+| `src/proxy/handler/responses.ts` | Responses API 端点 Fastify 插件 |
+
+**测试：**
+| 文件 | 职责 |
+|------|------|
+| `tests/proxy/transform/request-transform-responses.test.ts` | 一级请求转换测试 |
+| `tests/proxy/transform/response-transform-responses.test.ts` | 一级响应转换测试 |
+| `tests/proxy/transform/request-bridge-responses.test.ts` | 桥接请求转换测试 |
+| `tests/proxy/transform/response-bridge-responses.test.ts` | 桥接响应转换测试 |
+| `tests/proxy/transform/stream-ant2resp.test.ts` | Anthropic→Responses 流式测试 |
+| `tests/proxy/transform/stream-resp2ant.test.ts` | Responses→Anthropic 流式测试 |
+
+### 修改文件
+
+| 文件 | 修改内容 |
+|------|---------|
+| `src/db/providers.ts` | api_type 联合类型扩展为含 `"openai-responses"` |
+| `src/core/constants.ts` | PROXY_API_TYPES 增加 Responses 路由映射 |
+| `src/core/types.ts` | ApiType 联合类型（如有） |
+| `src/proxy/transform/types.ts` | TransformDirection 扩展 |
+| `src/proxy/transform/transform-coordinator.ts` | 3×3 转换矩阵 |
+| `src/proxy/handler/proxy-handler.ts` | apiType 类型签名扩展 |
+| `src/proxy/handler/proxy-handler-utils.ts` | serializeBlocksForStorage apiType 扩展 |
+| `src/proxy/proxy-core.ts` | buildUpstreamHeaders 支持 openai-responses |
+| `src/proxy/patch/index.ts` | applyProviderPatches 兼容 openai-responses |
+| `src/proxy/patch/deepseek/index.ts` | applyDeepSeekPatches apiType 签名扩展 |
+| `src/proxy/patch/tool-round-limiter.ts` | apiType 签名扩展 |
+| `src/proxy/loop-prevention/tool-loop-guard.ts` | apiType 签名扩展 |
+| `src/proxy/transport/transport-fn.ts` | apiType 签名扩展 |
+| `src/proxy/transform/plugin-types.ts` | apiType 签名扩展 |
+| `src/proxy/response-transform.ts` | maybeInjectModelInfoTag 兼容 Responses |
+| `src/proxy/proxy-logging.ts` | apiType 签名扩展 |
+| `src/proxy/orchestration/orchestrator.ts` | apiType 签名扩展 |
+| `src/monitor/stream-content-accumulator.ts` | apiType 签名扩展 |
+| `src/monitor/stream-extractor.ts` | extractStreamText 支持 openai-responses |
+| `src/monitor/request-tracker.ts` | apiType 签名扩展 |
+| `src/monitor/types.ts` | apiType 签名扩展 |
+| `src/metrics/sse-metrics-transform.ts` | apiType 签名扩展 + Responses SSE 解析 |
+| `src/metrics/metrics-extractor.ts` | apiType 签名扩展 + Responses 指标提取 |
+| `src/index.ts` | 注册 Responses 路由 |
+| `frontend/src/views/Providers.vue` | 添加 openai-responses 选项 |
+
+---
+
+## Task 1: 定义 ApiType 联合类型 + Responses API 类型
+
+**Files:**
+- Create: `src/proxy/transform/types-responses.ts`
+- Modify: `src/proxy/transform/types.ts`
+
+- [ ] **Step 1: 在 types.ts 中定义 ApiType 联合类型**
+
+在 `src/proxy/transform/types.ts` 末尾添加：
+
+```typescript
+/** 所有支持的 API 格式类型 */
+export type ApiType = "openai" | "openai-responses" | "anthropic";
+```
+
+同时修改现有的 `TransformDirection`：
+
+```typescript
+/** 格式转换方向 */
+export type TransformDirection =
+  // 现有
+  | "openai-to-anthropic" | "anthropic-to-openai"
+  // 一级：Responses ↔ Anthropic
+  | "openai-responses-to-anthropic" | "anthropic-to-openai-responses"
+  // 二级：Responses ↔ Chat
+  | "openai-to-openai-responses" | "openai-responses-to-openai";
+```
+
+- [ ] **Step 2: 创建 Responses API 类型定义**
+
+创建 `src/proxy/transform/types-responses.ts`：
+
+```typescript
+// ---------- Responses API 输入 item 类型 ----------
+
+export interface ResponseInputMessage {
+  type: "message";
+  role: "user" | "assistant" | "system" | "developer";
+  content: string | ResponseInputContentPart[];
+}
+
+export interface ResponseInputText {
+  type: "input_text";
+  text: string;
+}
+
+export interface ResponseInputImage {
+  type: "input_image";
+  image_url: string;
+  detail?: "auto" | "low" | "high";
+}
+
+export interface ResponseFunctionCallInput {
+  type: "function_call";
+  id: string;
+  call_id: string;
+  name: string;
+  arguments: string;
+}
+
+export interface ResponseFunctionCallOutputInput {
+  type: "function_call_output";
+  call_id: string;
+  output: string;
+}
+
+export interface ResponseReasoningInput {
+  type: "reasoning";
+  id: string;
+  summary: Array<{ type: "summary_text"; text: string }>;
+  encrypted_content?: string;
+}
+
+export type ResponseInputItem =
+  | ResponseInputMessage
+  | ResponseInputText
+  | ResponseInputImage
+  | ResponseFunctionCallInput
+  | ResponseFunctionCallOutputInput
+  | ResponseReasoningInput;
+
+export interface ResponseInputContentPart {
+  type: "input_text" | "input_image" | "input_file";
+  text?: string;
+  image_url?: string;
+  file_url?: string;
+  file_data?: string;
+  filename?: string;
+}
+
+// ---------- Responses API 工具类型 ----------
+
+export interface ResponseFunctionTool {
+  type: "function";
+  name: string;
+  description?: string;
+  parameters?: Record<string, unknown>;
+  strict?: boolean;
+}
+
+export interface ResponseWebSearchTool {
+  type: "web_search_preview";
+  search_context_size?: "low" | "medium" | "high";
+  user_location?: { type: "approximate"; city?: string; country?: string };
+}
+
+export interface ResponseFileSearchTool {
+  type: "file_search";
+  vector_store_ids?: string[];
+}
+
+export type ResponseTool =
+  | ResponseFunctionTool
+  | ResponseWebSearchTool
+  | ResponseFileSearchTool
+  | Record<string, unknown>; // 其他内置工具（computer_use_preview 等）
+
+// ---------- Responses API 响应输出 ----------
+
+export interface ResponseOutputMessage {
+  type: "message";
+  id: string;
+  role: "assistant";
+  content: ResponseOutputContent[];
+  status?: string;
+}
+
+export interface ResponseOutputContent {
+  type: "output_text";
+  text: string;
+  annotations?: unknown[];
+}
+
+export interface ResponseFunctionCallOutput {
+  type: "function_call";
+  id: string;
+  call_id: string;
+  name: string;
+  arguments: string;
+  status?: string;
+}
+
+export interface ResponseReasoningOutput {
+  type: "reasoning";
+  id: string;
+  summary: Array<{ type: "summary_text"; text: string }>;
+  encrypted_content?: string;
+}
+
+export type ResponseOutputItem =
+  | ResponseOutputMessage
+  | ResponseFunctionCallOutput
+  | ResponseReasoningOutput
+  | Record<string, unknown>; // web_search_call, file_search_call 等
+
+// ---------- Responses API 完整请求 ----------
+
+export interface ResponsesApiRequest {
+  model: string;
+  input: string | ResponseInputItem[];
+  instructions?: string;
+  max_output_tokens?: number;
+  temperature?: number;
+  top_p?: number;
+  tools?: ResponseTool[];
+  tool_choice?: "auto" | "none" | "required" | { type: "function"; name: string };
+  stream?: boolean;
+  stream_options?: { include_usage?: boolean };
+  reasoning?: {
+    effort?: "low" | "medium" | "high";
+    max_tokens?: number;
+    summary?: "auto" | "concise" | "detailed";
+  };
+  previous_response_id?: string;
+  metadata?: Record<string, string>;
+  text?: { format: { type: "json_schema"; json_schema: unknown } };
+  parallel_tool_calls?: boolean;
+  store?: boolean;
+}
+
+// ---------- Responses API 完整响应 ----------
+
+export interface ResponsesApiResponse {
+  id: string;
+  object: "response";
+  model: string;
+  status: "completed" | "failed" | "in_progress" | "incomplete";
+  output: ResponseOutputItem[];
+  usage?: ResponsesApiUsage;
+  error?: { code: string; message: string };
+  created_at?: number;
+  completed_at?: number;
+}
+
+export interface ResponsesApiUsage {
+  input_tokens: number;
+  output_tokens: number;
+  total_tokens: number;
+  input_tokens_details?: { cached_tokens: number };
+  output_tokens_details?: { reasoning_tokens: number };
+}
+
+// ---------- Responses SSE 流式事件类型 ----------
+
+export const RESPONSES_SSE_EVENTS = {
+  CREATED: "response.created",
+  IN_PROGRESS: "response.in_progress",
+  QUEUED: "response.queued",
+  OUTPUT_ITEM_ADDED: "response.output_item.added",
+  OUTPUT_ITEM_DONE: "response.output_item.done",
+  CONTENT_PART_ADDED: "response.content_part.added",
+  CONTENT_PART_DONE: "response.content_part.done",
+  OUTPUT_TEXT_DELTA: "response.output_text.delta",
+  OUTPUT_TEXT_DONE: "response.output_text.done",
+  REFUSAL_DELTA: "response.refusal.delta",
+  REFUSAL_DONE: "response.refusal.done",
+  FUNCTION_CALL_ARGUMENTS_DELTA: "response.function_call_arguments.delta",
+  FUNCTION_CALL_ARGUMENTS_DONE: "response.function_call_arguments.done",
+  REASONING_ITEM_ADDED: "response.output_item.added", // item.type === "reasoning"
+  REASONING_SUMMARY_PART_ADDED: "response.reasoning_summary_part.added",
+  REASONING_SUMMARY_PART_DONE: "response.reasoning_summary_part.done",
+  REASONING_SUMMARY_TEXT_DELTA: "response.reasoning_summary_text.delta",
+  REASONING_SUMMARY_TEXT_DONE: "response.reasoning_summary_text.done",
+  REASONING_TEXT_DELTA: "response.reasoning_text.delta",
+  REASONING_TEXT_DONE: "response.reasoning_text.done",
+  COMPLETED: "response.completed",
+  FAILED: "response.failed",
+  INCOMPLETE: "response.incomplete",
+  ERROR: "error",
+} as const;
+```
+
+- [ ] **Step 3: 验证类型无报错**
+
+Run: `cd /Users/zhushanwen/Code/llm-simple-router-workspace/feat-openai-response-endpoint && npx tsc --noEmit 2>&1 | head -20`
+Expected: 0 errors（新增文件未被任何模块 import，不影响编译）
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/proxy/transform/types-responses.ts src/proxy/transform/types.ts
+git commit -m "feat(responses): add ApiType union and Responses API type definitions"
+```
+
+---
+
+## Task 2: api_type 全局扩展 — 所有模块签名统一
+
+**Files:**
+- Modify: `src/db/providers.ts`
+- Modify: `src/proxy/handler/proxy-handler.ts`
+- Modify: `src/proxy/handler/proxy-handler-utils.ts`
+- Modify: `src/proxy/proxy-core.ts`
+- Modify: `src/proxy/patch/index.ts`
+- Modify: `src/proxy/patch/deepseek/index.ts`
+- Modify: `src/proxy/patch/tool-round-limiter.ts`
+- Modify: `src/proxy/loop-prevention/tool-loop-guard.ts`
+- Modify: `src/proxy/transport/transport-fn.ts`
+- Modify: `src/proxy/transform/plugin-types.ts`
+- Modify: `src/proxy/proxy-logging.ts`
+- Modify: `src/proxy/orchestration/orchestrator.ts`
+- Modify: `src/monitor/stream-content-accumulator.ts`
+- Modify: `src/monitor/stream-extractor.ts`
+- Modify: `src/monitor/request-tracker.ts`
+- Modify: `src/monitor/types.ts`
+- Modify: `src/metrics/sse-metrics-transform.ts`
+- Modify: `src/metrics/metrics-extractor.ts`
+- Modify: `src/core/constants.ts`
+
+> 策略：所有 `"openai" | "anthropic"` 字面联合类型替换为从 `types.ts` 导入 `ApiType`。这是一次性全局替换，所有模块行为不变（openai-responses 的特殊行为在后续 Task 中逐步添加）。
+
+- [ ] **Step 1: 在 src/db/providers.ts 中扩展 api_type**
+
+将所有 `"openai" | "anthropic"` 替换为 `"openai" | "openai-responses" | "anthropic"`。涉及 3 处：
+
+1. Provider 接口 `api_type` 字段类型（约第 8 行）
+2. `getActiveProviders` 函数（约第 34 行）
+3. `createProvider` / provider 相关的验证
+
+```typescript
+// src/db/providers.ts — 3 处修改
+// 第 8 行
+api_type: "openai" | "openai-responses" | "anthropic";
+
+// 第 34 行
+apiType: "openai" | "openai-responses" | "anthropic",
+
+// 第 53 行  
+api_type: "openai" | "openai-responses" | "anthropic";
+```
+
+- [ ] **Step 2: 扩展 proxy-handler.ts 中的 apiType 类型**
+
+3 处 `"openai" | "anthropic"` → `"openai" | "openai-responses" | "anthropic"`：
+
+1. `FailoverContext.apiType`（约第 46 行）
+2. `RejectParams.apiType`（约第 67 行）
+3. `handleProxyRequest` 参数（约第 119 行）
+
+- [ ] **Step 3: 扩展 proxy-handler-utils.ts**
+
+```typescript
+// src/proxy/handler/proxy-handler-utils.ts 第 17 行
+export function serializeBlocksForStorage(blocks: ContentBlock[] | undefined, apiType: "openai" | "openai-responses" | "anthropic"): string {
+```
+
+- [ ] **Step 4: 扩展 proxy-core.ts — buildUpstreamHeaders**
+
+```typescript
+// src/proxy/proxy-core.ts 第 118 行
+export function buildUpstreamHeaders(
+  clientHeaders: RawHeaders,
+  apiKey: string,
+  payloadBytes?: number,
+  apiType?: "openai" | "openai-responses" | "anthropic"
+): Record<string, string> {
+  const headers = selectHeaders(clientHeaders, SKIP_UPSTREAM);
+  if (apiType === "anthropic") {
+    headers["x-api-key"] = apiKey;
+    headers["anthropic-version"] ??= "2023-06-01";
+  } else {
+    // openai 和 openai-responses 都用 Bearer token
+    headers["Authorization"] = `Bearer ${apiKey}`;
+  }
+```
+
+函数体不变，因为 `openai-responses` 和 `openai` 的认证方式相同（Bearer token）。只是类型签名扩展。
+
+- [ ] **Step 5: 扩展 patch 系统**
+
+`src/proxy/patch/index.ts` — `ProviderInfo.api_type` 已经是 `string`，无需改签名。但需要确认 `applyDeepSeekPatches` 的分支逻辑：
+
+```typescript
+// src/proxy/patch/deepseek/index.ts 第 26 行
+export function applyDeepSeekPatches(
+  body: Record<string, unknown>,
+  apiType: "openai" | "openai-responses" | "anthropic",
+): void {
+  if (apiType === "anthropic") {
+    patchThinkingParam(body, apiType);
+    stripCacheControl(body);
+    patchMissingThinkingBlocks(body);
+    patchOrphanToolResults(body);
+  } else {
+    // openai 和 openai-responses 共用 OpenAI 格式的 patch
+    patchNonDeepSeekToolMessages(body);
+    patchOrphanToolResultsOA(body);
+  }
+}
+```
+
+> 注意：DeepSeek patch 目前只对 OpenAI 格式和 Anthropic 格式有效。`openai-responses` 格式走 `else` 分支（与 openai 相同的 patch 逻辑），因为 DeepSeek 不支持 Responses API，转换后到达 patch 层时 body 已经是 OpenAI Chat 格式了（由 TransformCoordinator 转换）。如果 entryApiType 是 `openai-responses`，格式转换在 patch 之前执行，所以 patch 层看到的始终是 provider 的 api_type 格式。
+
+- [ ] **Step 6: 扩展 tool-round-limiter.ts**
+
+```typescript
+// src/proxy/patch/tool-round-limiter.ts 第 79 行
+export function applyToolRoundLimit(
+  body: Record<string, unknown>,
+  apiType: "openai" | "openai-responses" | "anthropic",
+  maxRounds: number = DEFAULT_MAX_ROUNDS,
+```
+
+> 注意：此函数在 proxy-handler 中以 `apiType`（入口格式）调用。当入口是 `openai-responses` 时，body 是 Responses 格式，没有 `messages` 字段而是 `input`。需要在 Task 9 中处理 Responses 格式的工具轮数检测。此处仅扩展类型签名，暂不改变行为（Responses 格式的 body.messages 为 undefined，会走 `messages.length === 0` 分支直接返回，安全）。
+
+- [ ] **Step 7: 扩展 tool-loop-guard.ts**
+
+```typescript
+// src/proxy/loop-prevention/tool-loop-guard.ts 第 45 行
+injectLoopBreakPrompt(body: Record<string, unknown>, apiType: "openai" | "openai-responses" | "anthropic", toolName: string): Record<string, unknown> {
+```
+
+函数体中 `apiType === "anthropic"` 分支不变。`openai-responses` 走 else 分支（与 openai 相同的注入方式），安全但不精确。后续 Task 9 会优化。
+
+- [ ] **Step 8: 扩展 transport-fn.ts**
+
+```typescript
+// src/proxy/transport/transport-fn.ts 第 51 行
+apiType: "openai" | "openai-responses" | "anthropic";
+```
+
+TransportFnParams.apiType 类型扩展。Transport 层不关心具体格式，仅透传 apiType 到 metrics 和 headers。
+
+- [ ] **Step 9: 扩展 plugin-types.ts**
+
+```typescript
+// src/proxy/transform/plugin-types.ts
+// 第 9 行
+apiType?: "openai" | "openai-responses" | "anthropic";
+// 第 15-16 行
+sourceApiType: "openai" | "openai-responses" | "anthropic";
+targetApiType: "openai" | "openai-responses" | "anthropic";
+// 第 22-23 行
+sourceApiType: "openai" | "openai-responses" | "anthropic";
+targetApiType: "openai" | "openai-responses" | "anthropic";
+```
+
+- [ ] **Step 10: 扩展 proxy-logging.ts**
+
+3 处 `"openai" | "anthropic"` → `"openai" | "openai-responses" | "anthropic"`（第 36, 73, 187 行）。
+
+- [ ] **Step 11: 扩展 orchestration/orchestrator.ts**
+
+2 处（第 77, 127 行）。
+
+- [ ] **Step 12: 扩展 monitor 模块**
+
+4 个文件各 1 处：
+- `src/monitor/stream-content-accumulator.ts` 第 18 行
+- `src/monitor/stream-extractor.ts` 第 10 行
+- `src/monitor/request-tracker.ts` 第 120 行
+- `src/monitor/types.ts` 第 19 行
+
+- [ ] **Step 13: 扩展 metrics 模块**
+
+2 个文件：
+- `src/metrics/sse-metrics-transform.ts` 第 28, 37 行
+- `src/metrics/metrics-extractor.ts` 第 68, 161 行
+
+- [ ] **Step 14: 扩展 core/constants.ts — PROXY_API_TYPES**
+
+```typescript
+// src/core/constants.ts — PROXY_API_TYPES 添加 Responses 路由
+export const PROXY_API_TYPES: Record<string, string> = {
+  "/v1/chat/completions": "openai",
+  "/v1/models": "openai",
+  "/v1/messages": "anthropic",
+  "/v1/responses": "openai-responses",
+  "/responses": "openai-responses",
+};
+```
+
+- [ ] **Step 15: 运行全部测试确认无回归**
+
+Run: `cd /Users/zhushanwen/Code/llm-simple-router-workspace/feat-openai-response-endpoint && npm test -- --run 2>&1 | tail -30`
+Expected: 所有现有测试 PASS（行为未改变，只是类型签名扩展）
+
+- [ ] **Step 16: Commit**
+
+```bash
+git add -A
+git commit -m "feat(responses): extend api_type to 'openai | openai-responses | anthropic' across all modules"
+```
+
+---
+
+## Task 3: 一级请求转换 — Responses ↔ Anthropic
+
+**Files:**
+- Create: `src/proxy/transform/request-transform-responses.ts`
+- Create: `tests/proxy/transform/request-transform-responses.test.ts`
+
+- [ ] **Step 1: 编写测试**
+
+创建 `tests/proxy/transform/request-transform-responses.test.ts`：
+
+```typescript
+import { describe, it, expect } from "vitest";
+import {
+  responsesToAnthropicRequest,
+  anthropicToResponsesRequest,
+} from "../../../src/proxy/transform/request-transform-responses.js";
+
+describe("responsesToAnthropicRequest", () => {
+  it("converts basic text input (string)", () => {
+    const result = responsesToAnthropicRequest({
+      model: "gpt-4o",
+      input: "Hello",
+      instructions: "You are helpful.",
+      max_output_tokens: 1024,
+    });
+    expect(result.model).toBe("gpt-4o");
+    expect(result.system).toBe("You are helpful.");
+    expect(result.max_tokens).toBe(1024);
+    const msgs = result.messages as Array<Record<string, unknown>>;
+    expect(msgs.length).toBe(1);
+    expect(msgs[0].role).toBe("user");
+  });
+
+  it("converts input items with function_call and function_call_output", () => {
+    const result = responsesToAnthropicRequest({
+      model: "gpt-4o",
+      input: [
+        { type: "message", role: "user", content: "What's the weather?" },
+        { type: "function_call", id: "fc_1", call_id: "call_1", name: "get_weather", arguments: '{"city":"SF"}' },
+        { type: "function_call_output", call_id: "call_1", output: '{"temp":72}' },
+      ],
+      tools: [{ type: "function", name: "get_weather", parameters: { type: "object", properties: { city: { type: "string" } } } }],
+    });
+    const msgs = result.messages as Array<Record<string, unknown>>;
+    // user → assistant(tool_use) → user(tool_result)
+    expect(msgs.length).toBeGreaterThanOrEqual(3);
+    expect(msgs[0].role).toBe("user");
+    expect(msgs[1].role).toBe("assistant");
+    const assistantContent = msgs[1].content as Array<Record<string, unknown>>;
+    expect(assistantContent.some(b => b.type === "tool_use")).toBe(true);
+    expect(msgs[2].role).toBe("user");
+    const userContent = msgs[2].content as Array<Record<string, unknown>>;
+    expect(userContent.some(b => b.type === "tool_result")).toBe(true);
+  });
+
+  it("converts reasoning input to thinking", () => {
+    const result = responsesToAnthropicRequest({
+      model: "o3",
+      input: "Solve this",
+      reasoning: { effort: "high" },
+    });
+    expect(result.thinking).toBeDefined();
+    expect((result.thinking as Record<string, unknown>).type).toBe("enabled");
+    expect((result.thinking as Record<string, unknown>).budget_tokens).toBe(32768);
+  });
+
+  it("maps tool_choice correctly", () => {
+    const required = responsesToAnthropicRequest({ model: "gpt-4o", input: "hi", tool_choice: "required" });
+    expect((required.tool_choice as Record<string, unknown>).type).toBe("any");
+
+    const auto = responsesToAnthropicRequest({ model: "gpt-4o", input: "hi", tool_choice: "auto" });
+    expect((auto.tool_choice as Record<string, unknown>).type).toBe("auto");
+
+    const none = responsesToAnthropicRequest({ model: "gpt-4o", input: "hi", tool_choice: "none" });
+    expect(none.tool_choice).toBeUndefined();
+
+    const func = responsesToAnthropicRequest({ model: "gpt-4o", input: "hi", tool_choice: { type: "function", name: "foo" } });
+    expect((func.tool_choice as Record<string, unknown>).type).toBe("tool");
+    expect((func.tool_choice as Record<string, unknown>).name).toBe("foo");
+  });
+
+  it("converts tools (function type)", () => {
+    const result = responsesToAnthropicRequest({
+      model: "gpt-4o",
+      input: "hi",
+      tools: [{ type: "function", name: "foo", parameters: { type: "object" } }],
+    });
+    const tools = result.tools as Array<Record<string, unknown>>;
+    expect(tools.length).toBe(1);
+    expect(tools[0].name).toBe("foo");
+    expect(tools[0].input_schema).toBeDefined();
+    expect(tools[0].input_schema).toEqual({ type: "object" });
+  });
+
+  it("maps parallel_tool_calls=false to disable_parallel_tool_use", () => {
+    const result = responsesToAnthropicRequest({
+      model: "gpt-4o",
+      input: "hi",
+      tools: [{ type: "function", name: "foo", parameters: {} }],
+      parallel_tool_calls: false,
+    });
+    const tc = result.tool_choice as Record<string, unknown>;
+    expect(tc.disable_parallel_tool_use).toBe(true);
+  });
+});
+
+describe("anthropicToResponsesRequest", () => {
+  it("converts basic text with system", () => {
+    const result = anthropicToResponsesRequest({
+      model: "claude-sonnet-4-20250514",
+      system: "You are helpful.",
+      messages: [{ role: "user", content: "Hello" }],
+      max_tokens: 1024,
+    });
+    expect(result.model).toBe("claude-sonnet-4-20250514");
+    expect(result.instructions).toBe("You are helpful.");
+    expect(result.max_output_tokens).toBe(1024);
+    const input = result.input as Array<Record<string, unknown>>;
+    expect(input.length).toBe(1);
+    expect(input[0].type).toBe("message");
+    expect(input[0].role).toBe("user");
+  });
+
+  it("converts tool_use and tool_result to function_call items", () => {
+    const result = anthropicToResponsesRequest({
+      model: "claude-sonnet-4-20250514",
+      messages: [
+        { role: "user", content: "Weather?" },
+        { role: "assistant", content: [
+          { type: "text", text: "Let me check." },
+          { type: "tool_use", id: "toolu_1", name: "get_weather", input: { city: "SF" } },
+        ]},
+        { role: "user", content: [{ type: "tool_result", tool_use_id: "toolu_1", content: '{"temp":72}' }] },
+      ],
+      max_tokens: 4096,
+    });
+    const input = result.input as Array<Record<string, unknown>>;
+    // user(message) → assistant(message) + function_call → function_call_output
+    expect(input.some(i => i.type === "function_call")).toBe(true);
+    expect(input.some(i => i.type === "function_call_output")).toBe(true);
+  });
+
+  it("converts thinking to reasoning", () => {
+    const result = anthropicToResponsesRequest({
+      model: "claude-sonnet-4-20250514",
+      messages: [{ role: "user", content: "Think" }],
+      thinking: { type: "enabled", budget_tokens: 10000 },
+      max_tokens: 16000,
+    });
+    expect(result.reasoning).toBeDefined();
+    expect((result.reasoning as Record<string, unknown>).max_tokens).toBe(10000);
+  });
+
+  it("maps anthropic tool_choice to responses", () => {
+    const anyChoice = anthropicToResponsesRequest({ model: "x", messages: [], max_tokens: 1, tool_choice: { type: "any" } });
+    expect(anyChoice.tool_choice).toBe("required");
+
+    const toolChoice = anthropicToResponsesRequest({ model: "x", messages: [], max_tokens: 1, tool_choice: { type: "tool", name: "foo" } });
+    expect((toolChoice.tool_choice as Record<string, unknown>).type).toBe("function");
+  });
+
+  it("converts tools (input_schema → parameters)", () => {
+    const result = anthropicToResponsesRequest({
+      model: "x",
+      messages: [],
+      max_tokens: 1,
+      tools: [{ name: "foo", input_schema: { type: "object" } }],
+    });
+    const tools = result.tools as Array<Record<string, unknown>>;
+    expect(tools.length).toBe(1);
+    expect(tools[0].type).toBe("function");
+    expect(tools[0].name).toBe("foo");
+    expect(tools[0].parameters).toBeDefined();
+  });
+});
+
+describe("Responses ↔ Anthropic round-trip", () => {
+  it("preserves core fields after Responses → Anthropic → Responses", () => {
+    const original = {
+      model: "gpt-4o",
+      input: "Hello",
+      instructions: "Be helpful",
+      max_output_tokens: 2048,
+      temperature: 0.7,
+    };
+    const ant = responsesToAnthropicRequest(original);
+    const back = anthropicToResponsesRequest(ant);
+    expect(back.model).toBe("gpt-4o");
+    expect(back.instructions).toBe("Be helpful");
+    expect(back.max_output_tokens).toBe(2048);
+    expect(back.temperature).toBe(0.7);
+  });
+});
+```
+
+- [ ] **Step 2: 运行测试确认失败**
+
+Run: `cd /Users/zhushanwen/Code/llm-simple-router-workspace/feat-openai-response-endpoint && npx vitest run tests/proxy/transform/request-transform-responses.test.ts 2>&1 | tail -20`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: 实现 responsesToAnthropicRequest 和 anthropicToResponsesRequest**
+
+创建 `src/proxy/transform/request-transform-responses.ts`。核心实现：
+
+```typescript
+import { parseToolArguments } from "./sanitize.js";
+
+// ---------- Reasoning ↔ Thinking 映射 ----------
+
+const EFFORT_BUDGET: Record<string, number> = { low: 1024, medium: 8192, high: 32768 };
+const DEFAULT_BUDGET = 8192;
+
+function mapReasoningToThinking(reasoning: Record<string, unknown>): Record<string, unknown> {
+  const effort = reasoning.effort as string | undefined;
+  const maxTokens = reasoning.max_tokens as number | undefined;
+  const budget = maxTokens ?? EFFORT_BUDGET[effort ?? ""] ?? DEFAULT_BUDGET;
+  return { type: "enabled", budget_tokens: budget };
+}
+
+function mapThinkingToReasoning(thinking: Record<string, unknown>): Record<string, unknown> | undefined {
+  if (!thinking || thinking.type !== "enabled") return undefined;
+  return { max_tokens: thinking.budget_tokens };
+}
+
+// ---------- Tool 映射 ----------
+
+function convertToolsResp2Ant(tools: unknown[]): unknown[] {
+  return tools
+    .filter(t => (t as Record<string, unknown>).type === "function")
+    .map(t => {
+      const tool = t as Record<string, unknown>;
+      const result: Record<string, unknown> = { name: tool.name };
+      if (tool.description != null) result.description = tool.description;
+      if (tool.parameters != null) result.input_schema = tool.parameters;
+      return result;
+    });
+}
+
+function convertToolsAnt2Resp(tools: unknown[]): unknown[] {
+  return tools.map(t => {
+    const tool = t as Record<string, unknown>;
+    const result: Record<string, unknown> = { type: "function", name: tool.name };
+    if (tool.description != null) result.description = tool.description;
+    if (tool.input_schema != null) result.parameters = tool.input_schema;
+    return result;
+  });
+}
+
+// ---------- Tool Choice 映射 ----------
+
+function mapToolChoiceResp2Ant(tc: unknown, parallelToolCalls?: boolean): unknown | undefined {
+  if (tc === "none") return undefined;
+  if (tc === "auto") {
+    const result: Record<string, unknown> = { type: "auto" };
+    if (parallelToolCalls === false) result.disable_parallel_tool_use = true;
+    return result;
+  }
+  if (tc === "required") {
+    const result: Record<string, unknown> = { type: "any" };
+    if (parallelToolCalls === false) result.disable_parallel_tool_use = true;
+    return result;
+  }
+  if (typeof tc === "object" && tc !== null) {
+    const obj = tc as Record<string, unknown>;
+    if (obj.type === "function" && obj.name) {
+      const result: Record<string, unknown> = { type: "tool", name: obj.name };
+      if (parallelToolCalls === false) result.disable_parallel_tool_use = true;
+      return result;
+    }
+  }
+  return { type: "auto" };
+}
+
+function mapToolChoiceAnt2Resp(tc: unknown): unknown {
+  if (typeof tc === "string") return "auto";
+  if (typeof tc === "object" && tc !== null) {
+    const obj = tc as Record<string, unknown>;
+    if (obj.type === "auto") return "auto";
+    if (obj.type === "any") return "required";
+    if (obj.type === "tool" && obj.name) return { type: "function", name: obj.name };
+  }
+  return "auto";
+}
+
+// ---------- Input Items ↔ Anthropic Messages ----------
+
+interface AntMsg { role: string; content: Array<Record<string, unknown>> }
+
+function convertInputToMessages(input: unknown): AntMsg[] {
+  if (typeof input === "string") {
+    return [{ role: "user", content: [{ type: "text", text: input }] }];
+  }
+  if (!Array.isArray(input)) return [];
+
+  const raw: AntMsg[] = [];
+  for (const item of input) {
+    const it = item as Record<string, unknown>;
+    switch (it.type) {
+      case "message": {
+        const content = normalizeRespContent(it.content);
+        raw.push({ role: it.role as string, content });
+        break;
+      }
+      case "input_text": {
+        raw.push({ role: "user", content: [{ type: "text", text: it.text as string }] });
+        break;
+      }
+      case "function_call": {
+        const input = parseToolArguments(it.arguments as string);
+        raw.push({
+          role: "assistant",
+          content: [{ type: "tool_use", id: `toolu_${it.call_id ?? it.id}`, name: it.name as string, input }],
+        });
+        break;
+      }
+      case "function_call_output": {
+        raw.push({
+          role: "user",
+          content: [{ type: "tool_result", tool_use_id: `toolu_${it.call_id}`, content: it.output as string }],
+        });
+        break;
+      }
+      case "reasoning": {
+        const summary = (it.summary as Array<Record<string, unknown>>)?.map(s => s.text).join("") ?? "";
+        raw.push({ role: "assistant", content: [{ type: "thinking", thinking: summary }] });
+        break;
+      }
+      default: {
+        // 未知类型跳过
+        break;
+      }
+    }
+  }
+
+  // 合并连续同角色消息（Anthropic 要求严格交替）
+  const merged: AntMsg[] = [];
+  for (const msg of raw) {
+    const prev = merged[merged.length - 1];
+    if (prev && prev.role === msg.role) {
+      prev.content = [...prev.content, ...msg.content];
+    } else {
+      merged.push({ ...msg, content: [...msg.content] });
+    }
+  }
+
+  // 确保首条是 user
+  if (merged.length > 0 && merged[0].role !== "user") {
+    merged.unshift({ role: "user", content: [{ type: "text", text: "" }] });
+  }
+
+  return merged;
+}
+
+function normalizeRespContent(content: unknown): Array<Record<string, unknown>> {
+  if (typeof content === "string") return [{ type: "text", text: content }];
+  if (Array.isArray(content)) {
+    return (content as Array<Record<string, unknown>>).map(part => {
+      if (part.type === "input_text") return { type: "text", text: part.text ?? "" };
+      if (part.type === "input_image") return { type: "image", source: { type: "url", url: part.image_url ?? "" } };
+      return part;
+    });
+  }
+  return [];
+}
+
+function convertMessagesToInput(messages: unknown[]): unknown[] {
+  const items: unknown[] = [];
+  for (const msg of messages) {
+    const m = msg as Record<string, unknown>;
+    const content = m.content as Array<Record<string, unknown>> | undefined;
+
+    if (m.role === "user") {
+      if (!content || !Array.isArray(content)) {
+        items.push({ type: "message", role: "user", content: String(m.content ?? "") });
+        continue;
+      }
+      const textParts = content.filter(b => b.type === "text");
+      const toolResults = content.filter(b => b.type === "tool_result");
+      const imageParts = content.filter(b => b.type === "image");
+
+      if (textParts.length > 0 || imageParts.length > 0) {
+        const msgContent: unknown[] = [];
+        for (const tp of textParts) msgContent.push({ type: "input_text", text: tp.text ?? "" });
+        for (const ip of imageParts) {
+          const src = ip.source as Record<string, unknown> | undefined;
+          msgContent.push({ type: "input_image", image_url: src?.url ?? "" });
+        }
+        items.push({ type: "message", role: "user", content: msgContent });
+      }
+      for (const tr of toolResults) {
+        items.push({
+          type: "function_call_output",
+          call_id: (tr.tool_use_id as string ?? "").replace("toolu_", ""),
+          output: tr.content ?? "",
+        });
+      }
+    } else if (m.role === "assistant") {
+      if (!content || !Array.isArray(content)) {
+        items.push({ type: "message", role: "assistant", content: String(m.content ?? "") });
+        continue;
+      }
+      const textParts = content.filter(b => b.type === "text");
+      const toolUseParts = content.filter(b => b.type === "tool_use");
+      const thinkingParts = content.filter(b => b.type === "thinking");
+
+      // thinking → reasoning items
+      for (const tp of thinkingParts) {
+        items.push({
+          type: "reasoning",
+          id: `rs_${Math.random().toString(36).slice(2, 10)}`,
+          summary: [{ type: "summary_text", text: tp.thinking ?? "" }],
+        });
+      }
+      // text → message item
+      if (textParts.length > 0) {
+        const text = textParts.map(b => b.text ?? "").join("");
+        items.push({ type: "message", role: "assistant", content: [{ type: "output_text", text }] });
+      }
+      // tool_use → function_call items
+      for (const tu of toolUseParts) {
+        const callId = (tu.id as string ?? "").replace("toolu_", "");
+        items.push({
+          type: "function_call",
+          id: `fc_${callId}`,
+          call_id: callId,
+          name: tu.name,
+          arguments: JSON.stringify(tu.input ?? {}),
+        });
+      }
+    }
+  }
+  return items;
+}
+
+// ---------- 公共接口 ----------
+
+const RESP_KNOWN_FIELDS = new Set([
+  "model", "input", "instructions", "max_output_tokens", "temperature", "top_p",
+  "tools", "tool_choice", "stream", "stream_options", "reasoning", "previous_response_id",
+  "metadata", "text", "parallel_tool_calls", "store",
+]);
+
+const ANT_KNOWN_FIELDS = new Set([
+  "model", "system", "messages", "max_tokens", "stop_sequences", "temperature", "top_p",
+  "stream", "tools", "tool_choice", "thinking", "metadata",
+]);
+
+export function responsesToAnthropicRequest(body: Record<string, unknown>): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  result.model = body.model;
+
+  // instructions → system
+  if (body.instructions) result.system = body.instructions;
+
+  // input → messages
+  result.messages = convertInputToMessages(body.input);
+
+  // max_output_tokens → max_tokens
+  result.max_tokens = body.max_output_tokens ?? 4096;
+
+  // 直通字段
+  if (body.temperature != null) result.temperature = body.temperature;
+  if (body.top_p != null) result.top_p = body.top_p;
+  if (body.stream != null) result.stream = body.stream;
+
+  // tools (仅 function 类型)
+  if (body.tools) {
+    const antTools = convertToolsResp2Ant(body.tools as unknown[]);
+    if (antTools.length > 0) result.tools = antTools;
+  }
+
+  // tool_choice
+  if (body.tool_choice != null) {
+    const mapped = mapToolChoiceResp2Ant(body.tool_choice, body.parallel_toolCalls as boolean | undefined);
+    if (mapped != null) result.tool_choice = mapped;
+  } else if (body.parallel_tool_calls === false && result.tools) {
+    result.tool_choice = { type: "auto", disable_parallel_tool_use: true };
+  }
+
+  // reasoning → thinking
+  if (body.reasoning) {
+    result.thinking = mapReasoningToThinking(body.reasoning as Record<string, unknown>);
+    const thinkingBudget = (result.thinking as Record<string, unknown>).budget_tokens as number;
+    if (thinkingBudget > (result.max_tokens as number)) {
+      result.max_tokens = thinkingBudget;
+    }
+  }
+
+  // metadata → metadata
+  if (body.metadata) {
+    const meta = body.metadata as Record<string, string>;
+    if (meta.user_id) result.metadata = { user_id: meta.user_id };
+  }
+
+  // text.format → 忽略（Anthropic 无对应，日志警告）
+  if (body.text) {
+    console.warn("[request-transform-responses] text.format dropped: Anthropic has no JSON mode in this conversion path");
+  }
+
+  // log dropped fields
+  const dropped = Object.keys(body).filter(k => !RESP_KNOWN_FIELDS.has(k));
+  if (dropped.length > 0) {
+    console.warn(`[request-transform-responses] Responses→Ant: dropped fields: ${dropped.join(", ")}`);
+  }
+
+  return result;
+}
+
+export function anthropicToResponsesRequest(body: Record<string, unknown>): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  result.model = body.model;
+
+  // system → instructions
+  if (body.system != null) {
+    if (typeof body.system === "string") {
+      result.instructions = body.system;
+    } else if (Array.isArray(body.system)) {
+      result.instructions = (body.system as Array<Record<string, unknown>>).map(b => b.text ?? "").join("\n");
+    }
+  }
+
+  // messages → input
+  result.input = convertMessagesToInput(body.messages as unknown[] ?? []);
+
+  // max_tokens → max_output_tokens
+  if (body.max_tokens != null) result.max_output_tokens = body.max_tokens;
+
+  // 直通
+  if (body.temperature != null) result.temperature = body.temperature;
+  if (body.top_p != null) result.top_p = body.top_p;
+  if (body.stream != null) result.stream = body.stream;
+
+  // tools
+  if (body.tools) {
+    result.tools = convertToolsAnt2Resp(body.tools as unknown[]);
+  }
+
+  // tool_choice
+  if (body.tool_choice != null) {
+    result.tool_choice = mapToolChoiceAnt2Resp(body.tool_choice);
+  }
+
+  // thinking → reasoning
+  if (body.thinking) {
+    const reasoning = mapThinkingToReasoning(body.thinking as Record<string, unknown>);
+    if (reasoning) result.reasoning = reasoning;
+  }
+
+  // metadata.user_id
+  const meta = body.metadata as Record<string, unknown> | undefined;
+  if (meta?.user_id) {
+    result.metadata = { user_id: meta.user_id as string };
+  }
+
+  // stop_sequences — Responses 无对应，日志警告
+  if (body.stop_sequences) {
+    console.warn("[request-transform-responses] Ant→Responses: stop_sequences dropped (no Responses equivalent)");
+  }
+
+  const dropped = Object.keys(body).filter(k => !ANT_KNOWN_FIELDS.has(k));
+  if (dropped.length > 0) {
+    console.warn(`[request-transform-responses] Ant→Responses: dropped fields: ${dropped.join(", ")}`);
+  }
+
+  return result;
+}
+```
+
+- [ ] **Step 4: 运行测试确认通过**
+
+Run: `cd /Users/zhushanwen/Code/llm-simple-router-workspace/feat-openai-response-endpoint && npx vitest run tests/proxy/transform/request-transform-responses.test.ts 2>&1 | tail -20`
+Expected: 所有测试 PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/proxy/transform/request-transform-responses.ts tests/proxy/transform/request-transform-responses.test.ts
+git commit -m "feat(responses): implement Responses↔Anthropic request transform (tier-1)"
+```
+
+---
+
+## Task 4: 一级响应转换 — Responses ↔ Anthropic
+
+**Files:**
+- Create: `src/proxy/transform/response-transform-responses.ts`
+- Create: `tests/proxy/transform/response-transform-responses.test.ts`
+
+- [ ] **Step 1: 编写测试**
+
+创建 `tests/proxy/transform/response-transform-responses.test.ts`：
+
+```typescript
+import { describe, it, expect } from "vitest";
+import {
+  responsesToAnthropicResponse,
+  anthropicToResponsesResponse,
+} from "../../../src/proxy/transform/response-transform-responses.js";
+
+describe("responsesToAnthropicResponse", () => {
+  it("converts basic text output", () => {
+    const resp = JSON.stringify({
+      id: "resp_123", object: "response", model: "gpt-4o",
+      status: "completed",
+      output: [{ type: "message", id: "msg_1", role: "assistant", content: [{ type: "output_text", text: "Hello!" }] }],
+      usage: { input_tokens: 10, output_tokens: 5, total_tokens: 15 },
+    });
+    const result = JSON.parse(responsesToAnthropicResponse(resp));
+    expect(result.type).toBe("message");
+    expect(result.role).toBe("assistant");
+    expect(result.stop_reason).toBe("end_turn");
+    const content = result.content as Array<Record<string, unknown>>;
+    expect(content.some(b => b.type === "text" && b.text === "Hello!")).toBe(true);
+    expect(result.usage.input_tokens).toBe(10);
+  });
+
+  it("converts function_call output to tool_use", () => {
+    const resp = JSON.stringify({
+      id: "resp_123", object: "response", model: "gpt-4o",
+      status: "completed",
+      output: [
+        { type: "function_call", id: "fc_1", call_id: "call_1", name: "get_weather", arguments: '{"city":"SF"}' },
+      ],
+      usage: { input_tokens: 5, output_tokens: 10, total_tokens: 15 },
+    });
+    const result = JSON.parse(responsesToAnthropicResponse(resp));
+    const content = result.content as Array<Record<string, unknown>>;
+    expect(content.some(b => b.type === "tool_use")).toBe(true);
+    const toolUse = content.find(b => b.type === "tool_use")!;
+    expect(toolUse.name).toBe("get_weather");
+  });
+
+  it("converts reasoning output to thinking", () => {
+    const resp = JSON.stringify({
+      id: "resp_123", object: "response", model: "o3",
+      status: "completed",
+      output: [
+        { type: "reasoning", id: "rs_1", summary: [{ type: "summary_text", text: "Let me think..." }] },
+        { type: "message", id: "msg_1", role: "assistant", content: [{ type: "output_text", text: "Answer" }] },
+      ],
+      usage: { input_tokens: 10, output_tokens: 20, total_tokens: 30 },
+    });
+    const result = JSON.parse(responsesToAnthropicResponse(resp));
+    const content = result.content as Array<Record<string, unknown>>;
+    expect(content[0].type).toBe("thinking");
+  });
+
+  it("maps status to stop_reason", () => {
+    const completed = JSON.parse(responsesToAnthropicResponse(JSON.stringify({
+      id: "r", object: "response", model: "x", status: "completed", output: [], usage: {},
+    })));
+    expect(completed.stop_reason).toBe("end_turn");
+
+    const incomplete = JSON.parse(responsesToAnthropicResponse(JSON.stringify({
+      id: "r", object: "response", model: "x", status: "incomplete", output: [], usage: {},
+    })));
+    expect(incomplete.stop_reason).toBe("max_tokens");
+  });
+});
+
+describe("anthropicToResponsesResponse", () => {
+  it("converts basic text content", () => {
+    const ant = JSON.stringify({
+      id: "msg_123", type: "message", role: "assistant", model: "claude-sonnet-4-20250514",
+      content: [{ type: "text", text: "Hello!" }],
+      stop_reason: "end_turn",
+      usage: { input_tokens: 10, output_tokens: 5 },
+    });
+    const result = JSON.parse(anthropicToResponsesResponse(ant));
+    expect(result.object).toBe("response");
+    expect(result.status).toBe("completed");
+    expect(Array.isArray(result.output)).toBe(true);
+  });
+
+  it("converts tool_use to function_call output", () => {
+    const ant = JSON.stringify({
+      id: "msg_123", type: "message", role: "assistant", model: "claude",
+      content: [{ type: "tool_use", id: "toolu_abc", name: "foo", input: { x: 1 } }],
+      stop_reason: "tool_use",
+      usage: { input_tokens: 5, output_tokens: 10 },
+    });
+    const result = JSON.parse(anthropicToResponsesResponse(ant));
+    const funcCall = result.output.find((o: Record<string, unknown>) => o.type === "function_call");
+    expect(funcCall).toBeDefined();
+    expect(funcCall.name).toBe("foo");
+    expect(funcCall.call_id).toBe("abc");
+  });
+
+  it("converts thinking to reasoning output", () => {
+    const ant = JSON.stringify({
+      id: "msg_123", type: "message", role: "assistant", model: "claude",
+      content: [
+        { type: "thinking", thinking: "hmm..." },
+        { type: "text", text: "Answer" },
+      ],
+      stop_reason: "end_turn",
+      usage: { input_tokens: 10, output_tokens: 20 },
+    });
+    const result = JSON.parse(anthropicToResponsesResponse(ant));
+    const reasoning = result.output.find((o: Record<string, unknown>) => o.type === "reasoning");
+    expect(reasoning).toBeDefined();
+    expect(reasoning.summary[0].text).toBe("hmm...");
+  });
+
+  it("maps stop_reason to status", () => {
+    const endTurn = JSON.parse(anthropicToResponsesResponse(JSON.stringify({
+      id: "x", type: "message", role: "assistant", model: "x", content: [{ type: "text", text: "" }], stop_reason: "end_turn", usage: {},
+    })));
+    expect(endTurn.status).toBe("completed");
+
+    const maxTokens = JSON.parse(anthropicToResponsesResponse(JSON.stringify({
+      id: "x", type: "message", role: "assistant", model: "x", content: [{ type: "text", text: "" }], stop_reason: "max_tokens", usage: {},
+    })));
+    expect(maxTokens.status).toBe("incomplete");
+  });
+});
+```
+
+- [ ] **Step 2: 运行测试确认失败**
+
+Run: `cd /Users/zhushanwen/Code/llm-simple-router-workspace/feat-openai-response-endpoint && npx vitest run tests/proxy/transform/response-transform-responses.test.ts 2>&1 | tail -20`
+
+- [ ] **Step 3: 实现 responsesToAnthropicResponse 和 anthropicToResponsesResponse**
+
+创建 `src/proxy/transform/response-transform-responses.ts`：
+
+```typescript
+import { generateMsgId, generateRespId } from "./id-utils.js";
+
+// ---------- Status ↔ Stop Reason ----------
+
+const STATUS_TO_STOP: Record<string, string> = {
+  completed: "end_turn",
+  incomplete: "max_tokens",
+  failed: "end_turn",
+};
+
+const STOP_TO_STATUS: Record<string, string> = {
+  end_turn: "completed",
+  max_tokens: "incomplete",
+  stop_sequence: "completed",
+  tool_use: "completed",
+};
+
+// ---------- Responses → Anthropic ----------
+
+export function responsesToAnthropicResponse(bodyStr: string): string {
+  const resp = JSON.parse(bodyStr);
+  const content: Array<Record<string, unknown>> = [];
+
+  for (const item of (resp.output ?? []) as Array<Record<string, unknown>>) {
+    switch (item.type) {
+      case "message": {
+        const msgContent = item.content as Array<Record<string, unknown>> ?? [];
+        for (const part of msgContent) {
+          if (part.type === "output_text" && part.text) {
+            content.push({ type: "text", text: part.text });
+          }
+        }
+        break;
+      }
+      case "function_call": {
+        let input: unknown = {};
+        try { input = JSON.parse(item.arguments as string ?? "{}"); } catch { /* keep empty */ }
+        content.push({
+          type: "tool_use",
+          id: `toolu_${item.call_id ?? item.id}`,
+          name: item.name,
+          input,
+        });
+        break;
+      }
+      case "reasoning": {
+        const summary = (item.summary as Array<Record<string, unknown>> ?? []).map(s => s.text ?? "").join("");
+        content.push({ type: "thinking", thinking: summary });
+        break;
+      }
+      default:
+        // 其他输出类型（web_search_call 等）跳过
+        break;
+    }
+  }
+
+  if (content.length === 0) content.push({ type: "text", text: "" });
+
+  const usage = resp.usage as Record<string, number> | undefined;
+  return JSON.stringify({
+    id: generateMsgId(),
+    type: "message",
+    role: "assistant",
+    content,
+    model: resp.model,
+    stop_reason: STATUS_TO_STOP[resp.status] ?? "end_turn",
+    stop_sequence: null,
+    usage: {
+      input_tokens: usage?.input_tokens ?? 0,
+      output_tokens: usage?.output_tokens ?? 0,
+      cache_creation_input_tokens: 0,
+      cache_read_input_tokens: usage?.input_tokens_details?.cached_tokens ?? 0,
+    },
+  });
+}
+
+// ---------- Anthropic → Responses ----------
+
+export function anthropicToResponsesResponse(bodyStr: string): string {
+  const ant = JSON.parse(bodyStr);
+  const blocks = (ant.content ?? []) as Array<Record<string, unknown>>;
+  const output: Array<Record<string, unknown>> = [];
+
+  for (const block of blocks) {
+    switch (block.type) {
+      case "thinking": {
+        output.push({
+          type: "reasoning",
+          id: `rs_${Math.random().toString(36).slice(2, 10)}`,
+          summary: [{ type: "summary_text", text: block.thinking ?? "" }],
+        });
+        break;
+      }
+      case "text": {
+        output.push({
+          type: "message",
+          id: `msg_${Math.random().toString(36).slice(2, 10)}`,
+          role: "assistant",
+          content: [{ type: "output_text", text: block.text ?? "" }],
+        });
+        break;
+      }
+      case "tool_use": {
+        const callId = (block.id as string).replace("toolu_", "");
+        output.push({
+          type: "function_call",
+          id: `fc_${callId}`,
+          call_id: callId,
+          name: block.name,
+          arguments: JSON.stringify(block.input ?? {}),
+        });
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  if (output.length === 0) {
+    output.push({
+      type: "message",
+      id: `msg_${Math.random().toString(36).slice(2, 10)}`,
+      role: "assistant",
+      content: [{ type: "output_text", text: "" }],
+    });
+  }
+
+  const usage = ant.usage as Record<string, number> | undefined;
+  const inputTokens = (usage?.input_tokens ?? 0) + (usage?.cache_read_input_tokens ?? 0) + (usage?.cache_creation_input_tokens ?? 0);
+  const outputTokens = usage?.output_tokens ?? 0;
+
+  return JSON.stringify({
+    id: generateRespId(),
+    object: "response",
+    model: ant.model,
+    status: STOP_TO_STATUS[ant.stop_reason] ?? "completed",
+    output,
+    usage: {
+      input_tokens: inputTokens,
+      output_tokens: outputTokens,
+      total_tokens: inputTokens + outputTokens,
+      input_tokens_details: { cached_tokens: usage?.cache_read_input_tokens ?? 0 },
+      output_tokens_details: { reasoning_tokens: 0 },
+    },
+  });
+}
+```
+
+- [ ] **Step 4: 在 id-utils.ts 中添加 generateRespId**
+
+在 `src/proxy/transform/id-utils.ts` 中添加：
+
+```typescript
+/** 生成 resp_xxx 格式 ID（Responses API） */
+export function generateRespId(): string {
+  return `resp_${randomHex(24)}`;
+}
+```
+
+- [ ] **Step 5: 运行测试确认通过**
+
+Run: `cd /Users/zhushanwen/Code/llm-simple-router-workspace/feat-openai-response-endpoint && npx vitest run tests/proxy/transform/response-transform-responses.test.ts 2>&1 | tail -20`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/proxy/transform/response-transform-responses.ts src/proxy/transform/id-utils.ts tests/proxy/transform/response-transform-responses.test.ts
+git commit -m "feat(responses): implement Responses↔Anthropic response transform (tier-1)"
+```
+
+---
+
+## Task 5: 二级桥接请求转换 — Responses ↔ Chat
+
+**Files:**
+- Create: `src/proxy/transform/request-bridge-responses.ts`
+- Create: `tests/proxy/transform/request-bridge-responses.test.ts`
+
+- [ ] **Step 1: 编写测试**
+
+```typescript
+import { describe, it, expect } from "vitest";
+import {
+  responsesToChatRequest,
+  chatToResponsesRequest,
+} from "../../../src/proxy/transform/request-bridge-responses.js";
+
+describe("responsesToChatRequest", () => {
+  it("converts instructions → system message, input string → user message", () => {
+    const result = responsesToChatRequest({
+      model: "gpt-4o",
+      input: "Hello",
+      instructions: "Be helpful",
+      max_output_tokens: 1024,
+    });
+    const msgs = result.messages as Array<Record<string, unknown>>;
+    expect(msgs[0].role).toBe("system");
+    expect(msgs[0].content).toBe("Be helpful");
+    expect(msgs[1].role).toBe("user");
+    expect(result.max_completion_tokens).toBe(1024);
+  });
+
+  it("converts function_call input items to tool_calls", () => {
+    const result = responsesToChatRequest({
+      model: "gpt-4o",
+      input: [
+        { type: "message", role: "user", content: "Weather?" },
+        { type: "function_call", id: "fc_1", call_id: "call_1", name: "get_weather", arguments: '{"city":"SF"}' },
+        { type: "function_call_output", call_id: "call_1", output: '{"temp":72}' },
+      ],
+    });
+    const msgs = result.messages as Array<Record<string, unknown>>;
+    // Should have: user, assistant(tool_calls), tool
+    expect(msgs.some(m => m.role === "assistant" && m.tool_calls)).toBe(true);
+    expect(msgs.some(m => m.role === "tool")).toBe(true);
+  });
+
+  it("converts tools (function type, flatten parameters)", () => {
+    const result = responsesToChatRequest({
+      model: "gpt-4o",
+      input: "hi",
+      tools: [{ type: "function", name: "foo", parameters: { type: "object" } }],
+    });
+    const tools = result.tools as Array<Record<string, unknown>>;
+    expect(tools[0].type).toBe("function");
+    expect((tools[0].function as Record<string, unknown>).name).toBe("foo");
+    expect((tools[0].function as Record<string, unknown>).parameters).toEqual({ type: "object" });
+  });
+
+  it("converts reasoning.max_tokens", () => {
+    const result = responsesToChatRequest({
+      model: "o3",
+      input: "Think",
+      reasoning: { max_tokens: 5000 },
+    });
+    expect(result.reasoning).toBeDefined();
+    expect((result.reasoning as Record<string, unknown>).max_tokens).toBe(5000);
+  });
+});
+
+describe("chatToResponsesRequest", () => {
+  it("converts system message → instructions", () => {
+    const result = chatToResponsesRequest({
+      model: "gpt-4o",
+      messages: [
+        { role: "system", content: "Be helpful" },
+        { role: "user", content: "Hello" },
+      ],
+    });
+    expect(result.instructions).toBe("Be helpful");
+    const input = result.input as Array<Record<string, unknown>>;
+    expect(input[0].type).toBe("message");
+  });
+
+  it("converts tool_calls to function_call items", () => {
+    const result = chatToResponsesRequest({
+      model: "gpt-4o",
+      messages: [
+        { role: "user", content: "Hi" },
+        { role: "assistant", content: null, tool_calls: [
+          { id: "call_1", type: "function", function: { name: "foo", arguments: '{"x":1}' } },
+        ]},
+        { role: "tool", tool_call_id: "call_1", content: "result" },
+      ],
+    });
+    const input = result.input as Array<Record<string, unknown>>;
+    expect(input.some(i => i.type === "function_call")).toBe(true);
+    expect(input.some(i => i.type === "function_call_output")).toBe(true);
+  });
+
+  it("converts max_completion_tokens → max_output_tokens", () => {
+    const result = chatToResponsesRequest({
+      model: "gpt-4o",
+      messages: [{ role: "user", content: "hi" }],
+      max_completion_tokens: 2048,
+    });
+    expect(result.max_output_tokens).toBe(2048);
+  });
+});
+```
+
+- [ ] **Step 2: 运行测试确认失败**
+
+- [ ] **Step 3: 实现桥接逻辑**
+
+创建 `src/proxy/transform/request-bridge-responses.ts`。核心思路：
+
+**Responses → Chat**：`instructions` → `messages[system]`，`input items` → `messages`（function_call → assistant.tool_calls, function_call_output → role=tool），`tools[type=function]` → `tools[type=function].function`，`max_output_tokens` → `max_completion_tokens`
+
+**Chat → Responses**：`messages[system]` → `instructions`，`assistant.tool_calls` → `function_call items`，`role=tool` → `function_call_output`，`max_completion_tokens` → `max_output_tokens`
+
+（完整代码约 200 行，遵循与 Task 3 相同的模式，此处省略以节省篇幅但实现时必须写完整）
+
+- [ ] **Step 4: 运行测试确认通过**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/proxy/transform/request-bridge-responses.ts tests/proxy/transform/request-bridge-responses.test.ts
+git commit -m "feat(responses): implement Responses↔Chat bridge request transform"
+```
+
+---
+
+## Task 6: 二级桥接响应转换 — Responses ↔ Chat
+
+**Files:**
+- Create: `src/proxy/transform/response-bridge-responses.ts`
+- Create: `tests/proxy/transform/response-bridge-responses.test.ts`
+
+- [ ] **Step 1: 编写测试**
+
+```typescript
+import { describe, it, expect } from "vitest";
+import {
+  responsesToChatResponse,
+  chatToResponsesResponse,
+} from "../../../src/proxy/transform/response-bridge-responses.js";
+
+describe("responsesToChatResponse", () => {
+  it("converts output message to choices", () => {
+    const resp = JSON.stringify({
+      id: "resp_1", object: "response", model: "gpt-4o", status: "completed",
+      output: [{ type: "message", id: "msg_1", role: "assistant", content: [{ type: "output_text", text: "Hi!" }] }],
+      usage: { input_tokens: 10, output_tokens: 5, total_tokens: 15 },
+    });
+    const result = JSON.parse(responsesToChatResponse(resp));
+    expect(result.object).toBe("chat.completion");
+    expect(result.choices[0].message.content).toBe("Hi!");
+    expect(result.choices[0].finish_reason).toBe("stop");
+    expect(result.usage.prompt_tokens).toBe(10);
+  });
+
+  it("converts function_call output to tool_calls", () => {
+    const resp = JSON.stringify({
+      id: "resp_1", object: "response", model: "gpt-4o", status: "completed",
+      output: [{ type: "function_call", id: "fc_1", call_id: "call_1", name: "foo", arguments: '{"x":1}' }],
+      usage: { input_tokens: 5, output_tokens: 10, total_tokens: 15 },
+    });
+    const result = JSON.parse(responsesToChatResponse(resp));
+    expect(result.choices[0].message.tool_calls).toBeDefined();
+    expect(result.choices[0].message.tool_calls[0].function.name).toBe("foo");
+  });
+
+  it("converts reasoning output to reasoning_content (flattened)", () => {
+    const resp = JSON.stringify({
+      id: "resp_1", object: "response", model: "o3", status: "completed",
+      output: [
+        { type: "reasoning", id: "rs_1", summary: [{ type: "summary_text", text: "thinking..." }] },
+        { type: "message", id: "msg_1", role: "assistant", content: [{ type: "output_text", text: "Answer" }] },
+      ],
+      usage: { input_tokens: 10, output_tokens: 20, total_tokens: 30 },
+    });
+    const result = JSON.parse(responsesToChatResponse(resp));
+    expect(result.choices[0].message.reasoning_content).toBe("thinking...");
+    expect(result.choices[0].message.content).toBe("Answer");
+  });
+});
+
+describe("chatToResponsesResponse", () => {
+  it("converts choices to output items", () => {
+    const chat = JSON.stringify({
+      id: "chatcmpl-1", object: "chat.completion", model: "gpt-4o",
+      choices: [{ index: 0, message: { role: "assistant", content: "Hi!" }, finish_reason: "stop" }],
+      usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+    });
+    const result = JSON.parse(chatToResponsesResponse(chat));
+    expect(result.object).toBe("response");
+    expect(result.status).toBe("completed");
+    expect(result.output).toBeDefined();
+  });
+
+  it("converts tool_calls to function_call output", () => {
+    const chat = JSON.stringify({
+      id: "chatcmpl-1", object: "chat.completion", model: "gpt-4o",
+      choices: [{ index: 0, message: { role: "assistant", tool_calls: [
+        { id: "call_1", type: "function", function: { name: "foo", arguments: '{"x":1}' } },
+      ]}, finish_reason: "tool_calls" }],
+      usage: { prompt_tokens: 5, completion_tokens: 10, total_tokens: 15 },
+    });
+    const result = JSON.parse(chatToResponsesResponse(chat));
+    expect(result.output.some((o: Record<string, unknown>) => o.type === "function_call")).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: 运行测试确认失败**
+
+- [ ] **Step 3: 实现桥接响应转换**
+
+创建 `src/proxy/transform/response-bridge-responses.ts`。
+
+**Responses → Chat**：`output[message]` → `choices[0].message.content`，`output[function_call]` → `choices[0].message.tool_calls[]`，`output[reasoning]` → `choices[0].message.reasoning_content`（扁平化），`status` → `finish_reason`，`usage` 重新映射。
+
+**Chat → Responses**：`choices[0].message.content` → `output[message]`，`choices[0].message.tool_calls` → `output[function_call]`，`choices[0].message.reasoning_content` → `output[reasoning]`，`finish_reason` → `status`。
+
+- [ ] **Step 4: 运行测试确认通过**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/proxy/transform/response-bridge-responses.ts tests/proxy/transform/response-bridge-responses.test.ts
+git commit -m "feat(responses): implement Responses↔Chat bridge response transform"
+```
+
+---
+
+## Task 7: 流式转换 — Anthropic SSE ↔ Responses SSE（一级）
+
+**Files:**
+- Create: `src/proxy/transform/stream-ant2resp.ts`
+- Create: `src/proxy/transform/stream-resp2ant.ts`
+- Create: `tests/proxy/transform/stream-ant2resp.test.ts`
+- Create: `tests/proxy/transform/stream-resp2ant.test.ts`
+
+- [ ] **Step 1: 编写 Anthropic→Responses 流式测试**
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { AnthropicToResponsesTransform } from "../../../src/proxy/transform/stream-ant2resp.js";
+import { PassThrough } from "stream";
+
+function collectOutput(transform: AnthropicToResponsesTransform): string[] {
+  const output: string[] = [];
+  transform.on("data", (chunk: Buffer) => output.push(chunk.toString()));
+  return output;
+}
+
+describe("AnthropicToResponsesTransform", () => {
+  it("converts message_start → response.created + response.in_progress", () => {
+    const t = new AnthropicToResponsesTransform("gpt-4o");
+    const out = collectOutput(t);
+    t.write(`event: message_start\ndata: ${JSON.stringify({
+      type: "message_start",
+      message: { id: "msg_1", type: "message", role: "assistant", content: [], model: "gpt-4o", usage: { input_tokens: 10 } },
+    })}\n\n`);
+    t.end();
+    const joined = out.join("");
+    expect(joined).toContain("response.created");
+    expect(joined).toContain("response.in_progress");
+  });
+
+  it("converts text_delta → response.output_text.delta", () => {
+    const t = new AnthropicToResponsesTransform("gpt-4o");
+    const out = collectOutput(t);
+    // 先发 message_start
+    t.write(`event: message_start\ndata: ${JSON.stringify({
+      type: "message_start", message: { id: "msg_1", role: "assistant", content: [], usage: { input_tokens: 10 } },
+    })}\n\n`);
+    // 发 content_block_start (text)
+    t.write(`event: content_block_start\ndata: ${JSON.stringify({
+      type: "content_block_start", index: 0, content_block: { type: "text", text: "" },
+    })}\n\n`);
+    // 发 text delta
+    t.write(`event: content_block_delta\ndata: ${JSON.stringify({
+      type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "Hello" },
+    })}\n\n`);
+    // 发 message_delta (stop)
+    t.write(`event: message_delta\ndata: ${JSON.stringify({
+      type: "message_delta", delta: { stop_reason: "end_turn" }, usage: { output_tokens: 5 },
+    })}\n\n`);
+    t.write(`event: message_stop\ndata: ${JSON.stringify({ type: "message_stop" })}\n\n`);
+    t.end();
+    const joined = out.join("");
+    expect(joined).toContain("response.output_text.delta");
+    expect(joined).toContain("response.completed");
+  });
+
+  it("converts tool_use → function_call events", () => {
+    const t = new AnthropicToResponsesTransform("gpt-4o");
+    const out = collectOutput(t);
+    t.write(`event: message_start\ndata: ${JSON.stringify({
+      type: "message_start", message: { id: "msg_1", role: "assistant", content: [], usage: { input_tokens: 5 } },
+    })}\n\n`);
+    t.write(`event: content_block_start\ndata: ${JSON.stringify({
+      type: "content_block_start", index: 0, content_block: { type: "tool_use", id: "toolu_abc", name: "foo", input: {} },
+    })}\n\n`);
+    t.write(`event: content_block_delta\ndata: ${JSON.stringify({
+      type: "content_block_delta", index: 0, delta: { type: "input_json_delta", partial_json: '{"x":1}' },
+    })}\n\n`);
+    t.write(`event: content_block_stop\ndata: ${JSON.stringify({ type: "content_block_stop", index: 0 })}\n\n`);
+    t.write(`event: message_delta\ndata: ${JSON.stringify({
+      type: "message_delta", delta: { stop_reason: "tool_use" }, usage: { output_tokens: 10 },
+    })}\n\n`);
+    t.write(`event: message_stop\ndata: ${JSON.stringify({ type: "message_stop" })}\n\n`);
+    t.end();
+    const joined = out.join("");
+    expect(joined).toContain("response.function_call_arguments.delta");
+    expect(joined).toContain("abc"); // call_id
+  });
+});
+```
+
+- [ ] **Step 2: 运行测试确认失败**
+
+- [ ] **Step 3: 实现 AnthropicToResponsesTransform**
+
+创建 `src/proxy/transform/stream-ant2resp.ts`，继承 `BaseSSETransform`。
+
+状态机字段：
+```typescript
+type Ant2RespState = "init" | "text" | "thinking" | "tool_use" | "closing";
+private state: Ant2RespState = "init";
+private responseId = generateRespId();
+private currentOutputIndex = 0;
+private currentContentIndex = 0;
+private sequenceNumber = 0;
+private hasResponseCreated = false;
+private hasContentPartStarted = false;
+private inputTokens = 0;
+private outputTokens = 0;
+private pendingStatus: string | null = null;
+private activeToolCallId = "";
+private activeToolCallName = "";
+```
+
+SSE 事件映射逻辑：
+
+| Anthropic 事件 | Responses SSE 事件 |
+|---|---|
+| `message_start` | `response.created` + `response.in_progress` |
+| `content_block_start[thinking]` | `response.output_item.added[reasoning]` + `response.reasoning_summary_part.added` |
+| `content_block_delta[thinking_delta]` | `response.reasoning_summary_text.delta` |
+| `content_block_start[text]` | `response.output_item.added[message]` + `response.content_part.added[output_text]` |
+| `content_block_delta[text_delta]` | `response.output_text.delta` |
+| `content_block_start[tool_use]` | `response.output_item.added[function_call]` |
+| `content_block_delta[input_json_delta]` | `response.function_call_arguments.delta` |
+| `content_block_stop` | `response.content_part.done` / `response.function_call_arguments.done` + `response.output_item.done` |
+| `message_delta[stop_reason]` | 记录 pendingStatus + outputTokens |
+| `message_stop` | `response.completed` |
+
+- [ ] **Step 4: 编写 Responses→Anthropic 流式测试**
+
+类似结构，反向验证。
+
+- [ ] **Step 5: 实现 ResponsesToAnthropicTransform**
+
+创建 `src/proxy/transform/stream-resp2ant.ts`。
+
+| Responses SSE 事件 | Anthropic SSE 事件 |
+|---|---|
+| `response.created/in_progress` | `message_start` |
+| `response.output_item.added[message]` | 记录 outputIndex |
+| `response.content_part.added[output_text]` | `content_block_start[text]` |
+| `response.output_text.delta` | `content_block_delta[text_delta]` |
+| `response.output_item.added[function_call]` | `content_block_start[tool_use]` |
+| `response.function_call_arguments.delta` | `content_block_delta[input_json_delta]` |
+| `response.output_item.added[reasoning]` | `content_block_start[thinking]` |
+| `response.reasoning_summary_text.delta` | `content_block_delta[thinking_delta]` |
+| `response.completed` | `message_delta[stop_reason]` + `message_stop` |
+
+- [ ] **Step 6: 运行所有流式测试确认通过**
+
+Run: `cd /Users/zhushanwen/Code/llm-simple-router-workspace/feat-openai-response-endpoint && npx vitest run tests/proxy/transform/stream-ant2resp.test.ts tests/proxy/transform/stream-resp2ant.test.ts 2>&1 | tail -20`
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/proxy/transform/stream-ant2resp.ts src/proxy/transform/stream-resp2ant.ts tests/proxy/transform/stream-ant2resp.test.ts tests/proxy/transform/stream-resp2ant.test.ts
+git commit -m "feat(responses): implement Anthropic↔Responses SSE streaming transforms (tier-1)"
+```
+
+---
+
+## Task 8: 流式桥接 — Responses SSE ↔ Chat SSE（二级）
+
+**Files:**
+- Create: `src/proxy/transform/stream-bridge-chat2resp.ts`
+- Create: `src/proxy/transform/stream-bridge-resp2chat.ts`
+- Create: `tests/proxy/transform/stream-bridge.test.ts`
+
+- [ ] **Step 1: 编写测试**
+
+测试 Chat→Responses 桥接和 Responses→Chat 桥接两种方向。
+
+- [ ] **Step 2: 运行测试确认失败**
+
+- [ ] **Step 3: 实现 ChatToResponsesBridgeTransform**
+
+`stream-bridge-chat2resp.ts`：将 Chat SSE 匿名 delta 转为 Responses 命名事件。
+
+| Chat delta | Responses SSE 事件 |
+|---|---|
+| `delta: {role: "assistant"}` | `response.created` + `response.in_progress` |
+| `delta: {content: "..."}` | `response.output_item.added[message]` + `response.content_part.added` + `response.output_text.delta` |
+| `delta: {tool_calls: [{id, name}]}` | `response.output_item.added[function_call]` |
+| `delta: {tool_calls: [{arguments}]}` | `response.function_call_arguments.delta` |
+| `delta: {reasoning_content: "..."}` | `response.output_item.added[reasoning]` + `response.reasoning_summary_text.delta` |
+| `finish_reason` | `response.completed` |
+| `data: [DONE]` | （已由 response.completed 处理） |
+
+- [ ] **Step 4: 实现 ResponsesToChatBridgeTransform**
+
+`stream-bridge-resp2chat.ts`：将 Responses 命名事件转为 Chat 匿名 delta。
+
+| Responses SSE 事件 | Chat delta |
+|---|---|
+| `response.output_text.delta` | `delta: {content: "..."}` |
+| `response.output_item.added[function_call]` | `delta: {tool_calls: [{id, name}]}` |
+| `response.function_call_arguments.delta` | `delta: {tool_calls: [{arguments}]}` |
+| `response.reasoning_summary_text.delta` | `delta: {reasoning_content: "..."}` |
+| `response.completed` | `finish_reason: "stop"` + `data: [DONE]` |
+
+- [ ] **Step 5: 运行测试确认通过**
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/proxy/transform/stream-bridge-chat2resp.ts src/proxy/transform/stream-bridge-resp2chat.ts tests/proxy/transform/stream-bridge.test.ts
+git commit -m "feat(responses): implement Responses↔Chat SSE bridge streaming transforms"
+```
+
+---
+
+## Task 9: 扩展 TransformCoordinator — 3×3 转换矩阵 + 错误转换
+
+**Files:**
+- Modify: `src/proxy/transform/transform-coordinator.ts`
+- Create: `tests/proxy/transform/transform-coordinator-responses.test.ts`
+
+- [ ] **Step 1: 编写测试**
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { TransformCoordinator } from "../../../src/proxy/transform/transform-coordinator.js";
+
+describe("TransformCoordinator 3×3 matrix", () => {
+  const c = new TransformCoordinator();
+
+  it("openai → openai: no transform", () => {
+    expect(c.needsTransform("openai", "openai")).toBe(false);
+  });
+
+  it("anthropic → anthropic: no transform", () => {
+    expect(c.needsTransform("anthropic", "anthropic")).toBe(false);
+  });
+
+  it("openai-responses → openai-responses: no transform", () => {
+    expect(c.needsTransform("openai-responses", "openai-responses")).toBe(false);
+  });
+
+  it("openai-responses → anthropic: tier-1 request transform", () => {
+    const result = c.transformRequest(
+      { model: "gpt-4o", input: "Hello", instructions: "Hi" },
+      "openai-responses", "anthropic", "gpt-4o",
+    );
+    expect(result.upstreamPath).toBe("/v1/messages");
+    expect(result.body.system).toBe("Hi");
+    expect(result.body.messages).toBeDefined();
+  });
+
+  it("anthropic → openai-responses: tier-1 request transform", () => {
+    const result = c.transformRequest(
+      { model: "claude", system: "Hi", messages: [{ role: "user", content: "Hello" }], max_tokens: 1024 },
+      "anthropic", "openai-responses", "claude",
+    );
+    expect(result.upstreamPath).toBe("/v1/responses");
+    expect(result.body.instructions).toBe("Hi");
+    expect(result.body.input).toBeDefined();
+  });
+
+  it("openai → anthropic: existing transform preserved", () => {
+    const result = c.transformRequest(
+      { model: "gpt-4o", messages: [{ role: "user", content: "Hello" }] },
+      "openai", "anthropic", "gpt-4o",
+    );
+    expect(result.upstreamPath).toBe("/v1/messages");
+    expect(result.body.system).toBeUndefined();
+    expect(result.body.messages).toBeDefined();
+  });
+
+  it("anthropic → openai: existing transform preserved", () => {
+    const result = c.transformRequest(
+      { model: "claude", system: "Hi", messages: [{ role: "user", content: "Hello" }], max_tokens: 1024 },
+      "anthropic", "openai", "claude",
+    );
+    expect(result.upstreamPath).toBe("/v1/chat/completions");
+    expect(result.body.messages).toBeDefined();
+  });
+
+  it("openai-responses → openai: bridge request transform", () => {
+    const result = c.transformRequest(
+      { model: "gpt-4o", input: "Hello", instructions: "Hi", max_output_tokens: 1024 },
+      "openai-responses", "openai", "gpt-4o",
+    );
+    expect(result.upstreamPath).toBe("/v1/chat/completions");
+    expect(result.body.messages).toBeDefined();
+    expect(result.body.max_completion_tokens).toBe(1024);
+  });
+
+  it("openai → openai-responses: bridge request transform", () => {
+    const result = c.transformRequest(
+      { model: "gpt-4o", messages: [{ role: "system", content: "Hi" }, { role: "user", content: "Hello" }] },
+      "openai", "openai-responses", "gpt-4o",
+    );
+    expect(result.upstreamPath).toBe("/v1/responses");
+    expect(result.body.instructions).toBe("Hi");
+    expect(result.body.input).toBeDefined();
+  });
+
+  it("creates correct stream transforms for each direction", () => {
+    // 一级
+    expect(c.createFormatTransform("openai-responses", "anthropic", "m")?.constructor.name).toContain("ResponsesToAnthropic");
+    expect(c.createFormatTransform("anthropic", "openai-responses", "m")?.constructor.name).toContain("AnthropicToResponses");
+    // 现有
+    expect(c.createFormatTransform("anthropic", "openai", "m")?.constructor.name).toContain("AnthropicToOpenAI");
+    expect(c.createFormatTransform("openai", "anthropic", "m")?.constructor.name).toContain("OpenAIToAnthropic");
+    // 桥接
+    expect(c.createFormatTransform("openai-responses", "openai", "m")?.constructor.name).toContain("ResponsesToChatBridge");
+    expect(c.createFormatTransform("openai", "openai-responses", "m")?.constructor.name).toContain("ChatToResponsesBridge");
+  });
+
+  it("getUpstreamPath returns correct paths", () => {
+    expect(c.transformRequest({ model: "x" }, "openai", "openai", "x").upstreamPath).toBe("/v1/chat/completions");
+    expect(c.transformRequest({ model: "x" }, "anthropic", "anthropic", "x").upstreamPath).toBe("/v1/messages");
+    expect(c.transformRequest({ model: "x" }, "openai-responses", "openai-responses", "x").upstreamPath).toBe("/v1/responses");
+  });
+});
+```
+
+- [ ] **Step 2: 运行测试确认失败**
+
+- [ ] **Step 3: 重写 TransformCoordinator**
+
+用 3×3 矩阵重写 `transform-coordinator.ts`：
+
+```typescript
+import type { Transform } from "stream";
+import { transformRequestBody } from "./request-transform.js";
+import { transformResponseBody, transformErrorResponse } from "./response-transform.js";
+import { OpenAIToAnthropicTransform } from "./stream-oa2ant.js";
+import { AnthropicToOpenAITransform } from "./stream-ant2oa.js";
+import {
+  responsesToAnthropicRequest,
+  anthropicToResponsesRequest,
+} from "./request-transform-responses.js";
+import {
+  responsesToAnthropicResponse,
+  anthropicToResponsesResponse,
+} from "./response-transform-responses.js";
+import {
+  responsesToChatRequest,
+  chatToResponsesRequest,
+} from "./request-bridge-responses.js";
+import {
+  responsesToChatResponse,
+  chatToResponsesResponse,
+} from "./response-bridge-responses.js";
+import { AnthropicToResponsesTransform } from "./stream-ant2resp.js";
+import { ResponsesToAnthropicTransform } from "./stream-resp2ant.js";
+import { ChatToResponsesBridgeTransform } from "./stream-bridge-chat2resp.js";
+import { ResponsesToChatBridgeTransform } from "./stream-bridge-resp2chat.js";
+
+export class TransformCoordinator {
+  needsTransform(entryApiType: string, providerApiType: string): boolean {
+    return entryApiType !== providerApiType;
+  }
+
+  transformRequest(
+    body: Record<string, unknown>,
+    entryApiType: string,
+    providerApiType: string,
+    model: string,
+  ): { body: Record<string, unknown>; upstreamPath: string } {
+    if (entryApiType === providerApiType) {
+      return { body, upstreamPath: this.getUpstreamPath(providerApiType) };
+    }
+
+    // 一级：Responses ↔ Anthropic
+    if (entryApiType === "openai-responses" && providerApiType === "anthropic") {
+      return { body: responsesToAnthropicRequest(body), upstreamPath: "/v1/messages" };
+    }
+    if (entryApiType === "anthropic" && providerApiType === "openai-responses") {
+      return { body: anthropicToResponsesRequest(body), upstreamPath: "/v1/responses" };
+    }
+
+    // 现有：OpenAI Chat ↔ Anthropic（保留）
+    if (entryApiType === "openai" && providerApiType === "anthropic") {
+      return { body: transformRequestBody(body, "openai", "anthropic", model), upstreamPath: "/v1/messages" };
+    }
+    if (entryApiType === "anthropic" && providerApiType === "openai") {
+      return { body: transformRequestBody(body, "anthropic", "openai", model), upstreamPath: "/v1/chat/completions" };
+    }
+
+    // 二级：Responses ↔ Chat
+    if (entryApiType === "openai-responses" && providerApiType === "openai") {
+      return { body: responsesToChatRequest(body), upstreamPath: "/v1/chat/completions" };
+    }
+    if (entryApiType === "openai" && providerApiType === "openai-responses") {
+      return { body: chatToResponsesRequest(body), upstreamPath: "/v1/responses" };
+    }
+
+    return { body, upstreamPath: this.getUpstreamPath(providerApiType) };
+  }
+
+  transformResponse(bodyStr: string, sourceApiType: string, targetApiType: string): string {
+    if (sourceApiType === targetApiType) return bodyStr;
+
+    // 一级
+    if (sourceApiType === "openai-responses" && targetApiType === "anthropic") return responsesToAnthropicResponse(bodyStr);
+    if (sourceApiType === "anthropic" && targetApiType === "openai-responses") return anthropicToResponsesResponse(bodyStr);
+
+    // 现有
+    if (sourceApiType === "openai" && targetApiType === "anthropic") return transformResponseBody(bodyStr, "openai", "anthropic");
+    if (sourceApiType === "anthropic" && targetApiType === "openai") return transformResponseBody(bodyStr, "anthropic", "openai");
+
+    // 二级
+    if (sourceApiType === "openai-responses" && targetApiType === "openai") return responsesToChatResponse(bodyStr);
+    if (sourceApiType === "openai" && targetApiType === "openai-responses") return chatToResponsesResponse(bodyStr);
+
+    return bodyStr;
+  }
+
+  transformErrorResponse(bodyStr: string, sourceApiType: string, targetApiType: string): string {
+    if (sourceApiType === targetApiType) return bodyStr;
+    try {
+      // 统一错误转换：解析源格式错误，重新打包为目标格式
+      const parsed = JSON.parse(bodyStr);
+
+      if (sourceApiType === "openai-responses" && targetApiType === "anthropic") {
+        const err = parsed.error ?? parsed;
+        return JSON.stringify({ type: "error", error: { type: "api_error", message: err.message ?? "Unknown error" } });
+      }
+      if (sourceApiType === "anthropic" && targetApiType === "openai-responses") {
+        const err = parsed.error ?? parsed;
+        return JSON.stringify({ error: { message: err.message ?? "Unknown error", type: "invalid_request_error", code: "upstream_error" } });
+      }
+      if (sourceApiType === "openai-responses" && targetApiType === "openai") {
+        const err = parsed.error ?? parsed;
+        return JSON.stringify({ error: { message: err.message ?? "Unknown error", type: "api_error", code: "upstream_error" } });
+      }
+      if (sourceApiType === "openai" && targetApiType === "openai-responses") {
+        const err = (parsed.error ?? parsed);
+        return JSON.stringify({ error: { message: err.message ?? "Unknown error", type: "invalid_request_error", code: "upstream_error" } });
+      }
+      // 剩余走原有逻辑
+      return transformErrorResponse(bodyStr, sourceApiType, targetApiType);
+    } catch {
+      return bodyStr;
+    }
+  }
+
+  createFormatTransform(entryApiType: string, providerApiType: string, model: string): Transform | undefined {
+    if (entryApiType === providerApiType) return undefined;
+
+    // 一级流式
+    if (providerApiType === "anthropic" && entryApiType === "openai-responses") return new ResponsesToAnthropicTransform(model);
+    if (providerApiType === "openai-responses" && entryApiType === "anthropic") return new AnthropicToResponsesTransform(model);
+
+    // 现有流式
+    if (providerApiType === "openai" && entryApiType === "anthropic") return new OpenAIToAnthropicTransform(model);
+    if (providerApiType === "anthropic" && entryApiType === "openai") return new AnthropicToOpenAITransform(model);
+
+    // 二级流式桥接
+    if (providerApiType === "openai" && entryApiType === "openai-responses") return new ResponsesToChatBridgeTransform(model);
+    if (providerApiType === "openai-responses" && entryApiType === "openai") return new ChatToResponsesBridgeTransform(model);
+
+    return undefined;
+  }
+
+  private getUpstreamPath(apiType: string): string {
+    switch (apiType) {
+      case "openai": return "/v1/chat/completions";
+      case "openai-responses": return "/v1/responses";
+      case "anthropic": return "/v1/messages";
+      default: return "/v1/chat/completions";
+    }
+  }
+}
+```
+
+- [ ] **Step 4: 运行测试确认通过**
+
+Run: `cd /Users/zhushanwen/Code/llm-simple-router-workspace/feat-openai-response-endpoint && npx vitest run tests/proxy/transform/transform-coordinator-responses.test.ts 2>&1 | tail -20`
+
+- [ ] **Step 5: 运行全部测试确认无回归**
+
+Run: `cd /Users/zhushanwen/Code/llm-simple-router-workspace/feat-openai-response-endpoint && npm test -- --run 2>&1 | tail -30`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/proxy/transform/transform-coordinator.ts tests/proxy/transform/transform-coordinator-responses.test.ts
+git commit -m "feat(responses): extend TransformCoordinator for 3×3 conversion matrix"
+```
+
+---
+
+## Task 10: 扩展 monitor/metrics 系统 — 支持 Responses SSE 解析
+
+**Files:**
+- Modify: `src/monitor/stream-extractor.ts`
+- Modify: `src/metrics/metrics-extractor.ts`
+- Modify: `src/metrics/sse-metrics-transform.ts`
+- Modify: `src/proxy/handler/proxy-handler-utils.ts`
+
+> 此 Task 使 monitor 和 metrics 模块能正确解析 Responses API 的 SSE 流。这些模块在 formatTransform 之后的旁路管道中运行，看到的始终是 provider 的原始 SSE 格式。
+
+- [ ] **Step 1: 扩展 stream-extractor.ts — 添加 Responses 格式解析**
+
+在 `extractStreamText` 函数中添加 `openai-responses` 分支：
+
+```typescript
+export function extractStreamText(line: string, apiType: "openai" | "openai-responses" | "anthropic"): StreamExtraction {
+  // ... 现有 openai 和 anthropic 逻辑 ...
+
+  if (apiType === "openai-responses") {
+    // Responses SSE 使用 event: + data: 格式
+    // line 格式: "data: {json}"
+    const obj = JSON.parse(jsonStr) as Record<string, unknown>;
+    const type = obj.type as string;
+
+    if (type === "response.output_text.delta") {
+      const text = (obj.delta as string) ?? "";
+      return { text, block: text ? { index: obj.output_index as number ?? 0, type: "text", content: text } : null };
+    }
+    if (type === "response.function_call_arguments.delta") {
+      const partialJson = (obj.delta as string) ?? "";
+      return { text: "", block: { index: obj.output_index as number ?? 0, type: "tool_use", content: partialJson } };
+    }
+    if (type === "response.reasoning_summary_text.delta") {
+      const thinking = (obj.delta as string) ?? "";
+      return { text: "", block: { index: obj.output_index as number ?? 0, type: "thinking", content: thinking } };
+    }
+    return empty;
+  }
+```
+
+- [ ] **Step 2: 扩展 metrics-extractor.ts — 添加 Responses 事件处理**
+
+在 `MetricsExtractor.processEvent` 中添加 `openai-responses` 分支：
+
+```typescript
+processEvent(event: SSEEvent): void {
+  if (!event.data) return;
+  if (this.apiType === "anthropic") {
+    this.processAnthropicEvent(event);
+  } else if (this.apiType === "openai-responses") {
+    this.processResponsesEvent(event);
+  } else {
+    this.processOpenAIEvent(event);
+  }
+}
+
+private processResponsesEvent(event: SSEEvent): void {
+  const obj = JSON.parse(event.data) as Record<string, unknown>;
+  const type = obj.type as string;
+
+  if (type === "response.created" || type === "response.in_progress") {
+    this.streamStartTime = Date.now();
+    const resp = obj.response as Record<string, unknown> | undefined;
+    // 从 response.usage 提取初始 input_tokens（如果存在）
+  }
+
+  if (type === "response.output_text.delta" || type === "response.function_call_arguments.delta" || type === "response.reasoning_summary_text.delta") {
+    const delta = (obj.delta as string) ?? "";
+    if (delta && !this.firstContentReceived) {
+      this.firstContentReceived = true;
+      this.ttftMs = Date.now() - this.requestStartTime;
+    }
+    this.textContentBuffer += delta;
+  }
+
+  if (type === "response.completed") {
+    this.streamEndTime = Date.now();
+    this.complete = true;
+    const resp = obj.response as Record<string, unknown> | undefined;
+    const usage = resp?.usage as Record<string, number> | undefined;
+    if (usage) {
+      this.inputTokens = usage.input_tokens ?? null;
+      this.outputTokens = usage.output_tokens ?? null;
+    }
+    if (resp?.status === "completed") this.stopReason = "end_turn";
+    else if (resp?.status === "incomplete") this.stopReason = "max_tokens";
+    else this.stopReason = "stop";
+  }
+}
+```
+
+- [ ] **Step 3: 扩展 sse-metrics-transform.ts — extractContentDelta 支持 Responses**
+
+在 `extractContentDelta` 方法中添加 `openai-responses` 分支：
+
+```typescript
+private extractContentDelta(data: string): string | undefined {
+  // ... 现有逻辑 ...
+  if (this.apiType === "openai-responses") {
+    const parsed = JSON.parse(data) as Record<string, unknown>;
+    const type = parsed.type as string;
+    if (type === "response.output_text.delta") return parsed.delta as string;
+    if (type === "response.reasoning_summary_text.delta") return parsed.delta as string;
+    if (type === "response.function_call_arguments.delta") return parsed.delta as string;
+    return undefined;
+  }
+  // ...
+}
+```
+
+- [ ] **Step 4: 扩展 proxy-handler-utils.ts — serializeBlocksForStorage**
+
+函数签名已在 Task 2 扩展。Responses 格式的 stream content 通过 `extractStreamText` 的新分支处理，无需额外修改。
+
+- [ ] **Step 5: 运行全部测试**
+
+Run: `cd /Users/zhushanwen/Code/llm-simple-router-workspace/feat-openai-response-endpoint && npm test -- --run 2>&1 | tail -30`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/monitor/stream-extractor.ts src/metrics/metrics-extractor.ts src/metrics/sse-metrics-transform.ts
+git commit -m "feat(responses): extend monitor/metrics to parse Responses SSE events"
+```
+
+---
+
+## Task 11: 扩展 patch/plugin 系统 — 兼容 openai-responses
+
+**Files:**
+- Modify: `src/proxy/patch/tool-round-limiter.ts`
+- Modify: `src/proxy/loop-prevention/tool-loop-guard.ts`
+- Modify: `src/proxy/patch/index.ts`
+- Modify: `src/proxy/patch/deepseek/patch-thinking-param.ts`
+
+> patch 系统在 proxy-handler 中的执行位置：**格式转换之后**（所以 patch 看到的 body 已经是 provider 的 api_type 格式）。但如果 patch 逻辑使用入口 apiType（如 tool-round-limiter），需要处理 openai-responses 的情况。
+
+- [ ] **Step 1: 扩展 tool-round-limiter.ts — 支持 Responses 格式的 input**
+
+在 `applyToolRoundLimit` 函数中，当 `apiType === "openai-responses"` 时，需要将 `input` items 转为 messages 格式来计算轮数，或者直接扫描 input items：
+
+```typescript
+export function applyToolRoundLimit(
+  body: Record<string, unknown>,
+  apiType: "openai" | "openai-responses" | "anthropic",
+  maxRounds: number = DEFAULT_MAX_ROUNDS,
+): { body: Record<string, unknown>; injected: boolean; rounds: number } {
+  // Responses 格式：检查 input items 中的 function_call 数量
+  if (apiType === "openai-responses") {
+    const input = body.input as Array<Record<string, unknown>> | undefined;
+    if (!input || !Array.isArray(input)) return { body, injected: false, rounds: 0 };
+    const funcCalls = input.filter(i => i.type === "function_call").length;
+    if (funcCalls <= maxRounds) return { body, injected: false, rounds: funcCalls };
+    // 注入提示词：在最后一条 input item 后追加
+    const cloned = { ...body, input: [...input] };
+    const inputArr = cloned.input as Array<Record<string, unknown>>;
+    inputArr.push({
+      type: "message",
+      role: "user",
+      content: [{ type: "input_text", text: LOOP_WARNING_PROMPT }],
+    });
+    return { body: cloned, injected: true, rounds: funcCalls };
+  }
+
+  // 现有逻辑（openai / anthropic）...
+  const messages = (body.messages as Message[]) ?? [];
+  // ... 不变
+}
+```
+
+- [ ] **Step 2: 扩展 tool-loop-guard.ts — injectLoopBreakPrompt 支持 Responses**
+
+在 `injectLoopBreakPrompt` 方法中添加 `openai-responses` 分支：
+
+```typescript
+injectLoopBreakPrompt(body: Record<string, unknown>, apiType: "openai" | "openai-responses" | "anthropic", toolName: string): Record<string, unknown> {
+  if (apiType === "openai-responses") {
+    // Responses 格式：追加 user message 到 input
+    const input = body.input;
+    const inputArr = Array.isArray(input) ? [...input] : [{ type: "message", role: "user", content }];
+    // ... 在 inputArr 末尾追加提示消息
+    return { ...body, input: inputArr };
+  }
+  // 现有 anthropic / openai 逻辑不变
+}
+```
+
+- [ ] **Step 3: 确认 patch/index.ts 的 developer_role patch 对 Responses 无害**
+
+当前 `patchDeveloperRole` 只处理 `body.messages`，Responses 格式的 body 没有 `messages` 字段，`hasDeveloperRole` 返回 false，安全跳过。无需修改。
+
+- [ ] **Step 4: 确认 deepseek/patch-thinking-param.ts 兼容**
+
+签名已在 Task 2 扩展。函数体内 `if (apiType === "anthropic")` 分支不变，`openai-responses` 走 else 分支（与 openai 相同的逻辑），安全。
+
+- [ ] **Step 5: 确认 plugin-types.ts 兼容**
+
+签名已扩展。现有 plugin 的 `match.apiType` 仍为 `"openai"` 或 `"anthropic"`，不会匹配 `openai-responses` 的 provider。用户后续可自行编写针对 `openai-responses` 的 plugin。
+
+- [ ] **Step 6: 运行全部测试**
+
+Run: `cd /Users/zhushanwen/Code/llm-simple-router-workspace/feat-openai-response-endpoint && npm test -- --run 2>&1 | tail -30`
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/proxy/patch/tool-round-limiter.ts src/proxy/loop-prevention/tool-loop-guard.ts
+git commit -m "feat(responses): extend patch/loop-prevention to handle openai-responses format"
+```
+
+---
+
+## Task 12: Responses API 端点路由 + 注册
+
+**Files:**
+- Create: `src/proxy/handler/responses.ts`
+- Modify: `src/index.ts`
+- Modify: `src/proxy/response-transform.ts`
+
+- [ ] **Step 1: 创建 Responses 端点 handler**
+
+创建 `src/proxy/handler/responses.ts`，仿照 `openai.ts`：
+
+```typescript
+import type { FastifyPluginCallback, FastifyReply, FastifyRequest } from "fastify";
+import { randomUUID } from "crypto";
+import Database from "better-sqlite3";
+import fp from "fastify-plugin";
+import { insertRequestLog } from "../../db/index.js";
+import { createErrorFormatter, type ProxyErrorResponse } from "../proxy-core.js";
+import type { ErrorKind } from "../proxy-core.js";
+import type { RawHeaders } from "../types.js";
+import { handleProxyRequest, type RouteHandlerDeps } from "./proxy-handler.js";
+import { createOrchestrator } from "../orchestration/orchestrator.js";
+import { ProviderSemaphoreManager } from "../orchestration/semaphore.js";
+import type { RequestTracker } from "../../monitor/request-tracker.js";
+import type { AdaptiveConcurrencyController } from "../adaptive-controller.js";
+import { HTTP_BAD_GATEWAY } from "../../core/constants.js";
+import { SERVICE_KEYS } from "../../core/container.js";
+
+export interface ResponsesProxyOptions {
+  db: Database.Database;
+  container: import("../../core/container.js").ServiceContainer;
+}
+
+const RESPONSES_PATH = "/v1/responses";
+const RESPONSES_COMPAT_PATH = "/responses";
+
+// 复用 OpenAI 错误格式（Responses API 的错误格式与 OpenAI 一致）
+const RESPONSES_ERROR_META: Record<ErrorKind, { type: string; code: string }> = {
+  modelNotFound: { type: "invalid_request_error", code: "model_not_found" },
+  modelNotAllowed: { type: "invalid_request_error", code: "model_not_allowed" },
+  providerUnavailable: { type: "server_error", code: "provider_unavailable" },
+  providerTypeMismatch: { type: "server_error", code: "provider_type_mismatch" },
+  upstreamConnectionFailed: { type: "upstream_error", code: "upstream_connection_failed" },
+  concurrencyQueueFull: { type: "server_error", code: "concurrency_queue_full" },
+  concurrencyTimeout: { type: "server_error", code: "concurrency_timeout" },
+  promptTooLong: { type: "invalid_request_error", code: "context_window_exceeded" },
+};
+
+const responsesErrors = createErrorFormatter(
+  (kind, message) => ({ error: { message, ...RESPONSES_ERROR_META[kind] } }),
+);
+
+function sendError(reply: FastifyReply, e: ProxyErrorResponse) {
+  return reply.code(e.statusCode).send(e.body);
+}
+
+const responsesProxyRaw: FastifyPluginCallback<ResponsesProxyOptions> = (app, opts, done) => {
+  const { db, container } = opts;
+
+  const orchestrator = createOrchestrator(
+    container.resolve<ProviderSemaphoreManager>(SERVICE_KEYS.semaphoreManager),
+    container.resolve<RequestTracker>(SERVICE_KEYS.tracker),
+    container.resolve<AdaptiveConcurrencyController>(SERVICE_KEYS.adaptiveController),
+  );
+
+  const handleResponses = async (request: FastifyRequest, reply: FastifyReply) => {
+    if (!orchestrator) {
+      const body = request.body as Record<string, unknown> | undefined;
+      insertRequestLog(db, {
+        id: randomUUID(), api_type: "openai-responses", model: (body?.model as string) || null,
+        provider_id: null, status_code: HTTP_BAD_GATEWAY, latency_ms: 0, is_stream: 0,
+        error_message: "Orchestrator not available",
+        created_at: new Date().toISOString(),
+        client_request: JSON.stringify({ headers: request.headers }),
+        router_key_id: request.routerKey?.id ?? null,
+      });
+      return sendError(reply, responsesErrors.providerUnavailable());
+    }
+    const deps: RouteHandlerDeps = { db, orchestrator, container };
+    return handleProxyRequest(request, reply, "openai-responses", RESPONSES_PATH, responsesErrors, deps);
+  };
+
+  app.post(RESPONSES_PATH, handleResponses);
+  app.post(RESPONSES_COMPAT_PATH, handleResponses);
+
+  done();
+};
+
+export const responsesProxy = fp(responsesProxyRaw, { name: "responses-proxy" });
+```
+
+- [ ] **Step 2: 在 src/index.ts 中注册 Responses 路由**
+
+在 `buildApp` 函数中，找到 `app.register(openaiProxy, { db, container })` 和 `app.register(anthropicProxy, { db, container })` 的位置，在其后添加：
+
+```typescript
+import { responsesProxy } from "./proxy/handler/responses.js";
+// ...
+app.register(openaiProxy, { db, container });
+app.register(anthropicProxy, { db, container });
+app.register(responsesProxy, { db, container });
+```
+
+- [ ] **Step 3: 扩展 response-transform.ts — maybeInjectModelInfoTag**
+
+`maybeInjectModelInfoTag` 目前只在 Anthropic 格式（`bodyObj.content?.[0]?.text`）中注入。对于 Responses 格式，需要检查 `output[type=message].content[type=output_text].text`：
+
+```typescript
+export function maybeInjectModelInfoTag(
+  responseBody: string,
+  originalModel: string | null,
+  effectiveModel: string,
+): { body: string; meta: ResponseTransformMeta } {
+  if (!originalModel) {
+    return { body: responseBody, meta: { model_info_tag_injected: false } };
+  }
+  try {
+    const bodyObj = JSON.parse(responseBody);
+
+    // Anthropic 格式
+    if (bodyObj.content?.[0]?.text) {
+      bodyObj.content[0].text += `\n\n${buildModelInfoTag(effectiveModel)}`;
+      return { body: JSON.stringify(bodyObj), meta: { model_info_tag_injected: true } };
+    }
+
+    // Responses 格式：output[type=message].content[type=output_text].text
+    if (Array.isArray(bodyObj.output)) {
+      for (const item of bodyObj.output) {
+        if (item.type === "message" && Array.isArray(item.content)) {
+          for (const part of item.content) {
+            if (part.type === "output_text" && part.text) {
+              part.text += `\n\n${buildModelInfoTag(effectiveModel)}`;
+              return { body: JSON.stringify(bodyObj), meta: { model_info_tag_injected: true } };
+            }
+          }
+        }
+      }
+    }
+  } catch { /* non-JSON response, skip injection */ }
+  return { body: responseBody, meta: { model_info_tag_injected: false } };
+}
+```
+
+- [ ] **Step 4: 运行全部测试**
+
+Run: `cd /Users/zhushanwen/Code/llm-simple-router-workspace/feat-openai-response-endpoint && npm test -- --run 2>&1 | tail -30`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/proxy/handler/responses.ts src/index.ts src/proxy/response-transform.ts
+git commit -m "feat(responses): add /v1/responses endpoint and register route"
+```
+
+---
+
+## Task 13: 前端支持 — Provider 管理
+
+**Files:**
+- Modify: `frontend/src/views/Providers.vue`
+
+- [ ] **Step 1: 添加 openai-responses 选项**
+
+在 `frontend/src/views/Providers.vue` 中找到 SelectContent 部分（约第 128 行），添加：
+
+```html
+<SelectContent>
+  <SelectItem value="openai">OpenAI</SelectItem>
+  <SelectItem value="openai-responses">OpenAI Responses</SelectItem>
+  <SelectItem value="anthropic">Anthropic</SelectItem>
+</SelectContent>
+```
+
+- [ ] **Step 2: 验证前端构建**
+
+Run: `cd /Users/zhushanwen/Code/llm-simple-router-workspace/feat-openai-response-endpoint/frontend && pnpm build 2>&1 | tail -10`
+Expected: 构建成功
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/views/Providers.vue
+git commit -m "feat(responses): add openai-responses option in provider form"
+```
+
+---
+
+## Task 14: 集成测试 + 全量回归验证
+
+**Files:**
+- Create: `tests/proxy/transform/integration-responses.test.ts`
+
+- [ ] **Step 1: 编写集成测试**
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { TransformCoordinator } from "../../../src/proxy/transform/transform-coordinator.js";
+
+const coordinator = new TransformCoordinator();
+
+describe("Responses API integration — full conversion pipeline", () => {
+  it("Responses → Anthropic → Responses (round-trip preserves intent)", () => {
+    const request = {
+      model: "gpt-4o",
+      input: [
+        { type: "message", role: "user", content: "What's the weather?" },
+      ],
+      instructions: "You are a weather assistant.",
+      tools: [{ type: "function", name: "get_weather", parameters: { type: "object", properties: { city: { type: "string" } } } }],
+      max_output_tokens: 2048,
+    };
+
+    // Responses → Anthropic
+    const { body: antReq } = coordinator.transformRequest(request, "openai-responses", "anthropic", "gpt-4o");
+    expect(antReq.system).toBe("You are a weather assistant.");
+    expect(antReq.messages).toBeDefined();
+    expect(antReq.tools).toBeDefined();
+
+    // Anthropic → Responses (响应方向)
+    const antResponse = JSON.stringify({
+      id: "msg_1", type: "message", role: "assistant", model: "gpt-4o",
+      content: [{ type: "text", text: "The weather is sunny." }],
+      stop_reason: "end_turn",
+      usage: { input_tokens: 20, output_tokens: 10 },
+    });
+    const respResponse = coordinator.transformResponse(antResponse, "anthropic", "openai-responses");
+    const parsed = JSON.parse(respResponse);
+    expect(parsed.object).toBe("response");
+    expect(parsed.status).toBe("completed");
+  });
+
+  it("Responses → Chat (bridge) → back to Responses (round-trip)", () => {
+    const request = {
+      model: "gpt-4o",
+      input: "Hello",
+      instructions: "Be helpful",
+      max_output_tokens: 1024,
+    };
+
+    // Responses → Chat
+    const { body: chatReq } = coordinator.transformRequest(request, "openai-responses", "openai", "gpt-4o");
+    expect(chatReq.messages).toBeDefined();
+    expect(chatReq.max_completion_tokens).toBe(1024);
+
+    // Chat → Responses
+    const { body: respReq } = coordinator.transformRequest(chatReq, "openai", "openai-responses", "gpt-4o");
+    expect(respReq.instructions).toBe("Be helpful");
+    expect(respReq.max_output_tokens).toBe(1024);
+  });
+
+  it("Chat → Responses → Chat (bridge round-trip)", () => {
+    const request = {
+      model: "gpt-4o",
+      messages: [
+        { role: "system", content: "Be helpful" },
+        { role: "user", content: "Hello" },
+      ],
+      max_completion_tokens: 1024,
+      temperature: 0.7,
+    };
+
+    // Chat → Responses
+    const { body: respReq } = coordinator.transformRequest(request, "openai", "openai-responses", "gpt-4o");
+    expect(respReq.instructions).toBe("Be helpful");
+    expect(respReq.max_output_tokens).toBe(1024);
+
+    // Responses → Chat
+    const { body: chatReq } = coordinator.transformRequest(respReq, "openai-responses", "openai", "gpt-4o");
+    expect(chatReq.messages).toBeDefined();
+    expect(chatReq.max_completion_tokens).toBe(1024);
+    expect(chatReq.temperature).toBe(0.7);
+  });
+
+  it("existing Anthropic ↔ Chat path still works (regression check)", () => {
+    const request = {
+      model: "claude",
+      system: "Be helpful",
+      messages: [{ role: "user", content: "Hello" }],
+      max_tokens: 1024,
+    };
+
+    const { body: chatReq } = coordinator.transformRequest(request, "anthropic", "openai", "claude");
+    expect(chatReq.messages).toBeDefined();
+
+    const { body: antReq } = coordinator.transformRequest(chatReq, "openai", "anthropic", "claude");
+    expect(antReq.messages).toBeDefined();
+  });
+});
+```
+
+- [ ] **Step 2: 运行全部测试**
+
+Run: `cd /Users/zhushanwen/Code/llm-simple-router-workspace/feat-openai-response-endpoint && npm test -- --run 2>&1 | tail -40`
+Expected: 所有测试 PASS
+
+- [ ] **Step 3: 运行 TypeScript 类型检查**
+
+Run: `cd /Users/zhushanwen/Code/llm-simple-router-workspace/feat-openai-response-endpoint && npx tsc --noEmit 2>&1 | head -30`
+Expected: 0 errors
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/proxy/transform/integration-responses.test.ts
+git commit -m "test(responses): add integration tests for full conversion pipeline"
+```
+
+---
+
+## 执行顺序与依赖关系
+
+```
+Task 1 (类型定义)
+  ↓
+Task 2 (api_type 全局扩展 — 20+ 文件签名统一)
+  ↓
+  ├── Task 3 + Task 4 (一级请求/响应转换，可并行)
+  ├── Task 5 + Task 6 (桥接请求/响应转换，可并行)
+  ├── Task 7 + Task 8 (一级/桥接流式转换，可并行)
+  │                    ↓
+  │        Task 9 (TransformCoordinator 3×3 矩阵)
+  │                ↓
+  │        Task 10 (monitor/metrics 扩展)
+  │                ↓
+  │        Task 11 (patch/plugin 兼容)
+  │                ↓
+  │        Task 12 (端点路由 + 注册)
+  │                ↓
+  │        Task 13 (前端支持)
+  │                ↓
+  │        Task 14 (集成测试)
+```
+
+**可并行的任务组：**
+- Group A: Task 3 + Task 4（一级转换的请求和响应）
+- Group B: Task 5 + Task 6（桥接的请求和响应）
+- Group C: Task 7 + Task 8（流式转换的一级和桥接）
+
+**预估工作量：** 14 个 Task，约 12-16 小时。Task 2（全局类型扩展）和 Task 7/8（流式状态机）是最耗时的部分。

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -100,7 +100,7 @@ const API = {
 export interface ProviderPreset {
   plan: string;
   presetName: string;
-  apiType: "openai" | "anthropic";
+  apiType: "openai" | "openai-responses" | "anthropic";
   baseUrl: string;
   models: string[];
 }

--- a/frontend/src/components/layout/Sidebar.vue
+++ b/frontend/src/components/layout/Sidebar.vue
@@ -229,6 +229,7 @@ import {
   Zap,
   ChevronDown,
   Globe,
+  CalendarClock,
 } from 'lucide-vue-next'
 import { api, getApiMessage } from '@/api/client'
 import { Button } from '@/components/ui/button'
@@ -365,6 +366,7 @@ const navGroups = computed(() => {
       { path: '/mappings', label: t('sidebar.nav.modelMappings'), icon: ArrowLeftRight },
       { path: '/router-keys', label: t('sidebar.nav.routerKeys'), icon: KeyRound },
       { path: '/retry-rules', label: t('sidebar.nav.retryRules'), icon: RefreshCcw },
+      { path: '/schedules', label: t('sidebar.nav.schedules'), icon: CalendarClock },
     ],
   },
   {

--- a/frontend/src/components/layout/Sidebar.vue
+++ b/frontend/src/components/layout/Sidebar.vue
@@ -349,38 +349,37 @@ interface NavGroup {
 }
 
 // 与 router/index.ts 路由定义保持同步
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const navGroups = computed(() => {
   return [
-  {
-    items: [
-      { path: '/', label: t('sidebar.nav.dashboard'), icon: LayoutDashboard },
-    ],
-  },
-  {
-    label: t('sidebar.nav.agentConfig'),
-    expandable: true,
-    items: [
-      { path: '/quick-setup', label: t('sidebar.nav.quickSetup'), icon: Zap },
-      { path: '/providers', label: t('sidebar.nav.providers'), icon: Server },
-      { path: '/mappings', label: t('sidebar.nav.modelMappings'), icon: ArrowLeftRight },
-      { path: '/router-keys', label: t('sidebar.nav.routerKeys'), icon: KeyRound },
-      { path: '/retry-rules', label: t('sidebar.nav.retryRules'), icon: RefreshCcw },
-      { path: '/schedules', label: t('sidebar.nav.schedules'), icon: CalendarClock },
-    ],
-  },
-  {
-    label: t('sidebar.nav.monitoring'),
-    items: [
-      { path: '/monitor', label: t('sidebar.nav.monitor'), icon: Activity },
-      { path: '/logs', label: t('sidebar.nav.logs'), icon: FileText },
-    ],
-  },
-  {
-    items: [
-      { path: '/settings', label: t('sidebar.nav.settings'), icon: Settings },
-    ],
-  },
+    {
+      items: [
+        { path: '/', label: t('sidebar.nav.dashboard'), icon: LayoutDashboard },
+      ],
+    },
+    {
+      label: t('sidebar.nav.agentConfig'),
+      expandable: true,
+      items: [
+        { path: '/quick-setup', label: t('sidebar.nav.quickSetup'), icon: Zap },
+        { path: '/providers', label: t('sidebar.nav.providers'), icon: Server },
+        { path: '/mappings', label: t('sidebar.nav.modelMappings'), icon: ArrowLeftRight },
+        { path: '/router-keys', label: t('sidebar.nav.routerKeys'), icon: KeyRound },
+        { path: '/retry-rules', label: t('sidebar.nav.retryRules'), icon: RefreshCcw },
+        { path: '/schedules', label: t('sidebar.nav.schedules'), icon: CalendarClock },
+      ],
+    },
+    {
+      label: t('sidebar.nav.monitoring'),
+      items: [
+        { path: '/monitor', label: t('sidebar.nav.monitor'), icon: Activity },
+        { path: '/logs', label: t('sidebar.nav.logs'), icon: FileText },
+      ],
+    },
+    {
+      items: [
+        { path: '/settings', label: t('sidebar.nav.settings'), icon: Settings },
+      ],
+    },
   ] as NavGroup[]
 })
 

--- a/frontend/src/components/layout/Sidebar.vue
+++ b/frontend/src/components/layout/Sidebar.vue
@@ -177,7 +177,7 @@
         <AlertDialogHeader>
           <AlertDialogTitle>{{ t('sidebar.upgrade.confirmUpgrade', { version: upgradeStatus?.npm.latestVersion }) }}</AlertDialogTitle>
           <AlertDialogDescription>
-            {{ t('sidebar.upgrade.upgradeDesc', { command: `npm install -g llm-simple-router@${upgradeStatus?.npm.latestVersion}` }) }}
+            {{ t('sidebar.upgrade.upgradeDescBefore') }} <code class="bg-muted px-1 py-0.5 rounded text-xs">npm install -g llm-simple-router@{{ upgradeStatus?.npm.latestVersion }}</code>{{ t('sidebar.upgrade.upgradeDescAfter') }}
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>

--- a/frontend/src/components/quick-setup/types.ts
+++ b/frontend/src/components/quick-setup/types.ts
@@ -85,6 +85,11 @@ export const CONTEXT_WINDOW_OPTIONS = [
   { label: '1M', value: 1000000 },
 ]
 
+const CONTEXT_1M = 1_000_000
+const CONTEXT_128K = 128_000
+const CONTEXT_32K = 32_000
+const CONTEXT_8K = 8_000
+
 /** Default context window per model name pattern */
 export function getDefaultContextWindow(modelName: string): number {
   const m = modelName.toLowerCase()
@@ -95,12 +100,12 @@ export function getDefaultContextWindow(modelName: string): number {
     m.includes('r1') ||           // DeepSeek R1
     m.includes('reasoner') ||     // OpenAI reasoner
     m.includes('qwen3.6')         // Qwen 3.6 series
-  ) return 1000000
+  ) return CONTEXT_1M
   // Named context sizes
-  if (m.includes('128k')) return 128000
-  if (m.includes('32k')) return 32000
-  if (m.includes('8k')) return 8000
-  return 128000
+  if (m.includes('128k')) return CONTEXT_128K
+  if (m.includes('32k')) return CONTEXT_32K
+  if (m.includes('8k')) return CONTEXT_8K
+  return CONTEXT_128K
 }
 
 /** 映射目标（与后端 MappingTarget 对齐） */

--- a/frontend/src/components/quick-setup/types.ts
+++ b/frontend/src/components/quick-setup/types.ts
@@ -88,7 +88,16 @@ export const CONTEXT_WINDOW_OPTIONS = [
 /** Default context window per model name pattern */
 export function getDefaultContextWindow(modelName: string): number {
   const m = modelName.toLowerCase()
-  if (m.includes('v4') || m.includes('v3.2') || m.includes('r1') || m.includes('reasoner')) return 1000000
+  // 1M context window models
+  if (
+    m.includes('v4') ||           // DeepSeek v4
+    m.includes('v3.2') ||         // DeepSeek V3.2
+    m.includes('r1') ||           // DeepSeek R1
+    m.includes('reasoner') ||     // OpenAI reasoner
+    m.includes('minimax-m2') ||   // MiniMax M2.x series
+    m.includes('qwen3.6')         // Qwen 3.6 series
+  ) return 1000000
+  // Named context sizes
   if (m.includes('128k')) return 128000
   if (m.includes('32k')) return 32000
   if (m.includes('8k')) return 8000

--- a/frontend/src/components/quick-setup/types.ts
+++ b/frontend/src/components/quick-setup/types.ts
@@ -94,7 +94,6 @@ export function getDefaultContextWindow(modelName: string): number {
     m.includes('v3.2') ||         // DeepSeek V3.2
     m.includes('r1') ||           // DeepSeek R1
     m.includes('reasoner') ||     // OpenAI reasoner
-    m.includes('minimax-m2') ||   // MiniMax M2.x series
     m.includes('qwen3.6')         // Qwen 3.6 series
   ) return 1000000
   // Named context sizes

--- a/frontend/src/components/shared/MappingEditor.vue
+++ b/frontend/src/components/shared/MappingEditor.vue
@@ -194,7 +194,7 @@ const tagLabels: Record<string, string> = {
               <CascadingModelSelect
                 :providers="providerGroups"
                 :model-value="{ provider_id: target.provider_id, model: target.backend_model }"
-                placeholder="Select model..."
+                :placeholder="t('providers.shared.selectModel')"
                 @update:model-value="(v: SelectedValue) => updateTargetProvider(idx, tIdx, v)"
               />
             </div>

--- a/frontend/src/components/shared/MappingList.vue
+++ b/frontend/src/components/shared/MappingList.vue
@@ -199,8 +199,8 @@ function chunkTargets(targets: MappingTarget[], size = 2): MappingTarget[][] {
           </Button>
           <Switch
             v-if="editable"
-            :checked="entry.active"
-            @update:checked="emit('toggle-active', idx)"
+            :model-value="entry.active"
+            @update:model-value="emit('toggle-active', idx)"
             class="scale-75 shrink-0"
             @click.stop
           />

--- a/frontend/src/composables/useQuickSetup.ts
+++ b/frontend/src/composables/useQuickSetup.ts
@@ -40,7 +40,7 @@ export function useQuickSetup() {
   const providerGroups = ref<ProviderGroup[]>([])
   const selectedGroup = ref('')
   const selectedPlan = ref('')
-  const apiType = ref<'openai' | 'anthropic'>('anthropic')
+  const apiType = ref<'openai' | 'openai-responses' | 'anthropic'>('anthropic')
   const apiKey = ref('')
   const modelConfigs = ref<ModelConfig[]>([])
   const mappingEntries = ref<MappingEntry[]>([])
@@ -137,7 +137,7 @@ export function useQuickSetup() {
   })
 
   // --- Patch defaults ---
-  function getDefaultPatches(modelName: string, format: 'openai' | 'anthropic'): string[] {
+  function getDefaultPatches(modelName: string, format: 'openai' | 'openai-responses' | 'anthropic'): string[] {
     const patches: string[] = []
     const isDeepseek = modelName.toLowerCase().includes('deepseek')
 
@@ -156,7 +156,7 @@ export function useQuickSetup() {
     return patches
   }
 
-  function initModels(preset: { models: string[]; apiType: 'openai' | 'anthropic' }) {
+  function initModels(preset: { models: string[]; apiType: 'openai' | 'openai-responses' | 'anthropic' }) {
     modelConfigs.value = preset.models.map(name => ({
       name,
       contextWindow: getDefaultContextWindow(name),
@@ -255,7 +255,7 @@ export function useQuickSetup() {
         for (const preset of group.presets) {
           if (preset.plan === client.defaultPlan) {
             selectedPlan.value = preset.plan
-            apiType.value = preset.apiType as 'openai' | 'anthropic'
+            apiType.value = preset.apiType as 'openai' | 'openai-responses' | 'anthropic'
             initModels(preset)
             break
           }
@@ -286,7 +286,7 @@ export function useQuickSetup() {
           : null
         const preset = match ?? groupData.presets[0]
         selectedPlan.value = preset.plan
-        apiType.value = preset.apiType as 'openai' | 'anthropic'
+        apiType.value = preset.apiType as 'openai' | 'openai-responses' | 'anthropic'
         initModels(preset)
       }
     }
@@ -301,7 +301,7 @@ export function useQuickSetup() {
     if (!group) return
     const preset = group.presets.find(p => p.plan === plan)
     if (!preset) return
-    apiType.value = preset.apiType as 'openai' | 'anthropic'
+    apiType.value = preset.apiType as 'openai' | 'openai-responses' | 'anthropic'
     initModels(preset)
     updateMappings()
   }

--- a/frontend/src/i18n/locales/en/providers.json
+++ b/frontend/src/i18n/locales/en/providers.json
@@ -14,6 +14,13 @@
     "status": "Status",
     "actions": "Actions"
   },
+  "template": {
+    "title": "Template Selection",
+    "selectProvider": "Select provider template",
+    "selectPlan": "Select plan",
+    "custom": "Custom",
+    "selectFirst": "Select a template first, or use custom mode"
+  },
   "quickConfig": {
     "title": "Quick Config",
     "selectProvider": "Select Provider",

--- a/frontend/src/i18n/locales/en/sidebar.json
+++ b/frontend/src/i18n/locales/en/sidebar.json
@@ -49,6 +49,7 @@
     "configSyncSuccess": "Config synced successfully",
     "restartSent": "Restart command sent, waiting for service to recover...",
     "restartFailed": "Restart failed",
-    "upgradeDesc": "Will execute {command}. Service restart is required after upgrade."
+    "upgradeDescBefore": "Will execute",
+    "upgradeDescAfter": ". Service restart is required after upgrade."
   }
 }

--- a/frontend/src/i18n/locales/zh-CN/providers.json
+++ b/frontend/src/i18n/locales/zh-CN/providers.json
@@ -20,6 +20,13 @@
     "selectPlan": "选择套餐",
     "selectApiType": "选择 API 类型"
   },
+  "template": {
+    "title": "模板选择",
+    "selectProvider": "选择供应商模板",
+    "selectPlan": "选择套餐",
+    "custom": "自定义",
+    "selectFirst": "请先选择模板，或使用自定义模式"
+  },
   "fields": {
     "name": "名称",
     "apiType": "API 类型",

--- a/frontend/src/i18n/locales/zh-CN/sidebar.json
+++ b/frontend/src/i18n/locales/zh-CN/sidebar.json
@@ -49,6 +49,7 @@
     "configSyncSuccess": "配置同步成功",
     "restartSent": "重启指令已发送，等待服务恢复...",
     "restartFailed": "重启失败",
-    "upgradeDesc": "将执行 {command}，升级完成后需要重启服务才能生效。"
+    "upgradeDescBefore": "将执行",
+    "upgradeDescAfter": "，升级完成后需要重启服务才能生效。"
   }
 }

--- a/frontend/src/views/Logs.vue
+++ b/frontend/src/views/Logs.vue
@@ -26,9 +26,9 @@
         </Button>
       </div>
       <div class="flex items-center gap-1">
-        <Input type="datetime-local" v-model="dateRange.start" class="w-48" />
-        <span class="text-muted-foreground text-sm">~</span>
-        <Input type="datetime-local" v-model="dateRange.end" class="w-48" />
+        <Input type="datetime-local" v-model="dateRange.start" class="w-44" />
+        <span class="text-muted-foreground text-sm">-</span>
+        <Input type="datetime-local" v-model="dateRange.end" class="w-44" />
         <Button
           v-if="dateRange.start || dateRange.end"
           variant="ghost"

--- a/frontend/src/views/Providers.vue
+++ b/frontend/src/views/Providers.vue
@@ -86,76 +86,90 @@
     </div>
     <!-- Create/Edit Dialog -->
     <Dialog v-model:open="dialogOpen">
-      <DialogContent>
+      <DialogContent class="sm:max-w-4xl max-h-[85vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>{{ editingId ? t('providers.editProvider') : t('providers.addProvider') }}</DialogTitle>
         </DialogHeader>
-        <form @submit.prevent="handleSave" class="space-y-3">
-          <!-- 快速配置 -->
-          <div class="rounded-md border bg-muted/40 p-3 space-y-2">
-            <div class="text-xs font-medium text-muted-foreground">{{ t('providers.quickConfig.title') }}</div>
+        <form @submit.prevent="handleSave" class="space-y-4">
+          <!-- 模板选择 (仅新建模式) -->
+          <div v-if="!editingId" class="rounded-md border-2 border-primary/30 bg-primary/5 p-3 space-y-2">
+            <div class="flex items-center gap-1.5 text-xs font-semibold text-primary">
+              <svg class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
+              {{ t('providers.template.title') }}
+            </div>
             <div class="flex gap-2">
               <Select v-model="presetGroup" @update:model-value="onGroupChange">
-                <SelectTrigger class="flex-1">
-                  <SelectValue :placeholder="t('providers.quickConfig.selectProvider')" />
-                </SelectTrigger>
+                <SelectTrigger class="flex-1 border-primary/40"><SelectValue :placeholder="t('providers.template.selectProvider')" /></SelectTrigger>
                 <SelectContent>
+                  <SelectItem value="__custom__">{{ t('providers.template.custom') }}</SelectItem>
                   <SelectItem v-for="g in providerPresets" :key="g.group" :value="g.group">{{ g.group }}</SelectItem>
                 </SelectContent>
               </Select>
-              <Select v-model="presetPlan" @update:model-value="onPresetChange" :disabled="!presetGroup">
-                <SelectTrigger class="flex-1">
-                  <SelectValue :placeholder="t('providers.quickConfig.selectPlan')" />
-                </SelectTrigger>
+              <Select v-if="presetGroup !== '__custom__'" v-model="presetPlan" @update:model-value="onPresetChange" :disabled="!presetGroup || presetGroup === '__custom__'">
+                <SelectTrigger class="flex-1 border-primary/40"><SelectValue :placeholder="t('providers.template.selectPlan')" /></SelectTrigger>
                 <SelectContent>
                   <SelectItem v-for="p in availablePlans" :key="p.plan" :value="p.plan">{{ p.plan }}</SelectItem>
                 </SelectContent>
               </Select>
             </div>
           </div>
-          <div>
-            <Label class="block text-sm font-medium text-foreground mb-1">{{ t('providers.fields.name') }}</Label>
-            <Input v-model="form.name" type="text" required @input="delete errors.name" />
-            <p v-if="errors.name" class="text-sm text-destructive mt-1">{{ errors.name }}</p>
+
+          <!-- 未选模板提示 (仅新建模式) -->
+          <div v-if="!presetGroup && !editingId" class="flex flex-col items-center justify-center py-10 text-muted-foreground">
+            <svg class="w-10 h-10 mb-3 opacity-30" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M9 12l2 2 4-4"/></svg>
+            <span class="text-sm">{{ t('providers.template.selectFirst') }}</span>
           </div>
-          <div>
-            <Label class="block text-sm font-medium text-foreground mb-1">{{ t('providers.fields.apiType') }}</Label>
-            <Select v-model="form.api_type">
-              <SelectTrigger>
-                <SelectValue :placeholder="t('providers.quickConfig.selectApiType')" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="openai">OpenAI Chat Completions</SelectItem>
-                <SelectItem value="openai-responses">OpenAI Responses</SelectItem>
-                <SelectItem value="anthropic">Anthropic Messages</SelectItem>
-              </SelectContent>
-            </Select>
+
+          <template v-if="presetGroup || editingId">
+          <!-- 基本信息 2x2 -->
+          <div class="grid grid-cols-2 gap-3">
+            <div>
+              <Label class="text-xs text-muted-foreground">{{ t('providers.fields.name') }}</Label>
+              <Input v-model="form.name" type="text" required class="mt-1" @input="delete errors.name" />
+              <p v-if="errors.name" class="text-xs text-destructive mt-0.5">{{ errors.name }}</p>
+            </div>
+            <div>
+              <Label class="text-xs text-muted-foreground">{{ t('providers.fields.apiType') }}</Label>
+              <Select v-model="form.api_type" class="mt-1">
+                <SelectTrigger><SelectValue :placeholder="t('common.pleaseSelect')" /></SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="openai">OpenAI Chat Completions</SelectItem>
+                  <SelectItem value="openai-responses">OpenAI Responses</SelectItem>
+                  <SelectItem value="anthropic">Anthropic Messages</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div>
+              <Label class="text-xs text-muted-foreground">{{ t('providers.fields.baseUrl') }}</Label>
+              <Input v-model="form.base_url" type="url" required class="mt-1 font-mono text-xs" @input="delete errors.base_url" />
+              <p v-if="errors.base_url" class="text-xs text-destructive mt-0.5">{{ errors.base_url }}</p>
+            </div>
+            <div>
+              <Label class="text-xs text-muted-foreground">{{ t('providers.fields.apiKey') }}</Label>
+              <Input v-model="form.api_key" type="text" :required="!editingId" :placeholder="editingId ? t('providers.fields.apiKeyPlaceholder') : ''" class="mt-1" @input="delete errors.api_key" />
+              <p v-if="errors.api_key" class="text-xs text-destructive mt-0.5">{{ errors.api_key }}</p>
+            </div>
           </div>
+
+          <!-- 可用模型 -->
           <div>
-            <Label class="block text-sm font-medium text-foreground mb-1">{{ t('providers.fields.baseUrl') }}</Label>
-            <Input v-model="form.base_url" type="url" required @input="delete errors.base_url" />
-            <p v-if="errors.base_url" class="text-sm text-destructive mt-1">{{ errors.base_url }}</p>
-          </div>
-          <div>
-            <Label class="block text-sm font-medium text-foreground mb-1">{{ t('providers.fields.apiKey') }}</Label>
-            <Input v-model="form.api_key" type="text" :required="!editingId" :placeholder="editingId ? t('providers.fields.apiKeyPlaceholder') : ''" @input="delete errors.api_key" />
-            <p v-if="errors.api_key" class="text-sm text-destructive mt-1">{{ errors.api_key }}</p>
-          </div>
-          <div>
-            <Label class="block text-sm font-medium text-foreground mb-1">{{ t('providers.fields.availableModels') }}</Label>
-            <div class="flex flex-wrap gap-1.5 mb-1.5">
-              <Badge v-for="(m, i) in form.models" :key="i" variant="secondary" class="gap-1 pr-1">
-                {{ m.name }}
-                <span class="text-muted-foreground">({{ formatContextWindow(m.context_window ?? DEFAULT_CONTEXT_WINDOW) }})</span>
-                <Button type="button" variant="ghost" size="icon" class="h-4 w-4 rounded-full hover:bg-muted p-0 text-xs leading-none" @click="removeModel(i)">&times;</Button>
-              </Badge>
+            <Label class="text-xs text-muted-foreground mb-2">{{ t('providers.fields.availableModels') }}</Label>
+            <div class="grid grid-cols-3 gap-2 mb-3">
+              <div v-for="(m, i) in form.models" :key="i">
+                <ModelCard
+                  :model="{ name: m.name, contextWindow: m.context_window ?? 200000, enabled: true, patches: m.patches ?? [] }"
+                  :api-type="form.api_type"
+                  :is-deep-seek="m.name.toLowerCase().includes('deepseek')"
+                  :is-non-openai-endpoint="!isOfficialOpenai(form.base_url)"
+                  @update:model="updateModel(i, $event)"
+                  @remove="removeModel(i)"
+                />
+              </div>
             </div>
             <div class="flex gap-2">
               <Input v-model="modelInput" :placeholder="t('providers.fields.modelInputPlaceholder')" @keydown.enter.prevent="addModel" class="flex-1" />
               <Select v-model="contextWindowSelect">
-                <SelectTrigger class="w-28">
-                  <SelectValue :placeholder="t('providers.fields.context')" />
-                </SelectTrigger>
+                <SelectTrigger class="w-28"><SelectValue :placeholder="t('providers.fields.context')" /></SelectTrigger>
                 <SelectContent>
                   <SelectItem v-for="opt in CONTEXT_WINDOW_OPTIONS" :key="opt.value" :value="opt.value">{{ opt.label }}</SelectItem>
                 </SelectContent>
@@ -163,55 +177,41 @@
               <Button type="button" variant="outline" size="sm" @click="addModel" :disabled="!modelInput.trim()">{{ t('providers.fields.addModel') }}</Button>
             </div>
           </div>
-          <!-- 并发控制 -->
-          <div class="border-t pt-4 mt-4">
-            <div class="text-sm font-medium text-foreground mb-3">{{ t('providers.concurrency.title') }}</div>
-            <div class="space-y-3">
-              <div>
-                <Label class="block text-sm font-medium text-foreground mb-1">{{ t('providers.concurrency.mode') }}</Label>
-                <Select v-model="concurrencyMode" @update:model-value="(v: unknown) => onConcurrencyModeChange(v as 'auto' | 'manual' | 'none')">
-                  <SelectTrigger>
-                    <SelectValue :placeholder="t('providers.concurrency.selectMode')" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="auto">{{ t('providers.concurrency.autoAdaptive') }}</SelectItem>
-                    <SelectItem value="manual">{{ t('providers.concurrency.manual') }}</SelectItem>
-                    <SelectItem value="none">{{ t('providers.concurrency.none') }}</SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
-              <div v-if="concurrencyMode !== 'none'" class="space-y-2">
-                <div>
-                  <Label class="block text-sm font-medium text-foreground mb-1">{{ t('providers.concurrency.maxConcurrency') }}</Label>
-                  <Input v-model.number="form.max_concurrency" type="number" min="1" :max="MAX_CONCURRENCY" :placeholder="concurrencyMode === 'auto' ? '10' : '3'" @input="delete errors.max_concurrency" />
-                  <p v-if="errors.max_concurrency" class="text-sm text-destructive mt-1">{{ errors.max_concurrency }}</p>
-                </div>
-                <div>
-                  <Label class="block text-sm font-medium text-foreground mb-1">{{ t('providers.concurrency.queueTimeout') }}</Label>
-                  <Input v-model.number="form.queue_timeout_ms" type="number" min="0" :placeholder="t('providers.concurrency.queueTimeoutPlaceholder')" @input="delete errors.queue_timeout_ms" />
-                  <p v-if="errors.queue_timeout_ms" class="text-sm text-destructive mt-1">{{ errors.queue_timeout_ms }}</p>
-                </div>
-                <div>
-                  <Label class="block text-sm font-medium text-foreground mb-1">{{ t('providers.concurrency.maxQueueSize') }}</Label>
-                  <Input v-model.number="form.max_queue_size" type="number" min="1" :max="MAX_QUEUE_SIZE" :placeholder="DEFAULT_QUEUE_SIZE" @input="delete errors.max_queue_size" />
-                  <p v-if="errors.max_queue_size" class="text-sm text-destructive mt-1">{{ errors.max_queue_size }}</p>
-                </div>
-              </div>
+
+          <!-- 并发控制 + 转换规则 2 columns -->
+          <div class="grid grid-cols-2 gap-4">
+            <!-- 并发控制 -->
+            <div class="border rounded-md p-3 space-y-3">
+              <div class="text-xs font-medium text-muted-foreground">{{ t('providers.concurrency.title') }}</div>
+              <ConcurrencyControl
+                :mode="concurrencyMode"
+                :max-concurrency="form.max_concurrency"
+                :queue-timeout-ms="form.queue_timeout_ms"
+                :max-queue-size="form.max_queue_size"
+                compact
+                @update:mode="(v: unknown) => onConcurrencyModeChange(v as 'auto' | 'manual' | 'none')"
+                @update:max-concurrency="form.max_concurrency = $event"
+                @update:queue-timeout-ms="form.queue_timeout_ms = $event"
+                @update:max-queue-size="form.max_queue_size = $event"
+              />
+            </div>
+
+            <!-- 转换规则 -->
+            <div class="border rounded-md p-3 space-y-3">
+              <div class="text-xs font-medium text-muted-foreground">{{ t('providers.transform.title') }}</div>
+              <TransformRulesForm
+                :inject-headers="transformForm.injectHeadersInput"
+                :drop-fields="transformForm.dropFieldsInput"
+                :request-defaults="transformForm.requestDefaultsInput"
+                @update:inject-headers="transformForm.injectHeadersInput = $event"
+                @update:drop-fields="transformForm.dropFieldsInput = $event"
+                @update:request-defaults="transformForm.requestDefaultsInput = $event"
+              />
             </div>
           </div>
-          <!-- 转换规则面板（仅在编辑现有 Provider 时显示） -->
-          <Collapsible v-if="editingId" v-model:open="transformOpen" class="border rounded-md p-3 mt-2">
-            <CollapsibleTrigger class="flex items-center justify-between w-full text-sm font-medium text-foreground">
-              {{ t('providers.transform.title') }}
-              <ChevronDown class="w-4 h-4 transition-transform" :class="transformOpen ? 'rotate-180' : ''" />
-            </CollapsibleTrigger>
-            <CollapsibleContent class="mt-3 space-y-3">
-              <div><Label class="text-xs text-muted-foreground">{{ t('providers.transform.injectHeaders') }}</Label><Input v-model="transformForm.injectHeadersInput" placeholder='{"x-custom": "value"}' class="mt-1" /></div>
-              <div><Label class="text-xs text-muted-foreground">{{ t('providers.transform.dropFields') }}</Label><Input v-model="transformForm.dropFieldsInput" placeholder="logprobs, frequency_penalty" class="mt-1" /></div>
-              <div><Label class="text-xs text-muted-foreground">{{ t('providers.transform.requestDefaults') }}</Label><Input v-model="transformForm.requestDefaultsInput" placeholder='{"max_tokens": 4096}' class="mt-1" /></div>
-              <div class="flex gap-2"><Button type="button" variant="outline" size="sm" @click="saveTransformRules(editingId!)">{{ t('providers.transform.saveRules') }}</Button><Button type="button" variant="ghost" size="sm" @click="handleDeleteTransformRules(editingId!)" v-if="transformForm.exists">{{ t('providers.transform.deleteRules') }}</Button></div>
-            </CollapsibleContent>
-          </Collapsible>
+
+          </template>
+
           <DialogFooter>
             <Button type="button" variant="outline" @click="dialogOpen = false">{{ t('common.cancel') }}</Button>
             <Button type="submit">{{ t('common.save') }}</Button>
@@ -269,8 +269,11 @@ import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@
 import { Table, TableHeader, TableBody, TableRow, TableHead, TableCell } from '@/components/ui/table'
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog'
 import { AlertDialog, AlertDialogContent, AlertDialogHeader, AlertDialogTitle, AlertDialogDescription, AlertDialogFooter, AlertDialogCancel, AlertDialogAction } from '@/components/ui/alert-dialog'
-import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
-import { ChevronDown, RotateCw, Copy, Check } from 'lucide-vue-next'
+import { RotateCw, Copy, Check } from 'lucide-vue-next'
+import ConcurrencyControl from '@/components/shared/ConcurrencyControl.vue'
+import TransformRulesForm from '@/components/shared/TransformRulesForm.vue'
+import ModelCard from '@/components/quick-setup/ModelCard.vue'
+import type { ModelConfig } from '@/components/quick-setup/types'
 import { useTransformRules } from '@/composables/useTransformRules'
 const DEFAULT_CONCURRENCY = 3
 const DEFAULT_CONCURRENCY_AUTO = 10
@@ -313,9 +316,8 @@ const errors = ref<Record<string, string>>({})
 type ConcurrencyMode = 'auto' | 'manual' | 'none'
 const concurrencyMode = ref<ConcurrencyMode>('auto')
 // Transform rules state
-const transformOpen = ref(false)
 const { t } = useI18n()
-const { transformForm, loadTransformRules, saveTransformRules, handleDeleteTransformRules } = useTransformRules()
+const { transformForm, loadTransformRules, saveTransformRules } = useTransformRules()
 const copiedId = ref<string | null>(null)
 const reloading = ref(false)
 const MASK_VISIBLE_LEN = 7, MASK_ASTERISK_COUNT = 7, COPY_FEEDBACK_MS = 2000
@@ -364,6 +366,14 @@ const availablePlans = computed(() => {
   return providerPresets.value.find(g => g.group === presetGroup.value)?.presets ?? []
 })
 function onGroupChange() {
+  if (presetGroup.value === '__custom__') {
+    presetPlan.value = ''
+    form.value.name = ''
+    form.value.api_type = 'openai'
+    form.value.base_url = ''
+    form.value.models = []
+    return
+  }
   const plans = providerPresets.value.find(g => g.group === presetGroup.value)?.presets
   if (plans?.length) {
     presetPlan.value = plans[0].plan
@@ -381,7 +391,7 @@ function onPresetChange() {
   form.value.models = preset.models.map(name => ({
     name,
     context_window: DEFAULT_CONTEXT_WINDOW,
-    patches: [],
+    patches: getDefaultPatches(name, preset.apiType),
   }))
 }
 async function loadProviders() {
@@ -407,6 +417,27 @@ function addModel() {
 }
 function removeModel(index: number) {
   form.value.models.splice(index, 1)
+}
+
+function isOfficialOpenai(url: string): boolean {
+  return url.includes('api.openai.com')
+}
+
+function updateModel(index: number, updated: ModelConfig) {
+  form.value.models[index].context_window = updated.contextWindow
+  form.value.models[index].patches = updated.patches
+}
+
+function getDefaultPatches(modelName: string, apiType: string): string[] {
+  const patches: string[] = []
+  if (modelName.toLowerCase().includes('deepseek')) {
+    if (apiType === 'anthropic') {
+      patches.push('thinking-param', 'cache-control', 'thinking-blocks', 'orphan-tool-results')
+    } else {
+      patches.push('non-ds-tools', 'orphan-tool-results-oa')
+    }
+  }
+  return patches
 }
 
 function onConcurrencyModeChange(mode: ConcurrencyMode) {
@@ -457,7 +488,7 @@ function buildPayload(): ProviderFormPayload {
     name: form.value.name,
     api_type: form.value.api_type,
     base_url: form.value.base_url,
-    models: form.value.models.map(m => ({ name: m.name, context_window: m.context_window ?? undefined, patches: m.patches ?? [] })),
+    models: form.value.models.map(m => ({ name: m.name, context_window: m.context_window ?? undefined, patches: m.patches ?? undefined })),
     is_active: form.value.is_active ? 1 : 0,
     max_concurrency: concurrencyMode.value === 'none' ? 0 : form.value.max_concurrency,
     queue_timeout_ms: concurrencyMode.value === 'none' ? 0 : form.value.queue_timeout_ms,
@@ -472,12 +503,16 @@ async function handleSave() {
   try {
     const payload = buildPayload()
     payload.name = form.value.name.trim()
+    let providerId = editingId.value
     if (editingId.value) {
       await api.updateProvider(editingId.value, payload)
     } else {
       payload.api_key = form.value.api_key
-      await api.createProvider(payload)
+      const result = await api.createProvider(payload)
+      providerId = result.id
     }
+    // Save transform rules along with the provider
+    await saveTransformRules(providerId)
     dialogOpen.value = false
     await loadProviders()
   } catch (e: unknown) {
@@ -530,7 +565,6 @@ async function handleDelete() {
     await api.deleteProvider(target.id)
     await loadProviders()
   } catch (e: unknown) {
-    console.error('Failed to delete provider:', e)
     toast.error(getApiMessage(e, t('providers.toast.deleteFailed')))
   }
 }

--- a/frontend/src/views/Providers.vue
+++ b/frontend/src/views/Providers.vue
@@ -260,7 +260,7 @@ import { toast } from 'vue-sonner'
 import * as z from 'zod'
 import { api, getApiMessage, type ProviderPayload, type ProviderGroup } from '@/api/client'
 import type { Provider, ModelInfo } from '@/types/mapping'
-import { DEFAULT_CONTEXT_WINDOW } from '@/constants'
+import { DEFAULT_CONTEXT_WINDOW, getDefaultContextWindow } from '@/constants'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -390,7 +390,7 @@ function onPresetChange() {
   form.value.base_url = preset.baseUrl
   form.value.models = preset.models.map(name => ({
     name,
-    context_window: DEFAULT_CONTEXT_WINDOW,
+    context_window: getDefaultContextWindow(name),
     patches: getDefaultPatches(name, preset.apiType),
   }))
 }

--- a/frontend/src/views/Providers.vue
+++ b/frontend/src/views/Providers.vue
@@ -32,7 +32,7 @@
           <TableRow v-for="p in providers" :key="p.id" :class="{ 'opacity-60': !p.is_active }">
             <TableCell class="font-medium">{{ p.name }}</TableCell>
             <TableCell>
-              <Badge variant="secondary">{{ p.api_type }}</Badge>
+              <Badge variant="secondary">{{ API_TYPE_LABELS[p.api_type] ?? p.api_type }}</Badge>
             </TableCell>
             <TableCell class="text-muted-foreground">{{ p.base_url }}</TableCell>
             <TableCell>
@@ -125,8 +125,9 @@
                 <SelectValue :placeholder="t('providers.quickConfig.selectApiType')" />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="openai">OpenAI</SelectItem>
-                <SelectItem value="anthropic">Anthropic</SelectItem>
+                <SelectItem value="openai">OpenAI Chat Completions</SelectItem>
+                <SelectItem value="openai-responses">OpenAI Responses</SelectItem>
+                <SelectItem value="anthropic">Anthropic Messages</SelectItem>
               </SelectContent>
             </Select>
           </div>
@@ -290,6 +291,7 @@ const CONTEXT_WINDOW_OPTIONS = [
   { label: '256K', value: '256000' },
   { label: '1M', value: '1000000' },
 ] as const
+const API_TYPE_LABELS: Record<string, string> = { openai: 'OpenAI Chat Completions', 'openai-responses': 'OpenAI Responses', anthropic: 'Anthropic Messages' }
 const DEFAULT_FORM = { name: '', api_type: 'anthropic', base_url: '', api_key: '', models: [] as ModelInfo[], is_active: true, max_concurrency: DEFAULT_CONCURRENCY_AUTO, queue_timeout_ms: DEFAULT_QUEUE_TIMEOUT_MS, max_queue_size: DEFAULT_QUEUE_SIZE, adaptive_enabled: true }
 const modelInput = ref('')
 const modelContextWindow = ref(DEFAULT_CONTEXT_WINDOW)

--- a/frontend/src/views/QuickSetup.vue
+++ b/frontend/src/views/QuickSetup.vue
@@ -300,7 +300,7 @@
 import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { toast } from 'vue-sonner'
-import { useQuickSetup, type ConcurrencyMode } from '@/composables/useQuickSetup'
+import { useQuickSetup } from '@/composables/useQuickSetup'
 import ModelCard from '@/components/quick-setup/ModelCard.vue'
 import MappingList from '@/components/shared/MappingList.vue'
 import ConcurrencyControl from '@/components/shared/ConcurrencyControl.vue'

--- a/frontend/src/views/QuickSetup.vue
+++ b/frontend/src/views/QuickSetup.vue
@@ -59,8 +59,9 @@
               <Select v-model="apiType">
                 <SelectTrigger class="w-full"><SelectValue /></SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="anthropic">Anthropic</SelectItem>
-                  <SelectItem value="openai">OpenAI</SelectItem>
+                  <SelectItem value="anthropic">Anthropic Messages</SelectItem>
+                  <SelectItem value="openai">OpenAI Chat Completions</SelectItem>
+                  <SelectItem value="openai-responses">OpenAI Responses</SelectItem>
                 </SelectContent>
               </Select>
             </div>
@@ -85,8 +86,9 @@
               <Select v-model="apiType">
                 <SelectTrigger class="w-full"><SelectValue /></SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="anthropic">Anthropic</SelectItem>
-                  <SelectItem value="openai">OpenAI</SelectItem>
+                  <SelectItem value="anthropic">Anthropic Messages</SelectItem>
+                  <SelectItem value="openai">OpenAI Chat Completions</SelectItem>
+                  <SelectItem value="openai-responses">OpenAI Responses</SelectItem>
                 </SelectContent>
               </Select>
             </div>

--- a/frontend/src/views/QuickSetup.vue
+++ b/frontend/src/views/QuickSetup.vue
@@ -54,7 +54,7 @@
           </div>
           <!-- Custom mode: show format + editable base url -->
           <template v-if="isCustomProvider">
-            <div class="w-28 space-y-1">
+            <div class="w-48 space-y-1">
               <Label class="text-xs text-muted-foreground">{{ t('quickSetup.provider.format') }}</Label>
               <Select v-model="apiType">
                 <SelectTrigger class="w-full"><SelectValue /></SelectTrigger>
@@ -81,7 +81,7 @@
                 </SelectContent>
               </Select>
             </div>
-            <div class="w-28 space-y-1">
+            <div class="w-48 space-y-1">
               <Label class="text-xs text-muted-foreground">{{ t('quickSetup.provider.format') }}</Label>
               <Select v-model="apiType">
                 <SelectTrigger class="w-full"><SelectValue /></SelectTrigger>
@@ -92,7 +92,7 @@
                 </SelectContent>
               </Select>
             </div>
-            <div class="w-80 space-y-1">
+            <div class="w-72 space-y-1">
               <Label class="text-xs text-muted-foreground">Base URL</Label>
               <Input :model-value="baseUrl" readonly class="font-mono text-xs" />
             </div>

--- a/frontend/src/views/RetryRules.vue
+++ b/frontend/src/views/RetryRules.vue
@@ -198,6 +198,8 @@ import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/component
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { ChevronDown } from 'lucide-vue-next'
 
+const { t } = useI18n()
+
 interface RetryRule {
   id: string
   name: string
@@ -225,8 +227,6 @@ const editingId = ref<string | null>(null)
 const deleteTarget = ref<RetryRule | null>(null)
 const form = ref({ ...DEFAULT_FORM })
 const errors = ref<Record<string, string>>({})
-
-const { t } = useI18n()
 
 const MIN_STATUS_CODE = 100
 const MAX_STATUS_CODE = 599

--- a/frontend/src/views/RouterKeys.vue
+++ b/frontend/src/views/RouterKeys.vue
@@ -143,6 +143,8 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '
 import { AlertDialog, AlertDialogContent, AlertDialogHeader, AlertDialogTitle, AlertDialogDescription, AlertDialogFooter, AlertDialogCancel } from '@/components/ui/alert-dialog'
 import { Checkbox } from '@/components/ui/checkbox'
 
+const { t } = useI18n()
+
 interface RouterKey {
   id: string
   name: string
@@ -153,8 +155,6 @@ interface RouterKey {
   created_at: string
 }
 
-const { t } = useI18n()
-
 const DEFAULT_FORM = { name: '', allowed_models: [] as string[], is_active: true }
 
 const keys = ref<RouterKey[]>([])
@@ -164,6 +164,7 @@ const editingId = ref<string | null>(null)
 const deleteTarget = ref<RouterKey | null>(null)
 const form = ref({ ...DEFAULT_FORM, allowed_models: [] as string[] })
 const errors = ref<Record<string, string>>({})
+
 const { copied: tableCopied, copy: tableCopy } = useClipboard()
 
 function maskKey(key: string | null): string {

--- a/src/admin/quick-setup.ts
+++ b/src/admin/quick-setup.ts
@@ -20,7 +20,7 @@ const API_KEY_PREVIEW_PREFIX_LEN = 4;
 
 const QuickSetupProviderSchema = Type.Object({
   name: Type.String({ minLength: 1 }),
-  api_type: Type.Union([Type.Literal("openai"), Type.Literal("anthropic")]),
+  api_type: Type.Union([Type.Literal("openai"), Type.Literal("openai-responses"), Type.Literal("anthropic")]),
   base_url: Type.String({ minLength: 1 }),
   api_key: Type.String({ minLength: 1 }),
   models: Type.Array(Type.Object({

--- a/src/config/recommended.ts
+++ b/src/config/recommended.ts
@@ -4,7 +4,7 @@ import path from 'path'
 export interface ProviderPreset {
   plan: string
   presetName: string
-  apiType: 'openai' | 'anthropic'
+  apiType: 'openai' | 'openai-responses' | 'anthropic'
   baseUrl: string
   models: string[]
 }

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -16,6 +16,8 @@ export const PROXY_API_TYPES: Record<string, string> = {
   "/v1/chat/completions": "openai",
   "/v1/models": "openai",
   "/v1/messages": "anthropic",
+  "/v1/responses": "openai-responses",
+  "/responses": "openai-responses",
 };
 
 export function getProxyApiType(url: string): string | null {

--- a/src/db/migrations/035_add_openai_responses_api_type.sql
+++ b/src/db/migrations/035_add_openai_responses_api_type.sql
@@ -1,0 +1,36 @@
+-- Allow 'openai-responses' as a valid api_type for OpenAI Responses API support
+-- The providers table was renamed from backend_services in migration 005
+
+-- Remove the old CHECK constraint by recreating the table is not practical,
+-- so we use a workaround: SQLite doesn't support ALTER TABLE ... DROP CONSTRAINT,
+-- but we can recreate the table with the updated constraint.
+
+-- However, since the table name might be 'providers' (renamed in 005),
+-- we need to handle both cases. Let's use the simpler approach:
+
+-- Step 1: Create a new table with the updated constraint
+CREATE TABLE IF NOT EXISTS providers_new (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL UNIQUE,
+  api_type TEXT NOT NULL CHECK(api_type IN ('openai', 'openai-responses', 'anthropic')),
+  base_url TEXT NOT NULL,
+  api_key TEXT NOT NULL,
+  api_key_preview TEXT,
+  models TEXT,
+  is_active INTEGER NOT NULL DEFAULT 1,
+  max_concurrency INTEGER,
+  queue_timeout_ms INTEGER,
+  max_queue_size INTEGER,
+  adaptive_enabled INTEGER DEFAULT 0,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+-- Step 2: Copy data from the old table
+INSERT INTO providers_new SELECT * FROM providers;
+
+-- Step 3: Drop the old table
+DROP TABLE providers;
+
+-- Step 4: Rename the new table
+ALTER TABLE providers_new RENAME TO providers;

--- a/src/db/migrations/035_add_openai_responses_api_type.sql
+++ b/src/db/migrations/035_add_openai_responses_api_type.sql
@@ -1,36 +1,67 @@
--- Allow 'openai-responses' as a valid api_type for OpenAI Responses API support
--- The providers table was renamed from backend_services in migration 005
+-- Expand api_type CHECK constraint to include 'openai-responses'
+-- SQLite doesn't support ALTER TABLE ... ALTER CONSTRAINT, so we recreate the table.
+-- We must temporarily drop referencing foreign key tables and recreate them after.
 
--- Remove the old CHECK constraint by recreating the table is not practical,
--- so we use a workaround: SQLite doesn't support ALTER TABLE ... DROP CONSTRAINT,
--- but we can recreate the table with the updated constraint.
+-- Note: This migration runs inside db.transaction() in the migration runner,
+-- so we don't need our own BEGIN/COMMIT. PRAGMA foreign_keys doesn't work
+-- inside transactions, so we handle FK tables explicitly instead.
 
--- However, since the table name might be 'providers' (renamed in 005),
--- we need to handle both cases. Let's use the simpler approach:
+-- Step 1: Save referencing table data as temp tables
+CREATE TABLE IF NOT EXISTS _tmp_provider_model_info AS SELECT * FROM provider_model_info;
+CREATE TABLE IF NOT EXISTS _tmp_provider_transform_rules AS SELECT * FROM provider_transform_rules;
 
--- Step 1: Create a new table with the updated constraint
-CREATE TABLE IF NOT EXISTS providers_new (
+-- Step 2: Drop referencing tables
+DROP TABLE IF EXISTS provider_model_info;
+DROP TABLE IF EXISTS provider_transform_rules;
+
+-- Step 3: Recreate providers with expanded CHECK
+CREATE TABLE providers_new (
   id TEXT PRIMARY KEY,
   name TEXT NOT NULL UNIQUE,
   api_type TEXT NOT NULL CHECK(api_type IN ('openai', 'openai-responses', 'anthropic')),
   base_url TEXT NOT NULL,
   api_key TEXT NOT NULL,
   api_key_preview TEXT,
-  models TEXT,
+  models TEXT NOT NULL DEFAULT '[]',
   is_active INTEGER NOT NULL DEFAULT 1,
-  max_concurrency INTEGER,
-  queue_timeout_ms INTEGER,
-  max_queue_size INTEGER,
-  adaptive_enabled INTEGER DEFAULT 0,
+  max_concurrency INTEGER NOT NULL DEFAULT 0,
+  queue_timeout_ms INTEGER NOT NULL DEFAULT 0,
+  max_queue_size INTEGER NOT NULL DEFAULT 100,
+  adaptive_enabled INTEGER NOT NULL DEFAULT 0,
+  adaptive_min INTEGER NOT NULL DEFAULT 1,
   created_at TEXT NOT NULL,
   updated_at TEXT NOT NULL
 );
 
--- Step 2: Copy data from the old table
 INSERT INTO providers_new SELECT * FROM providers;
-
--- Step 3: Drop the old table
 DROP TABLE providers;
-
--- Step 4: Rename the new table
 ALTER TABLE providers_new RENAME TO providers;
+
+-- Step 4: Recreate referencing tables with their original schemas
+CREATE TABLE provider_model_info (
+  provider_id TEXT NOT NULL,
+  model_name TEXT NOT NULL,
+  context_window INTEGER NOT NULL,
+  PRIMARY KEY (provider_id, model_name),
+  FOREIGN KEY (provider_id) REFERENCES providers(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS provider_transform_rules (
+  provider_id TEXT PRIMARY KEY REFERENCES providers(id) ON DELETE CASCADE,
+  inject_headers TEXT,
+  request_defaults TEXT,
+  drop_fields TEXT,
+  field_overrides TEXT,
+  plugin_name TEXT,
+  is_active INTEGER DEFAULT 1,
+  created_at TEXT DEFAULT (datetime('now')),
+  updated_at TEXT DEFAULT (datetime('now'))
+);
+
+-- Step 5: Restore data
+INSERT INTO provider_model_info SELECT * FROM _tmp_provider_model_info;
+INSERT OR IGNORE INTO provider_transform_rules SELECT * FROM _tmp_provider_transform_rules;
+
+-- Step 6: Cleanup
+DROP TABLE _tmp_provider_model_info;
+DROP TABLE _tmp_provider_transform_rules;

--- a/src/db/providers.ts
+++ b/src/db/providers.ts
@@ -5,7 +5,7 @@ import { buildUpdateQuery, deleteById } from "./helpers.js";
 export interface Provider {
   id: string;
   name: string;
-  api_type: "openai" | "anthropic";
+  api_type: "openai" | "openai-responses" | "anthropic";
   base_url: string;
   api_key: string;
   api_key_preview?: string;
@@ -31,7 +31,7 @@ const PROVIDER_FIELDS = new Set([
 
 export function getActiveProviders(
   db: Database.Database,
-  apiType: "openai" | "anthropic",
+  apiType: "openai" | "openai-responses" | "anthropic",
 ): Provider[] {
   return db
     .prepare("SELECT * FROM providers WHERE api_type = ? AND is_active = 1")
@@ -50,7 +50,7 @@ export function createProvider(
   db: Database.Database,
   provider: {
     name: string;
-    api_type: "openai" | "anthropic";
+    api_type: "openai" | "openai-responses" | "anthropic";
     base_url: string;
     api_key: string;
     api_key_preview?: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ import { loadRecommendedConfig } from "./config/recommended.js";
 import { authMiddleware } from "./middleware/auth.js";
 import { openaiProxy } from "./proxy/handler/openai.js";
 import { anthropicProxy } from "./proxy/handler/anthropic.js";
+import { responsesProxy } from "./proxy/handler/responses.js";
 import { adminRoutes } from "./admin/routes.js";
 import { RetryRuleMatcher } from "./proxy/orchestration/retry-rules.js";
 import { PluginRegistry } from "./proxy/transform/plugin-registry.js";
@@ -272,6 +273,7 @@ export async function buildApp(
   app.register(authMiddleware, { db });
   app.register(openaiProxy, { db, container });
   app.register(anthropicProxy, { db, container });
+  app.register(responsesProxy, { db, container });
 
   // StateRegistry — Admin 层通过此接口触发 proxy 层状态刷新，消除 admin→proxy 依赖
   const stateRegistry: StateRegistry = {

--- a/src/metrics/metrics-extractor.ts
+++ b/src/metrics/metrics-extractor.ts
@@ -65,7 +65,7 @@ export class MetricsExtractor {
   private toolUseStreamStartTime: number | null = null;
 
   constructor(
-    private apiType: "openai" | "anthropic",
+    private apiType: "openai" | "openai-responses" | "anthropic",
     private requestStartTime: number,
   ) {}
 
@@ -158,7 +158,7 @@ export class MetricsExtractor {
   }
 
   static fromNonStreamResponse(
-    apiType: "openai" | "anthropic",
+    apiType: "openai" | "openai-responses" | "anthropic",
     responseBody: string,
   ): MetricsResult | null {
     let parsed: Record<string, unknown>;

--- a/src/metrics/metrics-extractor.ts
+++ b/src/metrics/metrics-extractor.ts
@@ -74,6 +74,8 @@ export class MetricsExtractor {
 
     if (this.apiType === "anthropic") {
       this.processAnthropicEvent(event);
+    } else if (this.apiType === "openai-responses") {
+      this.processResponsesEvent(event);
     } else {
       this.processOpenAIEvent(event);
     }
@@ -172,6 +174,44 @@ export class MetricsExtractor {
       return extractOpenAINonStream(parsed);
     }
     return extractAnthropicNonStream(parsed);
+  }
+
+  private processResponsesEvent(event: SSEEvent): void {
+    let obj: Record<string, unknown>;
+    try { obj = JSON.parse(event.data!) as Record<string, unknown>; } catch { return; }
+    const type = obj.type as string;
+
+    // Track first content for TTFT
+    const isContentDelta = type === "response.output_text.delta"
+      || type === "response.function_call_arguments.delta"
+      || type === "response.reasoning_summary_text.delta";
+
+    if (isContentDelta) {
+      const delta = (obj.delta as string) ?? "";
+      if (delta && !this.firstContentReceived) {
+        this.firstContentReceived = true;
+        this.ttftMs = Date.now() - this.requestStartTime;
+      }
+      this.textContentBuffer += delta;
+    }
+
+    // Track completion
+    if (type === "response.completed" || type === "response.incomplete") {
+      this.streamEndTime = Date.now();
+      this.complete = true;
+      const resp = obj.response as Record<string, unknown> | undefined;
+      if (resp) {
+        const usage = resp.usage as Record<string, number> | undefined;
+        if (usage) {
+          this.inputTokens = usage.input_tokens ?? null;
+          this.outputTokens = usage.output_tokens ?? null;
+        }
+        const status = resp.status as string;
+        if (status === "completed") this.stopReason = "end_turn";
+        else if (status === "incomplete") this.stopReason = "max_tokens";
+        else this.stopReason = "stop";
+      }
+    }
   }
 
   private processAnthropicEvent(event: SSEEvent): void {

--- a/src/metrics/sse-metrics-transform.ts
+++ b/src/metrics/sse-metrics-transform.ts
@@ -100,6 +100,12 @@ export class SSEMetricsTransform extends Transform {
         if (delta.type === "thinking_delta" && typeof delta.thinking === "string") return delta.thinking;
         if (delta.type === "text_delta" && typeof delta.text === "string") return delta.text;
         if (delta.type === "input_json_delta" && typeof delta.partial_json === "string") return delta.partial_json;
+      } else if (this.apiType === "openai-responses") {
+        const type = parsed.type as string;
+        if (type === "response.output_text.delta") return parsed.delta as string;
+        if (type === "response.reasoning_summary_text.delta") return parsed.delta as string;
+        if (type === "response.function_call_arguments.delta") return parsed.delta as string;
+        return undefined;
       } else {
         const choices = parsed.choices;
         if (!Array.isArray(choices) || choices.length === 0) return undefined;

--- a/src/metrics/sse-metrics-transform.ts
+++ b/src/metrics/sse-metrics-transform.ts
@@ -25,7 +25,7 @@ export interface MetricsTransformOptions {
 export class SSEMetricsTransform extends Transform {
   private parser: SSEParser;
   private extractor: MetricsExtractor;
-  private readonly apiType: "openai" | "anthropic";
+  private readonly apiType: "openai" | "openai-responses" | "anthropic";
   private onMetrics?: (metrics: MetricsResult) => void;
   private onChunk?: (rawLine: string) => void;
   private onContentDelta?: (text: string) => void;
@@ -34,7 +34,7 @@ export class SSEMetricsTransform extends Transform {
   private flushed = false;
 
   constructor(
-    apiType: "openai" | "anthropic",
+    apiType: "openai" | "openai-responses" | "anthropic",
     requestStartTime: number,
     options?: MetricsTransformOptions,
   ) {

--- a/src/monitor/request-tracker.ts
+++ b/src/monitor/request-tracker.ts
@@ -117,7 +117,7 @@ export class RequestTracker {
   appendStreamChunk(
     id: string,
     rawLine: string,
-    apiType: "openai" | "anthropic",
+    apiType: "openai" | "openai-responses" | "anthropic",
     maxRaw: number,
     maxText: number,
   ): void {

--- a/src/monitor/stream-content-accumulator.ts
+++ b/src/monitor/stream-content-accumulator.ts
@@ -15,7 +15,7 @@ export class StreamContentAccumulator {
     private readonly maxText: number = DEFAULT_MAX_TEXT,
   ) {}
 
-  append(rawLine: string, apiType: "openai" | "anthropic"): void {
+  append(rawLine: string, apiType: "openai" | "openai-responses" | "anthropic"): void {
     this.totalChars += rawLine.length;
 
     this.rawChunks += rawLine + "\n";

--- a/src/monitor/stream-extractor.ts
+++ b/src/monitor/stream-extractor.ts
@@ -7,7 +7,7 @@ export interface StreamExtraction {
   block?: { index: number; type: ContentBlock["type"]; content: string; name?: string } | null;
 }
 
-export function extractStreamText(line: string, apiType: "openai" | "anthropic"): StreamExtraction {
+export function extractStreamText(line: string, apiType: "openai" | "openai-responses" | "anthropic"): StreamExtraction {
   const empty: StreamExtraction = { text: "", block: null };
   if (!line.startsWith(SSE_DATA_PREFIX)) return empty;
   const jsonStr = line.slice(SSE_DATA_PREFIX.length);

--- a/src/monitor/stream-extractor.ts
+++ b/src/monitor/stream-extractor.ts
@@ -26,6 +26,29 @@ export function extractStreamText(line: string, apiType: "openai" | "openai-resp
     return { text, block: text ? { index: 0, type: "text", content: text } : null };
   }
 
+  if (apiType === "openai-responses") {
+    // Responses SSE uses named events, but line format is "data: {json}" (same as Anthropic)
+    // The event type is in the data JSON's "type" field
+    const type = obj.type as string;
+
+    if (type === "response.output_text.delta") {
+      const text = (obj.delta as string) ?? "";
+      const outputIndex = (obj.output_index as number) ?? 0;
+      return { text, block: text ? { index: outputIndex, type: "text" as const, content: text } : empty.block };
+    }
+    if (type === "response.function_call_arguments.delta") {
+      const partialJson = (obj.delta as string) ?? "";
+      const outputIndex = (obj.output_index as number) ?? 0;
+      return { text: "", block: { index: outputIndex, type: "tool_use" as const, content: partialJson } };
+    }
+    if (type === "response.reasoning_summary_text.delta") {
+      const thinking = (obj.delta as string) ?? "";
+      const outputIndex = (obj.output_index as number) ?? 0;
+      return { text: "", block: { index: outputIndex, type: "thinking" as const, content: thinking } };
+    }
+    return empty;
+  }
+
   // Anthropic
   const type = obj.type as string | undefined;
   const index = obj.index as number | undefined;

--- a/src/monitor/types.ts
+++ b/src/monitor/types.ts
@@ -16,7 +16,7 @@ export interface StreamContentSnapshot {
 
 export interface ActiveRequest {
   id: string;
-  apiType: "openai" | "anthropic";
+  apiType: "openai" | "openai-responses" | "anthropic";
   model: string;
   providerId: string;
   providerName: string;

--- a/src/proxy/handler/proxy-handler-utils.ts
+++ b/src/proxy/handler/proxy-handler-utils.ts
@@ -14,7 +14,7 @@ export function getTransportStatusCode(result: TransportResult): number | null {
 }
 
 /** 将 tracker blocks 序列化为前端 tryDirectParse 可解析的 JSON */
-export function serializeBlocksForStorage(blocks: ContentBlock[] | undefined, apiType: "openai" | "anthropic"): string {
+export function serializeBlocksForStorage(blocks: ContentBlock[] | undefined, apiType: "openai" | "openai-responses" | "anthropic"): string {
   if (!blocks || blocks.length === 0) return "";
   if (apiType === "anthropic") {
     const content = blocks.map(b => {

--- a/src/proxy/handler/proxy-handler.ts
+++ b/src/proxy/handler/proxy-handler.ts
@@ -44,7 +44,7 @@ const TIER2_LOOP_THRESHOLD = 2;
 interface FailoverContext {
   request: FastifyRequest;
   reply: FastifyReply;
-  apiType: "openai" | "anthropic";
+  apiType: "openai" | "openai-responses" | "anthropic";
   upstreamPath: string;
   errors: ProxyErrorFormatter;
   deps: RouteHandlerDeps;
@@ -65,7 +65,7 @@ interface FailoverContext {
 interface RejectParams {
   db: Database.Database;
   logId: string;
-  apiType: "openai" | "anthropic";
+  apiType: "openai" | "openai-responses" | "anthropic";
   model: string;
   startTime: number;
   isStream: boolean;
@@ -117,7 +117,7 @@ import { TransformCoordinator } from "../transform/transform-coordinator.js";
 export async function handleProxyRequest(
   request: FastifyRequest,
   reply: FastifyReply,
-  apiType: "openai" | "anthropic",
+  apiType: "openai" | "openai-responses" | "anthropic",
   upstreamPath: string,
   errors: ProxyErrorFormatter,
   deps: RouteHandlerDeps,
@@ -322,7 +322,7 @@ async function executeFailoverLoop(ctx: FailoverContext): Promise<FastifyReply> 
         body: currentBody,
         headers: {},
         sourceApiType: apiType,
-        targetApiType: provider.api_type as "openai" | "anthropic",
+        targetApiType: provider.api_type as "openai" | "openai-responses" | "anthropic",
         provider: { id: provider.id, name: provider.name, base_url: provider.base_url, api_type: provider.api_type },
       };
       pluginRegistry.applyBeforeRequest(pluginCtx);
@@ -372,7 +372,7 @@ async function executeFailoverLoop(ctx: FailoverContext): Promise<FastifyReply> 
             const respObj = JSON.parse(transformed);
             const respCtx: import("../transform/plugin-types.js").ResponseTransformContext = {
               response: respObj,
-              sourceApiType: provider.api_type as "openai" | "anthropic",
+              sourceApiType: provider.api_type as "openai" | "openai-responses" | "anthropic",
               targetApiType: apiType,
               provider: { id: provider.id, name: provider.name, base_url: provider.base_url, api_type: provider.api_type },
             };

--- a/src/proxy/handler/responses.ts
+++ b/src/proxy/handler/responses.ts
@@ -1,0 +1,75 @@
+import type { FastifyPluginCallback, FastifyReply, FastifyRequest } from "fastify";
+import { randomUUID } from "crypto";
+import Database from "better-sqlite3";
+import fp from "fastify-plugin";
+import { insertRequestLog } from "../../db/index.js";
+import { createErrorFormatter, type ProxyErrorResponse } from "../proxy-core.js";
+import type { ErrorKind } from "../proxy-core.js";
+import { handleProxyRequest, type RouteHandlerDeps } from "./proxy-handler.js";
+import { createOrchestrator } from "../orchestration/orchestrator.js";
+import { ProviderSemaphoreManager } from "../orchestration/semaphore.js";
+import type { RequestTracker } from "../../monitor/request-tracker.js";
+import type { AdaptiveConcurrencyController } from "../adaptive-controller.js";
+import { HTTP_BAD_GATEWAY } from "../../core/constants.js";
+import { SERVICE_KEYS } from "../../core/container.js";
+
+export interface ResponsesProxyOptions {
+  db: Database.Database;
+  container: import("../../core/container.js").ServiceContainer;
+}
+
+const RESPONSES_PATH = "/v1/responses";
+const RESPONSES_COMPAT_PATH = "/responses";
+
+const RESPONSES_ERROR_META: Record<ErrorKind, { type: string; code: string }> = {
+  modelNotFound: { type: "invalid_request_error", code: "model_not_found" },
+  modelNotAllowed: { type: "invalid_request_error", code: "model_not_allowed" },
+  providerUnavailable: { type: "server_error", code: "provider_unavailable" },
+  providerTypeMismatch: { type: "server_error", code: "provider_type_mismatch" },
+  upstreamConnectionFailed: { type: "upstream_error", code: "upstream_connection_failed" },
+  concurrencyQueueFull: { type: "server_error", code: "concurrency_queue_full" },
+  concurrencyTimeout: { type: "server_error", code: "concurrency_timeout" },
+  promptTooLong: { type: "invalid_request_error", code: "context_window_exceeded" },
+};
+
+const responsesErrors = createErrorFormatter(
+  (kind, message) => ({ error: { message, ...RESPONSES_ERROR_META[kind] } }),
+);
+
+function sendError(reply: FastifyReply, e: ProxyErrorResponse) {
+  return reply.code(e.statusCode).send(e.body);
+}
+
+const responsesProxyRaw: FastifyPluginCallback<ResponsesProxyOptions> = (app, opts, done) => {
+  const { db, container } = opts;
+
+  const orchestrator = createOrchestrator(
+    container.resolve<ProviderSemaphoreManager>(SERVICE_KEYS.semaphoreManager),
+    container.resolve<RequestTracker>(SERVICE_KEYS.tracker),
+    container.resolve<AdaptiveConcurrencyController>(SERVICE_KEYS.adaptiveController),
+  );
+
+  const handleResponses = async (request: FastifyRequest, reply: FastifyReply) => {
+    if (!orchestrator) {
+      const body = request.body as Record<string, unknown> | undefined;
+      insertRequestLog(db, {
+        id: randomUUID(), api_type: "openai-responses", model: (body?.model as string) || null,
+        provider_id: null, status_code: HTTP_BAD_GATEWAY, latency_ms: 0, is_stream: 0,
+        error_message: "Orchestrator not available",
+        created_at: new Date().toISOString(),
+        client_request: JSON.stringify({ headers: request.headers }),
+        router_key_id: request.routerKey?.id ?? null,
+      });
+      return sendError(reply, responsesErrors.providerUnavailable());
+    }
+    const deps: RouteHandlerDeps = { db, orchestrator, container };
+    return handleProxyRequest(request, reply, "openai-responses", RESPONSES_PATH, responsesErrors, deps);
+  };
+
+  app.post(RESPONSES_PATH, handleResponses);
+  app.post(RESPONSES_COMPAT_PATH, handleResponses);
+
+  done();
+};
+
+export const responsesProxy = fp(responsesProxyRaw, { name: "responses-proxy" });

--- a/src/proxy/loop-prevention/tool-loop-guard.ts
+++ b/src/proxy/loop-prevention/tool-loop-guard.ts
@@ -42,7 +42,7 @@ export class ToolLoopGuard {
     return { detected: false };
   }
 
-  injectLoopBreakPrompt(body: Record<string, unknown>, apiType: "openai" | "anthropic", toolName: string): Record<string, unknown> {
+  injectLoopBreakPrompt(body: Record<string, unknown>, apiType: "openai" | "openai-responses" | "anthropic", toolName: string): Record<string, unknown> {
     const cloned = JSON.parse(JSON.stringify(body));
     const prompt = `[系统提醒] 检测到你可能陷入了反复调用 "${toolName}" 工具的循环。请停下来，总结当前进展，直接告知用户。`;
 

--- a/src/proxy/loop-prevention/tool-loop-guard.ts
+++ b/src/proxy/loop-prevention/tool-loop-guard.ts
@@ -55,6 +55,15 @@ export class ToolLoopGuard {
       } else {
         cloned.system = [{ type: "text", text: prompt }];
       }
+    } else if (apiType === "openai-responses") {
+      // Append a user message to input items
+      const inputArr = Array.isArray(body.input) ? [...(body.input as Array<Record<string, unknown>>)] : [];
+      inputArr.push({
+        type: "message" as const,
+        role: "user" as const,
+        content: [{ type: "input_text", text: `[系统提醒] 检测到工具 "${toolName}" 可能陷入循环。请停止重复调用，总结当前进展。` }],
+      });
+      return { ...body, input: inputArr };
     } else {
       const messages = (cloned.messages as unknown[]) ?? [];
       messages.unshift({ role: "system", content: prompt });

--- a/src/proxy/orchestration/orchestrator.ts
+++ b/src/proxy/orchestration/orchestrator.ts
@@ -74,7 +74,7 @@ export class ProxyOrchestrator {
   async handle(
     request: FastifyRequest,
     reply: FastifyReply,
-    apiType: "openai" | "anthropic",
+    apiType: "openai" | "openai-responses" | "anthropic",
     config: OrchestratorConfig,
     ctx?: HandleContext,
   ): Promise<ResilienceResult> {
@@ -124,7 +124,7 @@ export class ProxyOrchestrator {
   private buildActiveRequest(
     request: FastifyRequest,
     config: OrchestratorConfig,
-    apiType: "openai" | "anthropic",
+    apiType: "openai" | "openai-responses" | "anthropic",
   ): ActiveRequest {
     return {
       id: config.trackerId ?? crypto.randomUUID(),

--- a/src/proxy/patch/deepseek/index.ts
+++ b/src/proxy/patch/deepseek/index.ts
@@ -23,7 +23,7 @@ import { patchOrphanToolResults, patchOrphanToolResultsOA } from "./patch-orphan
  */
 export function applyDeepSeekPatches(
   body: Record<string, unknown>,
-  apiType: "openai" | "anthropic",
+  apiType: "openai" | "openai-responses" | "anthropic",
 ): void {
   if (apiType === "anthropic") {
     patchThinkingParam(body, apiType);

--- a/src/proxy/patch/deepseek/patch-thinking-param.ts
+++ b/src/proxy/patch/deepseek/patch-thinking-param.ts
@@ -5,7 +5,7 @@
  */
 export function patchThinkingParam(
   body: Record<string, unknown>,
-  apiType: "openai" | "anthropic",
+  apiType: "openai" | "openai-responses" | "anthropic",
 ): void {
   if (body.thinking) return;
 

--- a/src/proxy/patch/index.ts
+++ b/src/proxy/patch/index.ts
@@ -76,7 +76,7 @@ export function applyProviderPatches(
 
   // DeepSeek 特定补丁
   if (needsDeepSeekPatch(body, provider)) {
-    applyDeepSeekPatches(ensureCloned(), provider.api_type as "openai" | "anthropic");
+    applyDeepSeekPatches(ensureCloned(), provider.api_type as "openai" | "openai-responses" | "anthropic");
     patches.push("deepseek");
   }
 

--- a/src/proxy/patch/tool-round-limiter.ts
+++ b/src/proxy/patch/tool-round-limiter.ts
@@ -79,6 +79,21 @@ export function applyToolRoundLimit(
   apiType: "openai" | "openai-responses" | "anthropic",
   maxRounds: number = DEFAULT_MAX_ROUNDS,
 ): { body: Record<string, unknown>; injected: boolean; rounds: number } {
+  if (apiType === "openai-responses") {
+    const input = body.input as Array<Record<string, unknown>> | undefined;
+    if (!input || !Array.isArray(input)) return { body, injected: false, rounds: 0 };
+    const funcCalls = input.filter(i => i.type === "function_call").length;
+    if (funcCalls <= maxRounds) return { body, injected: false, rounds: funcCalls };
+    // Inject warning: append a user message to input
+    const cloned: Record<string, unknown> = { ...body, input: [...input] };
+    (cloned.input as Array<Record<string, unknown>>).push({
+      type: "message",
+      role: "user",
+      content: [{ type: "input_text", text: LOOP_WARNING_PROMPT }],
+    });
+    return { body: cloned, injected: true, rounds: funcCalls };
+  }
+
   const messages = (body.messages as Message[]) ?? [];
   if (messages.length === 0) return { body, injected: false, rounds: 0 };
 

--- a/src/proxy/patch/tool-round-limiter.ts
+++ b/src/proxy/patch/tool-round-limiter.ts
@@ -76,7 +76,7 @@ export function countConsecutiveToolRounds(messages: Message[]): number {
  */
 export function applyToolRoundLimit(
   body: Record<string, unknown>,
-  apiType: "openai" | "anthropic",
+  apiType: "openai" | "openai-responses" | "anthropic",
   maxRounds: number = DEFAULT_MAX_ROUNDS,
 ): { body: Record<string, unknown>; injected: boolean; rounds: number } {
   const messages = (body.messages as Message[]) ?? [];

--- a/src/proxy/proxy-core.ts
+++ b/src/proxy/proxy-core.ts
@@ -115,7 +115,7 @@ export function buildUpstreamHeaders(
   clientHeaders: RawHeaders,
   apiKey: string,
   payloadBytes?: number,
-  apiType?: "openai" | "anthropic"
+  apiType?: "openai" | "openai-responses" | "anthropic"
 ): Record<string, string> {
   const headers = selectHeaders(clientHeaders, SKIP_UPSTREAM);
   if (apiType === "anthropic") {

--- a/src/proxy/proxy-logging.ts
+++ b/src/proxy/proxy-logging.ts
@@ -33,7 +33,7 @@ export function sanitizeHeadersForLog(headers: Record<string, string>): Record<s
 
 export function handleIntercept(
   db: Database.Database,
-  apiType: "openai" | "anthropic",
+  apiType: "openai" | "openai-responses" | "anthropic",
   request: FastifyRequest,
   reply: import("fastify").FastifyReply,
   interceptResponse: { statusCode: number; body: unknown; meta?: unknown },
@@ -70,7 +70,7 @@ export function handleIntercept(
 export function logResilienceResult(
   db: Database.Database,
   params: {
-    apiType: "openai" | "anthropic";
+    apiType: "openai" | "openai-responses" | "anthropic";
     model: string;
     providerId: string;
     isStream: boolean;
@@ -184,7 +184,7 @@ export function logResilienceResult(
 
 export function collectTransportMetrics(
   db: Database.Database,
-  apiType: "openai" | "anthropic",
+  apiType: "openai" | "openai-responses" | "anthropic",
   result: TransportResult,
   isStream: boolean,
   lastSuccessLogId: string,

--- a/src/proxy/response-transform.ts
+++ b/src/proxy/response-transform.ts
@@ -18,6 +18,19 @@ export function maybeInjectModelInfoTag(
       bodyObj.content[0].text += `\n\n${buildModelInfoTag(effectiveModel)}`;
       return { body: JSON.stringify(bodyObj), meta: { model_info_tag_injected: true } };
     }
+    // Responses format: output[type=message].content[type=output_text].text
+    if (Array.isArray(bodyObj.output)) {
+      for (const item of bodyObj.output as Array<Record<string, unknown>>) {
+        if (item.type === "message" && Array.isArray(item.content)) {
+          for (const part of item.content as Array<Record<string, unknown>>) {
+            if (part.type === "output_text" && part.text) {
+              (part as Record<string, unknown>).text = (part.text as string) + `\n\n${buildModelInfoTag(effectiveModel)}`;
+              return { body: JSON.stringify(bodyObj), meta: { model_info_tag_injected: true } };
+            }
+          }
+        }
+      }
+    }
   } catch { /* non-JSON response, skip injection */ }
   return { body: responseBody, meta: { model_info_tag_injected: false } };
 }

--- a/src/proxy/transform/id-utils.ts
+++ b/src/proxy/transform/id-utils.ts
@@ -10,4 +10,8 @@ export function generateChatcmplId(): string {
   return `chatcmpl-${randomUUID().slice(0, UUID_ID_LENGTH)}`;
 }
 
+export function generateRespId(): string {
+  return `resp_${randomUUID().slice(0, UUID_ID_LENGTH)}`;
+}
+
 export const MS_PER_SECOND = 1000;

--- a/src/proxy/transform/plugin-types.ts
+++ b/src/proxy/transform/plugin-types.ts
@@ -6,21 +6,21 @@ export interface PluginMatch {
   providerId?: string;
   providerName?: string;
   providerNamePattern?: string;
-  apiType?: "openai" | "anthropic";
+  apiType?: "openai" | "openai-responses" | "anthropic";
 }
 
 export interface RequestTransformContext {
   body: Record<string, unknown>;
   headers: Record<string, string>;
-  sourceApiType: "openai" | "anthropic";
-  targetApiType: "openai" | "anthropic";
+  sourceApiType: "openai" | "openai-responses" | "anthropic";
+  targetApiType: "openai" | "openai-responses" | "anthropic";
   provider: { id: string; name: string; base_url: string; api_type: string };
 }
 
 export interface ResponseTransformContext {
   response: Record<string, unknown>;
-  sourceApiType: "openai" | "anthropic";
-  targetApiType: "openai" | "anthropic";
+  sourceApiType: "openai" | "openai-responses" | "anthropic";
+  targetApiType: "openai" | "openai-responses" | "anthropic";
   provider: { id: string; name: string; base_url: string; api_type: string };
 }
 

--- a/src/proxy/transform/request-bridge-responses.ts
+++ b/src/proxy/transform/request-bridge-responses.ts
@@ -1,0 +1,345 @@
+/**
+ * Bridge (lossy) request transformation between OpenAI Responses API
+ * and OpenAI Chat Completions API.
+ *
+ * This is the SECONDARY conversion path used when the upstream provider
+ * only supports the opposite API format. It is lossy because Chat Completions
+ * cannot represent `previous_response_id`, built-in tools, or structured
+ * reasoning items.
+ */
+
+// ---------- Responses → Chat Completions ----------
+
+/**
+ * Convert an OpenAI Responses API request body to an OpenAI Chat Completions
+ * request body.
+ */
+export function responsesToChatRequest(
+  body: Record<string, unknown>,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  result.model = body.model;
+
+  // instructions → system message
+  const messages: Array<Record<string, unknown>> = [];
+  if (body.instructions != null && body.instructions !== "") {
+    messages.push({ role: "system", content: String(body.instructions) });
+  }
+
+  // input → messages
+  convertResponsesInputToChatMessages(body.input, messages);
+  result.messages = messages;
+
+  // max_output_tokens → max_completion_tokens
+  if (body.max_output_tokens != null) {
+    result.max_completion_tokens = body.max_output_tokens;
+  }
+
+  // Pass-through fields
+  if (body.temperature != null) result.temperature = body.temperature;
+  if (body.top_p != null) result.top_p = body.top_p;
+  if (body.stream != null) result.stream = body.stream;
+
+  // tools: Responses format → Chat Completions format
+  const tools = body.tools as Array<Record<string, unknown>> | undefined;
+  if (tools) {
+    const chatTools: Array<Record<string, unknown>> = [];
+    for (const t of tools) {
+      if (t.type === "function") {
+        // Responses tools are flat: {type:"function", name, parameters, description}
+        // Chat tools need function wrapper: {type:"function", function:{name, parameters}}
+        const fn: Record<string, unknown> = { name: String(t.name) };
+        if (t.description != null) fn.description = String(t.description);
+        if (t.parameters != null) fn.parameters = t.parameters;
+        chatTools.push({ type: "function", function: fn });
+      }
+      // Non-function tools (web_search_preview, file_search, etc.) → skip
+    }
+    if (chatTools.length > 0) {
+      result.tools = chatTools;
+    }
+  }
+
+  // tool_choice — compatible between Chat and Responses
+  if (body.tool_choice != null) {
+    result.tool_choice = body.tool_choice;
+  }
+
+  // reasoning — pass through (both use {effort?, max_tokens?})
+  if (body.reasoning != null) {
+    result.reasoning = body.reasoning;
+  }
+
+  // text.format → response_format
+  const text = body.text as Record<string, unknown> | undefined;
+  if (text?.format != null) {
+    result.response_format = text.format;
+  }
+
+  // stream_options
+  if (body.stream_options != null) {
+    result.stream_options = body.stream_options;
+  }
+
+  return result;
+}
+
+/**
+ * Convert Responses `input` (string | ResponseInputItem[]) into Chat
+ * Completions `messages[]`, appending to the provided array.
+ */
+function convertResponsesInputToChatMessages(
+  input: unknown,
+  messages: Array<Record<string, unknown>>,
+): void {
+  if (input == null) return;
+
+  // String shorthand → single user message
+  if (typeof input === "string") {
+    messages.push({ role: "user", content: input });
+    return;
+  }
+
+  if (!Array.isArray(input)) return;
+
+  // Track pending function_calls to merge into a single assistant message
+  const pendingFnCalls: Array<Record<string, unknown>> = [];
+
+  for (const item of input as Array<Record<string, unknown>>) {
+    const type = item.type as string;
+
+    // Flush any pending function_calls before processing non-function_call items
+    if (type !== "function_call" && pendingFnCalls.length > 0) {
+      flushFunctionCalls(messages, pendingFnCalls);
+    }
+
+    if (type === "message") {
+      // ResponseInputMessage → Chat message
+      const role = item.role as string;
+      const content = extractMessageTextContent(item);
+      messages.push({ role, content });
+    } else if (type === "input_text") {
+      messages.push({ role: "user", content: String(item.text ?? "") });
+    } else if (type === "function_call") {
+      // Collect; will be flushed when next non-function_call item appears
+      // or at end of loop
+      const fn: Record<string, unknown> = {
+        name: String(item.name ?? ""),
+        arguments: String(item.arguments ?? "{}"),
+      };
+      pendingFnCalls.push({
+        id: String(item.id ?? ""),
+        type: "function",
+        function: fn,
+      });
+    } else if (type === "function_call_output") {
+      messages.push({
+        role: "tool",
+        tool_call_id: String(item.call_id ?? ""),
+        content: String(item.output ?? ""),
+      });
+    } else if (type === "reasoning") {
+      // No Chat Completions equivalent — skip
+    }
+    // Unknown item types → skip
+  }
+
+  // Flush any remaining pending function_calls
+  if (pendingFnCalls.length > 0) {
+    flushFunctionCalls(messages, pendingFnCalls);
+  }
+}
+
+/**
+ * Flush accumulated function_call tool_calls into a single assistant message.
+ */
+function flushFunctionCalls(
+  messages: Array<Record<string, unknown>>,
+  pending: Array<Record<string, unknown>>,
+): void {
+  messages.push({
+    role: "assistant",
+    content: null,
+    tool_calls: [...pending],
+  });
+  pending.length = 0;
+}
+
+/**
+ * Extract text content from a ResponseInputMessage.
+ */
+function extractMessageTextContent(msg: Record<string, unknown>): string {
+  const content = msg.content;
+  if (content == null) return "";
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return (content as Array<Record<string, unknown>>)
+      .filter((p) => p.type === "input_text" && p.text != null)
+      .map((p) => String(p.text))
+      .join("");
+  }
+  return "";
+}
+
+// ---------- Chat Completions → Responses ----------
+
+/**
+ * Convert an OpenAI Chat Completions request body to an OpenAI Responses API
+ * request body.
+ */
+export function chatToResponsesRequest(
+  body: Record<string, unknown>,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  result.model = body.model;
+
+  // Extract instructions from system/developer messages
+  const messages = body.messages as Array<Record<string, unknown>> | undefined;
+  const { instructions, nonSystemMsgs } = extractChatInstructions(messages ?? []);
+  if (instructions) {
+    result.instructions = instructions;
+  }
+
+  // Convert non-system messages → input items
+  result.input = convertChatMessagesToResponsesInput(nonSystemMsgs);
+
+  // max_completion_tokens / max_tokens → max_output_tokens
+  if (body.max_completion_tokens != null) {
+    result.max_output_tokens = body.max_completion_tokens;
+  } else if (body.max_tokens != null) {
+    result.max_output_tokens = body.max_tokens;
+  }
+
+  // Pass-through fields
+  if (body.temperature != null) result.temperature = body.temperature;
+  if (body.top_p != null) result.top_p = body.top_p;
+  if (body.stream != null) result.stream = body.stream;
+
+  // tools: Chat format → Responses format
+  const tools = body.tools as Array<Record<string, unknown>> | undefined;
+  if (tools) {
+    const respTools: Array<Record<string, unknown>> = [];
+    for (const t of tools) {
+      if (t.type === "function" && t.function) {
+        // Chat: {type:"function", function:{name, parameters, description}}
+        // Responses: {type:"function", name, parameters, description}
+        const fn = t.function as Record<string, unknown>;
+        const mapped: Record<string, unknown> = {
+          type: "function",
+          name: String(fn.name),
+        };
+        if (fn.description != null) mapped.description = String(fn.description);
+        if (fn.parameters != null) mapped.parameters = fn.parameters;
+        respTools.push(mapped);
+      }
+      // Non-function tools → skip
+    }
+    if (respTools.length > 0) {
+      result.tools = respTools;
+    }
+  }
+
+  // tool_choice — compatible
+  if (body.tool_choice != null) {
+    result.tool_choice = body.tool_choice;
+  }
+
+  // reasoning — pass through
+  if (body.reasoning != null) {
+    result.reasoning = body.reasoning;
+  }
+
+  // response_format → text.format
+  if (body.response_format != null) {
+    result.text = { format: body.response_format };
+  }
+
+  // stream_options
+  if (body.stream_options != null) {
+    result.stream_options = body.stream_options;
+  }
+
+  return result;
+}
+
+/**
+ * Extract system/developer messages from Chat messages as instructions.
+ */
+function extractChatInstructions(
+  messages: Array<Record<string, unknown>>,
+): { instructions: string; nonSystemMsgs: Array<Record<string, unknown>> } {
+  const parts: string[] = [];
+  const nonSystemMsgs: Array<Record<string, unknown>> = [];
+
+  for (const msg of messages) {
+    const role = msg.role as string;
+    if (role === "system" || role === "developer") {
+      parts.push(String(msg.content ?? ""));
+    } else {
+      nonSystemMsgs.push(msg);
+    }
+  }
+
+  return {
+    instructions: parts.length > 0 ? parts.join("\n") : "",
+    nonSystemMsgs,
+  };
+}
+
+/**
+ * Convert Chat Completions non-system messages → Responses input items.
+ */
+function convertChatMessagesToResponsesInput(
+  messages: Array<Record<string, unknown>>,
+): unknown[] {
+  const items: unknown[] = [];
+
+  for (const msg of messages) {
+    const role = msg.role as string;
+
+    if (role === "user") {
+      const content = msg.content;
+      const text = typeof content === "string" ? content : String(content ?? "");
+      items.push({
+        type: "message",
+        role: "user",
+        content: [{ type: "input_text", text }],
+      });
+    } else if (role === "assistant") {
+      // Text content → assistant message with output_text
+      const content = msg.content;
+      if (content != null && content !== "" && content !== null) {
+        const text = typeof content === "string" ? content : String(content);
+        items.push({
+          type: "message",
+          role: "assistant",
+          content: [{ type: "output_text", text }],
+        });
+      }
+
+      // tool_calls → function_call items
+      const toolCalls = msg.tool_calls as Array<Record<string, unknown>> | undefined;
+      if (toolCalls) {
+        for (const tc of toolCalls) {
+          const fn = tc.function as Record<string, unknown> | undefined;
+          items.push({
+            type: "function_call",
+            id: String(tc.id ?? ""),
+            call_id: String(tc.id ?? ""),
+            name: String(fn?.name ?? ""),
+            arguments: String(fn?.arguments ?? "{}"),
+          });
+        }
+      }
+    } else if (role === "tool") {
+      items.push({
+        type: "function_call_output",
+        call_id: String(msg.tool_call_id ?? ""),
+        output: String(msg.content ?? ""),
+      });
+    }
+    // reasoning_content in messages → skip (can't create reasoning items)
+  }
+
+  return items;
+}

--- a/src/proxy/transform/request-transform-responses.ts
+++ b/src/proxy/transform/request-transform-responses.ts
@@ -1,0 +1,377 @@
+import { sanitizeToolUseId, parseToolArguments } from "./sanitize.js";
+import type { AnthropicContentBlock } from "./types.js";
+
+// ---------- Effort → budget mapping (shared with thinking-mapper) ----------
+
+const EFFORT_BUDGET: Record<string, number> = { low: 1024, medium: 8192, high: 32768 };
+const DEFAULT_BUDGET = 8192;
+
+// ---------- Internal types ----------
+
+interface AntMessage {
+  role: string;
+  content: AnthropicContentBlock[];
+}
+
+// ---------- Helpers ----------
+
+/** Strip "toolu_" prefix from a tool_use_id to recover the original call_id. */
+function stripTooluPrefix(id: string): string {
+  return id.startsWith("toolu_") ? id.slice(6) : id;
+}
+
+/** Merge consecutive same-role messages to satisfy Anthropic strict alternation. */
+function mergeConsecutiveMessages(msgs: AntMessage[]): AntMessage[] {
+  const merged: AntMessage[] = [];
+  for (const msg of msgs) {
+    const prev = merged[merged.length - 1];
+    if (prev && prev.role === msg.role) {
+      prev.content = [...prev.content, ...msg.content];
+    } else {
+      merged.push({ ...msg, content: [...msg.content] });
+    }
+  }
+  return merged;
+}
+
+/** Ensure first message has role "user" (prepend empty user if needed). */
+function ensureFirstIsUser(msgs: AntMessage[]): AntMessage[] {
+  if (msgs.length > 0 && msgs[0].role !== "user") {
+    msgs.unshift({ role: "user", content: [{ type: "text", text: "" }] });
+  }
+  return msgs;
+}
+
+// ---------- Responses → Anthropic ----------
+
+export function responsesToAnthropicRequest(
+  body: Record<string, unknown>,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  result.model = body.model;
+
+  // instructions → system
+  if (body.instructions != null) {
+    result.system = String(body.instructions);
+  }
+
+  // input → messages
+  result.messages = convertResponsesInputToAntMessages(body.input);
+
+  // max_output_tokens → max_tokens
+  if (body.max_output_tokens != null) {
+    result.max_tokens = body.max_output_tokens;
+  }
+
+  // temperature, top_p, stream — pass through
+  if (body.temperature != null) result.temperature = body.temperature;
+  if (body.top_p != null) result.top_p = body.top_p;
+  if (body.stream != null) result.stream = body.stream;
+
+  // tools: only function-type tools are forwarded
+  const tools = body.tools as Array<Record<string, unknown>> | undefined;
+  if (tools) {
+    const fnTools = tools.filter(t => t.type === "function");
+    if (fnTools.length > 0 && body.tool_choice !== "none") {
+      result.tools = fnTools.map(t => {
+        const mapped: Record<string, unknown> = { name: String(t.name) };
+        if (t.description != null) mapped.description = String(t.description);
+        if (t.parameters != null) mapped.input_schema = t.parameters;
+        return mapped;
+      });
+
+      // tool_choice mapping
+      if (body.tool_choice != null && body.tool_choice !== "none") {
+        const tc = mapToolChoiceResponses2Ant(body.tool_choice);
+        if (tc != null) {
+          result.tool_choice = body.parallel_tool_calls === false
+            ? { ...(tc as Record<string, unknown>), disable_parallel_tool_use: true }
+            : tc;
+        }
+      } else if (body.parallel_tool_calls === false) {
+        result.tool_choice = { type: "auto", disable_parallel_tool_use: true };
+      }
+    }
+  }
+
+  // reasoning → thinking
+  if (body.reasoning) {
+    const reasoning = body.reasoning as Record<string, unknown>;
+    const effort = reasoning.effort as string | undefined;
+    const maxTokens = reasoning.max_tokens as number | undefined;
+    const budget = maxTokens ?? EFFORT_BUDGET[effort ?? ""] ?? DEFAULT_BUDGET;
+    result.thinking = { type: "enabled", budget_tokens: budget };
+
+    // Ensure max_tokens >= budget_tokens
+    if (result.max_tokens != null && (result.max_tokens as number) < budget) {
+      result.max_tokens = budget;
+    }
+  }
+
+  // metadata.user_id
+  const meta = body.metadata as Record<string, unknown> | undefined;
+  if (meta?.user_id) {
+    result.metadata = { user_id: meta.user_id };
+  }
+
+  return result;
+}
+
+/** Convert Responses input (string | ResponseInputItem[]) → Anthropic messages. */
+function convertResponsesInputToAntMessages(input: unknown): AntMessage[] {
+  if (input == null) return [];
+  // String shorthand → single user message
+  if (typeof input === "string") {
+    return [{ role: "user", content: [{ type: "text", text: input }] }];
+  }
+  if (!Array.isArray(input)) return [];
+
+  const raw: AntMessage[] = [];
+
+  for (const item of input as Array<Record<string, unknown>>) {
+    const type = item.type as string;
+
+    if (type === "message") {
+      // ResponseInputMessage: extract content as AnthropicContentBlock[]
+      const role = item.role as string;
+      const content = extractMessageContent(item);
+      raw.push({ role, content });
+    } else if (type === "function_call") {
+      // → assistant tool_use (Anthropic requires "toolu_" prefix)
+      const rawId = String(item.call_id ?? item.id ?? "");
+      const antId = rawId.startsWith("toolu_") ? rawId : `toolu_${rawId}`;
+      raw.push({
+        role: "assistant",
+        content: [{
+          type: "tool_use",
+          id: sanitizeToolUseId(antId),
+          name: String(item.name ?? ""),
+          input: parseToolArguments(item.arguments),
+        }],
+      });
+    } else if (type === "function_call_output") {
+      // → user tool_result (Anthropic requires "toolu_" prefix)
+      const rawCallId = String(item.call_id ?? "");
+      const antCallId = rawCallId.startsWith("toolu_") ? rawCallId : `toolu_${rawCallId}`;
+      raw.push({
+        role: "user",
+        content: [{
+          type: "tool_result",
+          tool_use_id: sanitizeToolUseId(antCallId),
+          content: String(item.output ?? ""),
+        }],
+      });
+    } else if (type === "reasoning") {
+      // → assistant thinking
+      const summary = item.summary as Array<Record<string, unknown>> | undefined;
+      const thinkingText = summary
+        ? summary.map(s => String(s.text ?? "")).join("\n")
+        : "";
+      raw.push({
+        role: "assistant",
+        content: [{ type: "thinking", thinking: thinkingText }],
+      });
+    } else if (type === "input_text") {
+      // → user text
+      raw.push({
+        role: "user",
+        content: [{ type: "text", text: String(item.text ?? "") }],
+      });
+    }
+  }
+
+  const merged = mergeConsecutiveMessages(raw);
+  ensureFirstIsUser(merged);
+  return merged;
+}
+
+/** Extract content blocks from a ResponseInputMessage. */
+function extractMessageContent(msg: Record<string, unknown>): AnthropicContentBlock[] {
+  const content = msg.content;
+  if (content == null) return [];
+  if (typeof content === "string") {
+    return [{ type: "text", text: content }];
+  }
+  if (Array.isArray(content)) {
+    return (content as Array<Record<string, unknown>>).flatMap((part): AnthropicContentBlock[] => {
+      if (part.type === "input_text" && part.text != null) {
+        return [{ type: "text", text: String(part.text) }];
+      }
+      return [];
+    });
+  }
+  return [];
+}
+
+/** Map Responses tool_choice → Anthropic tool_choice. */
+function mapToolChoiceResponses2Ant(tc: unknown): Record<string, unknown> | undefined {
+  if (tc === "auto") return { type: "auto" };
+  if (tc === "required") return { type: "any" };
+  if (tc === "none") return undefined;
+  if (typeof tc === "object" && tc !== null) {
+    const obj = tc as Record<string, unknown>;
+    if (obj.type === "function" && obj.name) {
+      return { type: "tool", name: String(obj.name) };
+    }
+  }
+  return { type: "auto" };
+}
+
+// ---------- Anthropic → Responses ----------
+
+export function anthropicToResponsesRequest(
+  body: Record<string, unknown>,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  result.model = body.model;
+
+  // system → instructions
+  if (body.system != null) {
+    if (typeof body.system === "string") {
+      result.instructions = body.system;
+    } else if (Array.isArray(body.system)) {
+      result.instructions = (body.system as Array<Record<string, unknown>>)
+        .map(b => String(b.text ?? ""))
+        .join("\n");
+    } else {
+      result.instructions = String(body.system);
+    }
+  }
+
+  // messages → input items
+  const antMessages = body.messages as Array<Record<string, unknown>> | undefined;
+  result.input = antMessages ? convertAntMessagesToResponsesInput(antMessages) : [];
+
+  // max_tokens → max_output_tokens
+  if (body.max_tokens != null) result.max_output_tokens = body.max_tokens;
+
+  // temperature, top_p, stream — pass through
+  if (body.temperature != null) result.temperature = body.temperature;
+  if (body.top_p != null) result.top_p = body.top_p;
+  if (body.stream != null) result.stream = body.stream;
+
+  // tools
+  const tools = body.tools as Array<Record<string, unknown>> | undefined;
+  if (tools && tools.length > 0) {
+    result.tools = tools.map(t => {
+      const mapped: Record<string, unknown> = {
+        type: "function",
+        name: String(t.name),
+      };
+      if (t.description != null) mapped.description = String(t.description);
+      if (t.input_schema != null) mapped.parameters = t.input_schema;
+      return mapped;
+    });
+  }
+
+  // tool_choice
+  if (body.tool_choice != null) {
+    const tc = mapToolChoiceAnt2Responses(body.tool_choice);
+    if (tc != null) result.tool_choice = tc;
+  }
+
+  // thinking → reasoning
+  if (body.thinking) {
+    const thinking = body.thinking as Record<string, unknown>;
+    if (thinking.type === "enabled" && thinking.budget_tokens != null) {
+      result.reasoning = { max_tokens: thinking.budget_tokens };
+    }
+  }
+
+  // metadata.user_id
+  const meta = body.metadata as Record<string, unknown> | undefined;
+  if (meta?.user_id) {
+    result.metadata = { user_id: meta.user_id };
+  }
+
+  return result;
+}
+
+/** Convert Anthropic messages → Responses input items. */
+function convertAntMessagesToResponsesInput(
+  messages: Array<Record<string, unknown>>,
+): unknown[] {
+  const items: unknown[] = [];
+
+  for (const msg of messages) {
+    const role = msg.role as string;
+    const content = msg.content as Array<Record<string, unknown>> | undefined;
+    if (!content || !Array.isArray(content)) continue;
+
+    if (role === "user") {
+      // Separate text blocks and tool_result blocks
+      const textBlocks = content.filter(b => b.type === "text");
+      const toolResultBlocks = content.filter(b => b.type === "tool_result");
+
+      if (textBlocks.length > 0) {
+        const text = textBlocks.map(b => String(b.text ?? "")).join("");
+        items.push({
+          type: "message",
+          role: "user",
+          content: [{ type: "input_text", text }],
+        });
+      }
+      for (const tr of toolResultBlocks) {
+        items.push({
+          type: "function_call_output",
+          call_id: stripTooluPrefix(String(tr.tool_use_id ?? "")),
+          output: String(tr.content ?? ""),
+        });
+      }
+    } else if (role === "assistant") {
+      const textBlocks = content.filter(b => b.type === "text");
+      const toolUseBlocks = content.filter(b => b.type === "tool_use");
+      const thinkingBlocks = content.filter(b => b.type === "thinking");
+
+      // thinking → reasoning items
+      for (const tb of thinkingBlocks) {
+        items.push({
+          type: "reasoning",
+          id: `rs_${Date.now()}_${items.length}`,
+          summary: [{ type: "summary_text", text: String(tb.thinking ?? "") }],
+        });
+      }
+
+      // text → assistant message
+      if (textBlocks.length > 0) {
+        const text = textBlocks.map(b => String(b.text ?? "")).join("");
+        items.push({
+          type: "message",
+          role: "assistant",
+          content: [{ type: "output_text", text }],
+        });
+      }
+
+      // tool_use → function_call
+      for (const tu of toolUseBlocks) {
+        items.push({
+          type: "function_call",
+          id: String(tu.id ?? ""),
+          call_id: stripTooluPrefix(String(tu.id ?? "")),
+          name: String(tu.name ?? ""),
+          arguments: JSON.stringify(tu.input ?? {}),
+        });
+      }
+    }
+  }
+
+  return items;
+}
+
+/** Map Anthropic tool_choice → Responses tool_choice. */
+function mapToolChoiceAnt2Responses(tc: unknown): unknown {
+  if (typeof tc === "string") {
+    if (tc === "auto") return "auto";
+    if (tc === "any") return "required";
+    return "auto";
+  }
+  if (typeof tc === "object" && tc !== null) {
+    const obj = tc as Record<string, unknown>;
+    if (obj.type === "auto") return "auto";
+    if (obj.type === "any") return "required";
+    if (obj.type === "tool" && obj.name) {
+      return { type: "function", name: String(obj.name) };
+    }
+  }
+  return "auto";
+}

--- a/src/proxy/transform/response-bridge-responses.ts
+++ b/src/proxy/transform/response-bridge-responses.ts
@@ -1,0 +1,189 @@
+/**
+ * Bridge (lossy) response transformation between OpenAI Responses API
+ * and OpenAI Chat Completions API.
+ *
+ * This is the SECONDARY conversion path used when the upstream provider
+ * only supports the opposite API format. It is lossy because Chat Completions
+ * cannot represent structured reasoning summaries, built-in tool outputs,
+ * or response-level metadata.
+ */
+
+import { generateChatcmplId, generateRespId, MS_PER_SECOND } from "./id-utils.js";
+import { parseToolArguments } from "./sanitize.js";
+
+// ---------- Responses → Chat Completions ----------
+
+/**
+ * Convert a Responses API response body to a Chat Completions response body.
+ *
+ * Lossy: structured reasoning summaries are flattened to a single string;
+ * built-in tool output items (web_search_call, etc.) are skipped.
+ */
+export function responsesToChatResponse(bodyStr: string): string {
+  const resp = JSON.parse(bodyStr) as Record<string, unknown>;
+  const output = (resp.output as Array<Record<string, unknown>>) ?? [];
+
+  const message: Record<string, unknown> = { role: "assistant" };
+  const toolCalls: Array<Record<string, unknown>> = [];
+  const textParts: string[] = [];
+  let hasFunctionCall = false;
+
+  for (const item of output) {
+    const type = item.type as string;
+
+    if (type === "message") {
+      // ResponseOutputMessage → extract text content
+      const msgContent = (item.content as Array<Record<string, unknown>>) ?? [];
+      for (const part of msgContent) {
+        if (part.type === "output_text" && part.text != null) {
+          textParts.push(String(part.text));
+        }
+      }
+    } else if (type === "function_call") {
+      // → tool_calls
+      hasFunctionCall = true;
+      toolCalls.push({
+        id: String(item.id ?? ""),
+        type: "function",
+        function: {
+          name: String(item.name ?? ""),
+          arguments: String(item.arguments ?? "{}"),
+        },
+      });
+    } else if (type === "reasoning") {
+      // → reasoning_content (joined summary text, LOSSY)
+      const summary = item.summary as Array<Record<string, unknown>> | undefined;
+      if (summary) {
+        const joined = summary.map(s => String(s.text ?? "")).join("");
+        if (joined) {
+          message.reasoning_content = joined;
+        }
+      }
+    }
+    // Other output types (web_search_call, file_search_call, etc.) → skip
+  }
+
+  // Text content
+  if (textParts.length > 0) {
+    message.content = textParts.join("");
+  }
+
+  // Tool calls
+  if (toolCalls.length > 0) {
+    message.tool_calls = toolCalls;
+  }
+
+  // finish_reason
+  let finishReason: string;
+  if (hasFunctionCall) {
+    finishReason = "tool_calls";
+  } else {
+    finishReason = mapStatusToFinishReason(String(resp.status ?? "completed"));
+  }
+
+  // Usage mapping
+  const usage = resp.usage as Record<string, unknown> | undefined;
+  const promptTokens = (usage?.input_tokens as number) ?? 0;
+  const completionTokens = (usage?.output_tokens as number) ?? 0;
+
+  return JSON.stringify({
+    id: generateChatcmplId(),
+    object: "chat.completion",
+    created: Math.floor(Date.now() / MS_PER_SECOND),
+    model: resp.model ?? "",
+    choices: [{
+      index: 0,
+      message,
+      finish_reason: finishReason,
+    }],
+    usage: {
+      prompt_tokens: promptTokens,
+      completion_tokens: completionTokens,
+      total_tokens: promptTokens + completionTokens,
+    },
+  });
+}
+
+/** Responses API status → Chat Completions finish_reason */
+function mapStatusToFinishReason(status: string): string {
+  if (status === "incomplete") return "length";
+  return "stop";
+}
+
+// ---------- Chat Completions → Responses ----------
+
+/**
+ * Convert a Chat Completions response body to a Responses API response body.
+ *
+ * Lossy: Chat Completions has no equivalent for built-in tool output items
+ * or structured reasoning summaries.
+ */
+export function chatToResponsesResponse(bodyStr: string): string {
+  const oai = JSON.parse(bodyStr) as Record<string, unknown>;
+  const choice = oai.choices?.[0] as Record<string, unknown> | undefined;
+  const msg = choice?.message as Record<string, unknown> | undefined;
+  const output: Array<Record<string, unknown>> = [];
+
+  // reasoning_content → reasoning output
+  if (msg?.reasoning_content) {
+    output.push({
+      type: "reasoning",
+      id: `rs_${Date.now()}_0`,
+      summary: [{ type: "summary_text", text: String(msg.reasoning_content) }],
+    });
+  }
+
+  // text content → message output
+  if (msg?.content) {
+    output.push({
+      type: "message",
+      id: `msg_${Date.now()}_1`,
+      role: "assistant",
+      content: [{ type: "output_text", text: String(msg.content) }],
+    });
+  }
+
+  // tool_calls → function_call output items
+  const toolCalls = msg?.tool_calls as Array<Record<string, unknown>> | undefined;
+  if (toolCalls) {
+    for (let i = 0; i < toolCalls.length; i++) {
+      const tc = toolCalls[i];
+      const fn = tc.function as Record<string, unknown> | undefined;
+      output.push({
+        type: "function_call",
+        id: String(tc.id ?? `fc_${i}`),
+        call_id: String(tc.id ?? `fc_${i}`),
+        name: String(fn?.name ?? ""),
+        arguments: String(fn?.arguments ?? "{}"),
+      });
+    }
+  }
+
+  // Status mapping
+  const finishReason = String(choice?.finish_reason ?? "stop");
+  const status = mapFinishReasonToStatus(finishReason);
+
+  // Usage mapping
+  const oaiUsage = oai.usage as Record<string, unknown> | undefined;
+  const inputTokens = (oaiUsage?.prompt_tokens as number) ?? 0;
+  const outputTokens = (oaiUsage?.completion_tokens as number) ?? 0;
+
+  return JSON.stringify({
+    id: generateRespId(),
+    object: "response",
+    model: oai.model ?? "",
+    status,
+    output,
+    usage: {
+      input_tokens: inputTokens,
+      output_tokens: outputTokens,
+      total_tokens: inputTokens + outputTokens,
+    },
+  });
+}
+
+/** Chat Completions finish_reason → Responses API status */
+function mapFinishReasonToStatus(reason: string): string {
+  if (reason === "length") return "incomplete";
+  return "completed"; // "stop", "tool_calls", and unknown → completed
+}

--- a/src/proxy/transform/response-bridge-responses.ts
+++ b/src/proxy/transform/response-bridge-responses.ts
@@ -120,7 +120,8 @@ function mapStatusToFinishReason(status: string): string {
  */
 export function chatToResponsesResponse(bodyStr: string): string {
   const oai = JSON.parse(bodyStr) as Record<string, unknown>;
-  const choice = oai.choices?.[0] as Record<string, unknown> | undefined;
+  const choices = (oai.choices ?? []) as Array<Record<string, unknown>>;
+  const choice = choices[0];
   const msg = choice?.message as Record<string, unknown> | undefined;
   const output: Array<Record<string, unknown>> = [];
 

--- a/src/proxy/transform/response-transform-responses.ts
+++ b/src/proxy/transform/response-transform-responses.ts
@@ -1,0 +1,153 @@
+import { generateMsgId, generateRespId } from "./id-utils.js";
+import { parseToolArguments } from "./sanitize.js";
+
+// ---------- Status ↔ stop_reason mapping ----------
+
+const RESP_STATUS_TO_STOP: Record<string, string> = {
+  completed: "end_turn",
+  incomplete: "max_tokens",
+  failed: "end_turn",
+};
+
+const ANT_STOP_TO_RESP_STATUS: Record<string, string> = {
+  end_turn: "completed",
+  stop_sequence: "completed",
+  tool_use: "completed",
+  max_tokens: "incomplete",
+};
+
+/** Responses API status → Anthropic stop_reason */
+function mapStatusToStopReason(status: string): string {
+  return RESP_STATUS_TO_STOP[status] ?? "end_turn";
+}
+
+/** Anthropic stop_reason → Responses API status */
+function mapStopReasonToStatus(reason: string): string {
+  return ANT_STOP_TO_RESP_STATUS[reason] ?? "completed";
+}
+
+// ---------- Responses → Anthropic ----------
+
+export function responsesToAnthropicResponse(bodyStr: string): string {
+  const resp = JSON.parse(bodyStr) as Record<string, unknown>;
+  const output = (resp.output as Array<Record<string, unknown>>) ?? [];
+  const content: Array<Record<string, unknown>> = [];
+
+  for (const item of output) {
+    const type = item.type as string;
+
+    if (type === "message") {
+      // ResponseOutputMessage → text blocks
+      const msgContent = (item.content as Array<Record<string, unknown>>) ?? [];
+      for (const part of msgContent) {
+        if (part.type === "output_text" && part.text != null) {
+          content.push({ type: "text", text: String(part.text) });
+        }
+      }
+    } else if (type === "function_call") {
+      // → tool_use block (Anthropic requires "toolu_" prefix)
+      const rawCallId = String(item.call_id ?? "");
+      const antId = rawCallId.startsWith("toolu_") ? rawCallId : `toolu_${rawCallId}`;
+      content.push({
+        type: "tool_use",
+        id: antId,
+        name: String(item.name ?? ""),
+        input: parseToolArguments(item.arguments),
+      });
+    } else if (type === "reasoning") {
+      // → thinking block
+      const summary = item.summary as Array<Record<string, unknown>> | undefined;
+      const thinkingText = summary
+        ? summary.map(s => String(s.text ?? "")).join("")
+        : "";
+      content.push({ type: "thinking", thinking: thinkingText });
+    }
+    // Other output types (web_search_call, etc.) → skip
+  }
+
+  if (content.length === 0) {
+    content.push({ type: "text", text: "" });
+  }
+
+  const usage = resp.usage as Record<string, unknown> | undefined;
+
+  return JSON.stringify({
+    id: generateMsgId(),
+    type: "message",
+    role: "assistant",
+    content,
+    model: resp.model ?? "",
+    stop_reason: mapStatusToStopReason(String(resp.status ?? "completed")),
+    stop_sequence: null,
+    usage: {
+      input_tokens: (usage?.input_tokens as number) ?? 0,
+      output_tokens: (usage?.output_tokens as number) ?? 0,
+    },
+  });
+}
+
+// ---------- Anthropic → Responses ----------
+
+/** Strip "toolu_" prefix from a tool_use_id to recover the original call_id. */
+function stripTooluPrefix(id: string): string {
+  return id.startsWith("toolu_") ? id.slice(6) : id;
+}
+
+export function anthropicToResponsesResponse(bodyStr: string): string {
+  const ant = JSON.parse(bodyStr) as Record<string, unknown>;
+  const blocks = (ant.content as Array<Record<string, unknown>>) ?? [];
+  const output: Array<Record<string, unknown>> = [];
+
+  for (const block of blocks) {
+    const type = block.type as string;
+
+    if (type === "thinking") {
+      // → reasoning output
+      output.push({
+        type: "reasoning",
+        id: `rs_${Date.now()}_${output.length}`,
+        summary: [{ type: "summary_text", text: String(block.thinking ?? "") }],
+      });
+    } else if (type === "text") {
+      // → message output
+      output.push({
+        type: "message",
+        id: generateMsgId(),
+        role: "assistant",
+        content: [{ type: "output_text", text: String(block.text ?? "") }],
+      });
+    } else if (type === "tool_use") {
+      // → function_call output
+      const rawId = String(block.id ?? "");
+      const callId = stripTooluPrefix(rawId);
+      output.push({
+        type: "function_call",
+        id: `fc_${callId}`,
+        call_id: callId,
+        name: String(block.name ?? ""),
+        arguments: JSON.stringify(block.input ?? {}),
+      });
+    }
+  }
+
+  // Usage mapping: Anthropic → Responses
+  const antUsage = ant.usage as Record<string, unknown> | undefined;
+  const inputTokens =
+    ((antUsage?.input_tokens as number) ?? 0) +
+    ((antUsage?.cache_read_input_tokens as number) ?? 0) +
+    ((antUsage?.cache_creation_input_tokens as number) ?? 0);
+  const outputTokens = (antUsage?.output_tokens as number) ?? 0;
+
+  return JSON.stringify({
+    id: generateRespId(),
+    object: "response",
+    model: ant.model ?? "",
+    status: mapStopReasonToStatus(String(ant.stop_reason ?? "end_turn")),
+    output,
+    usage: {
+      input_tokens: inputTokens,
+      output_tokens: outputTokens,
+      total_tokens: inputTokens + outputTokens,
+    },
+  });
+}

--- a/src/proxy/transform/stream-ant2resp.ts
+++ b/src/proxy/transform/stream-ant2resp.ts
@@ -1,0 +1,330 @@
+import { randomBytes } from "crypto";
+import { BaseSSETransform } from "./stream-transform-base.js";
+import { generateRespId } from "./id-utils.js";
+import { RESPONSES_SSE_EVENTS } from "./types-responses.js";
+import type { ResponsesApiResponse, ResponseOutputItem } from "./types-responses.js";
+
+type Ant2RespState = "init" | "text" | "thinking" | "tool_use" | "closing";
+
+function randomHex(bytes: number): string {
+  return randomBytes(bytes).toString("hex");
+}
+
+export class AnthropicToResponsesTransform extends BaseSSETransform {
+  private state: Ant2RespState = "init";
+  private responseId = generateRespId();
+  private outputIndex = 0;
+  private sequenceNumber = 0;
+  private hasResponseCreated = false;
+  private inputTokens = 0;
+  private outputTokens = 0;
+  private pendingStatus: string | null = null;
+  private activeToolCallId = "";
+  private collectedOutput: ResponseOutputItem[] = [];
+  private currentItemId = "";
+  private currentSummaryPartId = "";
+  private currentContentPartIndex = 0;
+  private createdAt = Math.floor(Date.now() / 1000);
+
+  private nextSeq(): number {
+    return this.sequenceNumber++;
+  }
+
+  private emitResponseCreated(): void {
+    if (this.hasResponseCreated) return;
+    this.hasResponseCreated = true;
+    const base = {
+      id: this.responseId,
+      object: "response" as const,
+      model: this.model,
+      status: "in_progress",
+      output: [],
+      created_at: this.createdAt,
+    };
+    this.pushResponsesSSE(RESPONSES_SSE_EVENTS.CREATED, {
+      type: RESPONSES_SSE_EVENTS.CREATED,
+      response: { ...base, status: "queued" },
+      sequence_number: this.nextSeq(),
+    });
+    this.pushResponsesSSE(RESPONSES_SSE_EVENTS.IN_PROGRESS, {
+      type: RESPONSES_SSE_EVENTS.IN_PROGRESS,
+      response: base,
+      sequence_number: this.nextSeq(),
+    });
+  }
+
+  protected processEvent(event: { event?: string; data?: string }): void {
+    let data: Record<string, unknown>;
+    try { data = JSON.parse(event.data!); } catch (err) { this.emit("warning", err); return; }
+
+    switch (data.type) {
+      case "message_start": {
+        const msg = data.message as Record<string, unknown> | undefined;
+        const usage = msg?.usage as Record<string, unknown> | undefined;
+        this.inputTokens = (usage?.input_tokens as number) ?? 0;
+        this.emitResponseCreated();
+        break;
+      }
+
+      case "content_block_start": {
+        const block = data.content_block as Record<string, unknown>;
+        const blockType = block?.type as string;
+
+        if (blockType === "thinking") {
+          this.state = "thinking";
+          this.currentItemId = `rs_${randomHex(12)}`;
+          this.currentSummaryPartId = `sp_${randomHex(8)}`;
+          this.pushResponsesSSE(RESPONSES_SSE_EVENTS.OUTPUT_ITEM_ADDED, {
+            type: RESPONSES_SSE_EVENTS.OUTPUT_ITEM_ADDED,
+            output_index: this.outputIndex,
+            item: { type: "reasoning", id: this.currentItemId, summary: [] },
+            sequence_number: this.nextSeq(),
+          });
+          this.pushResponsesSSE(RESPONSES_SSE_EVENTS.REASONING_SUMMARY_PART_ADDED, {
+            type: RESPONSES_SSE_EVENTS.REASONING_SUMMARY_PART_ADDED,
+            output_index: this.outputIndex,
+            summary_index: 0,
+            part: { type: "summary_text", text: "" },
+            sequence_number: this.nextSeq(),
+          });
+        } else if (blockType === "text") {
+          this.state = "text";
+          this.currentItemId = `msg_${randomHex(12)}`;
+          this.currentContentPartIndex = 0;
+          this.pushResponsesSSE(RESPONSES_SSE_EVENTS.OUTPUT_ITEM_ADDED, {
+            type: RESPONSES_SSE_EVENTS.OUTPUT_ITEM_ADDED,
+            output_index: this.outputIndex,
+            item: { type: "message", id: this.currentItemId, role: "assistant", content: [], status: "in_progress" },
+            sequence_number: this.nextSeq(),
+          });
+          this.pushResponsesSSE(RESPONSES_SSE_EVENTS.CONTENT_PART_ADDED, {
+            type: RESPONSES_SSE_EVENTS.CONTENT_PART_ADDED,
+            output_index: this.outputIndex,
+            content_index: 0,
+            part: { type: "output_text", text: "", annotations: [] },
+            sequence_number: this.nextSeq(),
+          });
+        } else if (blockType === "tool_use") {
+          this.state = "tool_use";
+          const toolId = block.id as string;
+          // Convert toolu_ prefix to fc_ prefix
+          this.activeToolCallId = toolId.startsWith("toolu_")
+            ? `fc_${toolId.slice(6)}`
+            : `fc_${randomHex(12)}`;
+          const callId = this.activeToolCallId;
+          this.currentItemId = callId;
+          this.pushResponsesSSE(RESPONSES_SSE_EVENTS.OUTPUT_ITEM_ADDED, {
+            type: RESPONSES_SSE_EVENTS.OUTPUT_ITEM_ADDED,
+            output_index: this.outputIndex,
+            item: {
+              type: "function_call",
+              id: callId,
+              call_id: callId,
+              name: block.name as string,
+              arguments: "",
+              status: "in_progress",
+            },
+            sequence_number: this.nextSeq(),
+          });
+        }
+        break;
+      }
+
+      case "content_block_delta": {
+        const delta = data.delta as Record<string, unknown>;
+        const deltaType = delta?.type as string;
+
+        if (deltaType === "thinking_delta") {
+          const thinking = delta.thinking as string;
+          if (thinking) {
+            this.pushResponsesSSE(RESPONSES_SSE_EVENTS.REASONING_SUMMARY_TEXT_DELTA, {
+              type: RESPONSES_SSE_EVENTS.REASONING_SUMMARY_TEXT_DELTA,
+              output_index: this.outputIndex,
+              summary_index: 0,
+              delta: thinking,
+              sequence_number: this.nextSeq(),
+            });
+          }
+        } else if (deltaType === "text_delta") {
+          const text = delta.text as string;
+          if (text) {
+            this.pushResponsesSSE(RESPONSES_SSE_EVENTS.OUTPUT_TEXT_DELTA, {
+              type: RESPONSES_SSE_EVENTS.OUTPUT_TEXT_DELTA,
+              output_index: this.outputIndex,
+              content_index: 0,
+              delta: text,
+              sequence_number: this.nextSeq(),
+            });
+          }
+        } else if (deltaType === "input_json_delta") {
+          const partialJson = delta.partial_json as string;
+          if (partialJson) {
+            this.pushResponsesSSE(RESPONSES_SSE_EVENTS.FUNCTION_CALL_ARGUMENTS_DELTA, {
+              type: RESPONSES_SSE_EVENTS.FUNCTION_CALL_ARGUMENTS_DELTA,
+              output_index: this.outputIndex,
+              item_id: this.currentItemId,
+              call_id: this.activeToolCallId,
+              delta: partialJson,
+              sequence_number: this.nextSeq(),
+            });
+          }
+        }
+        break;
+      }
+
+      case "content_block_stop": {
+        if (this.state === "thinking") {
+          this.pushResponsesSSE(RESPONSES_SSE_EVENTS.REASONING_SUMMARY_TEXT_DONE, {
+            type: RESPONSES_SSE_EVENTS.REASONING_SUMMARY_TEXT_DONE,
+            output_index: this.outputIndex,
+            summary_index: 0,
+            text: "",
+            sequence_number: this.nextSeq(),
+          });
+          this.pushResponsesSSE(RESPONSES_SSE_EVENTS.REASONING_SUMMARY_PART_DONE, {
+            type: RESPONSES_SSE_EVENTS.REASONING_SUMMARY_PART_DONE,
+            output_index: this.outputIndex,
+            summary_index: 0,
+            part: { type: "summary_text", text: "" },
+            sequence_number: this.nextSeq(),
+          });
+          this.pushResponsesSSE(RESPONSES_SSE_EVENTS.OUTPUT_ITEM_DONE, {
+            type: RESPONSES_SSE_EVENTS.OUTPUT_ITEM_DONE,
+            output_index: this.outputIndex,
+            item: { type: "reasoning", id: this.currentItemId, summary: [{ type: "summary_text", text: "" }] },
+            sequence_number: this.nextSeq(),
+          });
+          this.collectedOutput.push({ type: "reasoning", id: this.currentItemId, summary: [{ type: "summary_text", text: "" }] });
+        } else if (this.state === "text") {
+          this.pushResponsesSSE(RESPONSES_SSE_EVENTS.OUTPUT_TEXT_DONE, {
+            type: RESPONSES_SSE_EVENTS.OUTPUT_TEXT_DONE,
+            output_index: this.outputIndex,
+            content_index: 0,
+            text: "",
+            sequence_number: this.nextSeq(),
+          });
+          this.pushResponsesSSE(RESPONSES_SSE_EVENTS.CONTENT_PART_DONE, {
+            type: RESPONSES_SSE_EVENTS.CONTENT_PART_DONE,
+            output_index: this.outputIndex,
+            content_index: 0,
+            part: { type: "output_text", text: "", annotations: [] },
+            sequence_number: this.nextSeq(),
+          });
+          this.pushResponsesSSE(RESPONSES_SSE_EVENTS.OUTPUT_ITEM_DONE, {
+            type: RESPONSES_SSE_EVENTS.OUTPUT_ITEM_DONE,
+            output_index: this.outputIndex,
+            item: { type: "message", id: this.currentItemId, role: "assistant", content: [{ type: "output_text", text: "", annotations: [] }], status: "completed" },
+            sequence_number: this.nextSeq(),
+          });
+          this.collectedOutput.push({
+            type: "message", id: this.currentItemId, role: "assistant",
+            content: [{ type: "output_text", text: "", annotations: [] }],
+          });
+        } else if (this.state === "tool_use") {
+          this.pushResponsesSSE(RESPONSES_SSE_EVENTS.FUNCTION_CALL_ARGUMENTS_DONE, {
+            type: RESPONSES_SSE_EVENTS.FUNCTION_CALL_ARGUMENTS_DONE,
+            output_index: this.outputIndex,
+            item_id: this.currentItemId,
+            call_id: this.activeToolCallId,
+            arguments: "",
+            sequence_number: this.nextSeq(),
+          });
+          this.pushResponsesSSE(RESPONSES_SSE_EVENTS.OUTPUT_ITEM_DONE, {
+            type: RESPONSES_SSE_EVENTS.OUTPUT_ITEM_DONE,
+            output_index: this.outputIndex,
+            item: {
+              type: "function_call", id: this.activeToolCallId,
+              call_id: this.activeToolCallId,
+              name: "", arguments: "", status: "completed",
+            },
+            sequence_number: this.nextSeq(),
+          });
+          this.collectedOutput.push({
+            type: "function_call", id: this.activeToolCallId,
+            call_id: this.activeToolCallId, name: "", arguments: "",
+          });
+        }
+        this.outputIndex++;
+        this.state = "init";
+        break;
+      }
+
+      case "message_delta": {
+        const msgDelta = data.delta as Record<string, unknown>;
+        const usage = data.usage as Record<string, unknown> | undefined;
+        this.outputTokens = (usage?.output_tokens as number) ?? this.outputTokens;
+
+        const stopReason = msgDelta?.stop_reason as string | undefined;
+        if (stopReason === "tool_use") {
+          this.pendingStatus = "completed"; // will have function_calls → status remains completed
+        } else if (stopReason === "max_tokens") {
+          this.pendingStatus = "incomplete";
+        } else {
+          this.pendingStatus = "completed";
+        }
+        break;
+      }
+
+      case "message_stop": {
+        this.emitCompleted();
+        break;
+      }
+
+      case "error": {
+        const error = data.error as Record<string, unknown>;
+        this.pushResponsesSSE(RESPONSES_SSE_EVENTS.ERROR, {
+          type: "error",
+          message: (error?.message as string) ?? "Stream error",
+          code: (error?.type as string) ?? "upstream_error",
+        });
+        this.pushDone();
+        break;
+      }
+
+      case "ping": {
+        break;
+      }
+
+      default: {
+        this.emit("warning", { event: "unknown_event", type: data.type });
+        break;
+      }
+    }
+  }
+
+  private emitCompleted(): void {
+    const status = this.pendingStatus ?? "completed";
+    const completedAt = Math.floor(Date.now() / 1000);
+    const response: ResponsesApiResponse = {
+      id: this.responseId,
+      object: "response",
+      model: this.model,
+      status: status as ResponsesApiResponse["status"],
+      output: this.collectedOutput,
+      usage: {
+        input_tokens: this.inputTokens,
+        output_tokens: this.outputTokens,
+        total_tokens: this.inputTokens + this.outputTokens,
+      },
+      created_at: this.createdAt,
+      completed_at: completedAt,
+    };
+    this.pushResponsesSSE(RESPONSES_SSE_EVENTS.COMPLETED, {
+      type: RESPONSES_SSE_EVENTS.COMPLETED,
+      response,
+      sequence_number: this.nextSeq(),
+    });
+    this.pushDone();
+  }
+
+  protected flushPendingData(): void {
+    // No buffered data to flush
+  }
+
+  protected ensureTerminated(): void {
+    if (!this.done) {
+      this.emitResponseCreated();
+      this.emitCompleted();
+    }
+  }
+}

--- a/src/proxy/transform/stream-bridge-chat2resp.ts
+++ b/src/proxy/transform/stream-bridge-chat2resp.ts
@@ -1,0 +1,398 @@
+import { randomBytes } from "crypto";
+import { BaseSSETransform } from "./stream-transform-base.js";
+import { generateRespId } from "./id-utils.js";
+import { RESPONSES_SSE_EVENTS } from "./types-responses.js";
+import type { ResponsesApiResponse, ResponseOutputItem } from "./types-responses.js";
+
+function randomHex(bytes: number): string {
+  return randomBytes(bytes).toString("hex");
+}
+
+/**
+ * Bridge transform: Chat Completions SSE → Responses API SSE.
+ *
+ * Used when the client sends a Responses API request but the upstream
+ * provider speaks Chat Completions. This is a lossy conversion —
+ * Responses API has richer event types than Chat delta chunks.
+ */
+export class ChatToResponsesBridgeTransform extends BaseSSETransform {
+  private responseId = generateRespId();
+  private hasResponseCreated = false;
+  private outputIndex = 0;
+  private contentIndex = 0;
+  private sequenceNumber = 0;
+  private hasMessageItemStarted = false;
+  private hasContentPartStarted = false;
+  private hasReasoningItemStarted = false;
+  private inputTokens = 0;
+  private outputTokens = 0;
+  private pendingCompletion = false;
+  private collectedOutput: ResponseOutputItem[] = [];
+  private currentMessageItemId = "";
+  private currentFunctionCallId = "";
+  private currentFunctionCallName = "";
+  private currentReasoningItemId = "";
+  private createdAt = Math.floor(Date.now() / 1000);
+
+  private nextSeq(): number {
+    return this.sequenceNumber++;
+  }
+
+  private ensureResponseCreated(): void {
+    if (this.hasResponseCreated) return;
+    this.hasResponseCreated = true;
+    const base = {
+      id: this.responseId,
+      object: "response" as const,
+      model: this.model,
+      status: "in_progress",
+      output: [],
+      created_at: this.createdAt,
+    };
+    this.pushResponsesSSE(RESPONSES_SSE_EVENTS.CREATED, {
+      type: RESPONSES_SSE_EVENTS.CREATED,
+      response: { ...base, status: "queued" },
+      sequence_number: this.nextSeq(),
+    });
+    this.pushResponsesSSE(RESPONSES_SSE_EVENTS.IN_PROGRESS, {
+      type: RESPONSES_SSE_EVENTS.IN_PROGRESS,
+      response: base,
+      sequence_number: this.nextSeq(),
+    });
+  }
+
+  private closeCurrentMessageItem(): void {
+    if (this.hasContentPartStarted) {
+      this.pushResponsesSSE(RESPONSES_SSE_EVENTS.OUTPUT_TEXT_DONE, {
+        type: RESPONSES_SSE_EVENTS.OUTPUT_TEXT_DONE,
+        output_index: this.outputIndex,
+        content_index: this.contentIndex,
+        text: "",
+        sequence_number: this.nextSeq(),
+      });
+      this.pushResponsesSSE(RESPONSES_SSE_EVENTS.CONTENT_PART_DONE, {
+        type: RESPONSES_SSE_EVENTS.CONTENT_PART_DONE,
+        output_index: this.outputIndex,
+        content_index: this.contentIndex,
+        part: { type: "output_text", text: "", annotations: [] },
+        sequence_number: this.nextSeq(),
+      });
+      this.hasContentPartStarted = false;
+    }
+    if (this.hasMessageItemStarted) {
+      this.pushResponsesSSE(RESPONSES_SSE_EVENTS.OUTPUT_ITEM_DONE, {
+        type: RESPONSES_SSE_EVENTS.OUTPUT_ITEM_DONE,
+        output_index: this.outputIndex,
+        item: {
+          type: "message",
+          id: this.currentMessageItemId,
+          role: "assistant",
+          content: [{ type: "output_text", text: "", annotations: [] }],
+          status: "completed",
+        },
+        sequence_number: this.nextSeq(),
+      });
+      this.collectedOutput.push({
+        type: "message",
+        id: this.currentMessageItemId,
+        role: "assistant",
+        content: [{ type: "output_text", text: "", annotations: [] }],
+      });
+      this.hasMessageItemStarted = false;
+      this.outputIndex++;
+    }
+  }
+
+  private closeCurrentReasoningItem(): void {
+    if (!this.hasReasoningItemStarted) return;
+    this.pushResponsesSSE(RESPONSES_SSE_EVENTS.REASONING_SUMMARY_TEXT_DONE, {
+      type: RESPONSES_SSE_EVENTS.REASONING_SUMMARY_TEXT_DONE,
+      output_index: this.outputIndex,
+      summary_index: 0,
+      text: "",
+      sequence_number: this.nextSeq(),
+    });
+    this.pushResponsesSSE(RESPONSES_SSE_EVENTS.REASONING_SUMMARY_PART_DONE, {
+      type: RESPONSES_SSE_EVENTS.REASONING_SUMMARY_PART_DONE,
+      output_index: this.outputIndex,
+      summary_index: 0,
+      part: { type: "summary_text", text: "" },
+      sequence_number: this.nextSeq(),
+    });
+    this.pushResponsesSSE(RESPONSES_SSE_EVENTS.OUTPUT_ITEM_DONE, {
+      type: RESPONSES_SSE_EVENTS.OUTPUT_ITEM_DONE,
+      output_index: this.outputIndex,
+      item: {
+        type: "reasoning",
+        id: this.currentReasoningItemId,
+        summary: [{ type: "summary_text", text: "" }],
+      },
+      sequence_number: this.nextSeq(),
+    });
+    this.collectedOutput.push({
+      type: "reasoning",
+      id: this.currentReasoningItemId,
+      summary: [{ type: "summary_text", text: "" }],
+    });
+    this.hasReasoningItemStarted = false;
+    this.outputIndex++;
+  }
+
+  private closeCurrentFunctionCall(): void {
+    this.pushResponsesSSE(RESPONSES_SSE_EVENTS.FUNCTION_CALL_ARGUMENTS_DONE, {
+      type: RESPONSES_SSE_EVENTS.FUNCTION_CALL_ARGUMENTS_DONE,
+      output_index: this.outputIndex,
+      item_id: this.currentFunctionCallId,
+      call_id: this.currentFunctionCallId,
+      arguments: "",
+      sequence_number: this.nextSeq(),
+    });
+    this.pushResponsesSSE(RESPONSES_SSE_EVENTS.OUTPUT_ITEM_DONE, {
+      type: RESPONSES_SSE_EVENTS.OUTPUT_ITEM_DONE,
+      output_index: this.outputIndex,
+      item: {
+        type: "function_call",
+        id: this.currentFunctionCallId,
+        call_id: this.currentFunctionCallId,
+        name: this.currentFunctionCallName,
+        arguments: "",
+        status: "completed",
+      },
+      sequence_number: this.nextSeq(),
+    });
+    this.collectedOutput.push({
+      type: "function_call",
+      id: this.currentFunctionCallId,
+      call_id: this.currentFunctionCallId,
+      name: this.currentFunctionCallName,
+      arguments: "",
+    });
+    this.outputIndex++;
+    this.currentFunctionCallId = "";
+    this.currentFunctionCallName = "";
+  }
+
+  private closeAllOpenItems(): void {
+    this.closeCurrentReasoningItem();
+    this.closeCurrentMessageItem();
+    if (this.currentFunctionCallId) {
+      this.closeCurrentFunctionCall();
+    }
+  }
+
+  private emitCompleted(): void {
+    const completedAt = Math.floor(Date.now() / 1000);
+    const response: ResponsesApiResponse = {
+      id: this.responseId,
+      object: "response",
+      model: this.model,
+      status: "completed",
+      output: this.collectedOutput,
+      usage: {
+        input_tokens: this.inputTokens,
+        output_tokens: this.outputTokens,
+        total_tokens: this.inputTokens + this.outputTokens,
+      },
+      created_at: this.createdAt,
+      completed_at: completedAt,
+    };
+    this.pushResponsesSSE(RESPONSES_SSE_EVENTS.COMPLETED, {
+      type: RESPONSES_SSE_EVENTS.COMPLETED,
+      response,
+      sequence_number: this.nextSeq(),
+    });
+    this.pushDone();
+  }
+
+  protected processEvent(event: { event?: string; data?: string }): void {
+    let chunk: Record<string, unknown>;
+    try { chunk = JSON.parse(event.data!); } catch (err) { this.emit("warning", err); return; }
+
+    // Extract usage when present (usage-only chunks or chunks with usage)
+    if (chunk.usage) {
+      const usage = chunk.usage as Record<string, number>;
+      this.inputTokens = usage.prompt_tokens ?? this.inputTokens;
+      this.outputTokens = usage.completion_tokens ?? this.outputTokens;
+    }
+
+    // Usage-only chunk (no choices) — may trigger completion
+    if (chunk.usage && !(Array.isArray(chunk.choices) && chunk.choices.length > 0)) {
+      if (this.pendingCompletion) {
+        this.closeAllOpenItems();
+        this.emitCompleted();
+        this.pendingCompletion = false;
+      }
+      return;
+    }
+
+    const choices = chunk.choices as Array<Record<string, unknown>> | undefined;
+    const choice = choices?.[0];
+    if (!choice) return;
+
+    const delta = choice.delta as Record<string, unknown> | undefined;
+
+    // First chunk with role → emit response.created + response.in_progress
+    if (delta?.role === "assistant") {
+      this.ensureResponseCreated();
+    }
+
+    // Handle reasoning_content
+    if (delta?.reasoning_content != null && delta.reasoning_content !== "") {
+      this.ensureResponseCreated();
+      // Close message item if open (reasoning comes first, but could be interleaved)
+      this.closeCurrentMessageItem();
+
+      if (!this.hasReasoningItemStarted) {
+        this.hasReasoningItemStarted = true;
+        this.currentReasoningItemId = `rs_${randomHex(12)}`;
+        this.pushResponsesSSE(RESPONSES_SSE_EVENTS.OUTPUT_ITEM_ADDED, {
+          type: RESPONSES_SSE_EVENTS.OUTPUT_ITEM_ADDED,
+          output_index: this.outputIndex,
+          item: { type: "reasoning", id: this.currentReasoningItemId, summary: [] },
+          sequence_number: this.nextSeq(),
+        });
+        this.pushResponsesSSE(RESPONSES_SSE_EVENTS.REASONING_SUMMARY_PART_ADDED, {
+          type: RESPONSES_SSE_EVENTS.REASONING_SUMMARY_PART_ADDED,
+          output_index: this.outputIndex,
+          summary_index: 0,
+          part: { type: "summary_text", text: "" },
+          sequence_number: this.nextSeq(),
+        });
+      }
+      this.pushResponsesSSE(RESPONSES_SSE_EVENTS.REASONING_SUMMARY_TEXT_DELTA, {
+        type: RESPONSES_SSE_EVENTS.REASONING_SUMMARY_TEXT_DELTA,
+        output_index: this.outputIndex,
+        summary_index: 0,
+        delta: delta.reasoning_content as string,
+        sequence_number: this.nextSeq(),
+      });
+    }
+
+    // Handle text content
+    if (delta?.content != null && delta.content !== "") {
+      this.ensureResponseCreated();
+      // Close reasoning item if transitioning to text
+      this.closeCurrentReasoningItem();
+
+      if (!this.hasMessageItemStarted) {
+        this.hasMessageItemStarted = true;
+        this.contentIndex = 0;
+        this.currentMessageItemId = `msg_${randomHex(12)}`;
+        this.pushResponsesSSE(RESPONSES_SSE_EVENTS.OUTPUT_ITEM_ADDED, {
+          type: RESPONSES_SSE_EVENTS.OUTPUT_ITEM_ADDED,
+          output_index: this.outputIndex,
+          item: {
+            type: "message",
+            id: this.currentMessageItemId,
+            role: "assistant",
+            content: [],
+            status: "in_progress",
+          },
+          sequence_number: this.nextSeq(),
+        });
+      }
+      if (!this.hasContentPartStarted) {
+        this.hasContentPartStarted = true;
+        this.pushResponsesSSE(RESPONSES_SSE_EVENTS.CONTENT_PART_ADDED, {
+          type: RESPONSES_SSE_EVENTS.CONTENT_PART_ADDED,
+          output_index: this.outputIndex,
+          content_index: this.contentIndex,
+          part: { type: "output_text", text: "", annotations: [] },
+          sequence_number: this.nextSeq(),
+        });
+      }
+      this.pushResponsesSSE(RESPONSES_SSE_EVENTS.OUTPUT_TEXT_DELTA, {
+        type: RESPONSES_SSE_EVENTS.OUTPUT_TEXT_DELTA,
+        output_index: this.outputIndex,
+        content_index: this.contentIndex,
+        delta: delta.content as string,
+        sequence_number: this.nextSeq(),
+      });
+    }
+
+    // Handle tool_calls
+    const toolCalls = delta?.tool_calls as Array<Record<string, unknown>> | undefined;
+    if (toolCalls) {
+      this.ensureResponseCreated();
+      // Close any open items before starting a tool call
+      this.closeCurrentReasoningItem();
+      this.closeCurrentMessageItem();
+
+      for (const tc of toolCalls) {
+        const fn = tc.function as Record<string, unknown> | undefined;
+        const tcId = tc.id as string | undefined;
+        const tcName = fn?.name as string | undefined;
+
+        // New tool call (has id + name)
+        if (tcId && tcName) {
+          // Close previous function call if any
+          if (this.currentFunctionCallId) {
+            this.closeCurrentFunctionCall();
+          }
+          this.currentFunctionCallId = tcId;
+          this.currentFunctionCallName = tcName;
+          this.pushResponsesSSE(RESPONSES_SSE_EVENTS.OUTPUT_ITEM_ADDED, {
+            type: RESPONSES_SSE_EVENTS.OUTPUT_ITEM_ADDED,
+            output_index: this.outputIndex,
+            item: {
+              type: "function_call",
+              id: tcId,
+              call_id: tcId,
+              name: tcName,
+              arguments: "",
+              status: "in_progress",
+            },
+            sequence_number: this.nextSeq(),
+          });
+          // Also emit any initial arguments
+          const args = fn?.arguments as string | undefined;
+          if (args && args !== "") {
+            this.pushResponsesSSE(RESPONSES_SSE_EVENTS.FUNCTION_CALL_ARGUMENTS_DELTA, {
+              type: RESPONSES_SSE_EVENTS.FUNCTION_CALL_ARGUMENTS_DELTA,
+              output_index: this.outputIndex,
+              item_id: tcId,
+              call_id: tcId,
+              delta: args,
+              sequence_number: this.nextSeq(),
+            });
+          }
+        } else if (fn?.arguments) {
+          // Arguments continuation for current tool call
+          this.pushResponsesSSE(RESPONSES_SSE_EVENTS.FUNCTION_CALL_ARGUMENTS_DELTA, {
+            type: RESPONSES_SSE_EVENTS.FUNCTION_CALL_ARGUMENTS_DELTA,
+            output_index: this.outputIndex,
+            item_id: this.currentFunctionCallId,
+            call_id: this.currentFunctionCallId,
+            delta: fn.arguments as string,
+            sequence_number: this.nextSeq(),
+          });
+        }
+      }
+    }
+
+    // Handle finish_reason
+    const finishReason = choice.finish_reason as string | undefined;
+    if (finishReason) {
+      this.closeAllOpenItems();
+      this.pendingCompletion = true;
+      // If there's no usage-only chunk coming, emit completed now
+      // Usage chunk may come in a separate chunk or was already in this chunk
+      if (chunk.usage) {
+        this.emitCompleted();
+        this.pendingCompletion = false;
+      }
+    }
+  }
+
+  protected flushPendingData(): void {
+    // No buffered data to flush
+  }
+
+  protected ensureTerminated(): void {
+    if (!this.done) {
+      this.ensureResponseCreated();
+      this.closeAllOpenItems();
+      this.emitCompleted();
+    }
+  }
+}

--- a/src/proxy/transform/stream-bridge-resp2chat.ts
+++ b/src/proxy/transform/stream-bridge-resp2chat.ts
@@ -1,0 +1,249 @@
+import { BaseSSETransform } from "./stream-transform-base.js";
+import { generateChatcmplId } from "./id-utils.js";
+
+/**
+ * Bridge transform: Responses API SSE → Chat Completions SSE.
+ *
+ * Used when the client sends a Chat Completions request but the upstream
+ * provider speaks Responses API. This is a lossy conversion —
+ * Chat Completions has fewer event types than Responses API.
+ */
+export class ResponsesToChatBridgeTransform extends BaseSSETransform {
+  private chatcmplId = generateChatcmplId();
+  private hasSentRole = false;
+  private currentToolCallIndex = 0;
+  private inputTokens = 0;
+  private outputTokens = 0;
+  private finishReasonEmitted = false;
+  private hasFunctionCall = false;
+
+  private ensureRoleSent(): void {
+    if (this.hasSentRole) return;
+    this.hasSentRole = true;
+    this.pushOpenAISSE({
+      id: this.chatcmplId,
+      object: "chat.completion.chunk",
+      choices: [{ index: 0, delta: { role: "assistant" }, finish_reason: null }],
+    });
+  }
+
+  protected processEvent(event: { event?: string; data?: string }): void {
+    const eventType = event.event;
+    let payload: Record<string, unknown>;
+    try { payload = JSON.parse(event.data!); } catch (err) { this.emit("warning", err); return; }
+
+    switch (eventType) {
+      case "response.created":
+      case "response.in_progress":
+      case "response.queued": {
+        // Extract usage from response object if present
+        const resp = payload.response as Record<string, unknown> | undefined;
+        if (resp?.usage) {
+          const usage = resp.usage as Record<string, unknown>;
+          this.inputTokens = (usage.input_tokens as number) ?? this.inputTokens;
+          this.outputTokens = (usage.output_tokens as number) ?? this.outputTokens;
+        }
+        break;
+      }
+
+      case "response.output_text.delta": {
+        this.ensureRoleSent();
+        const delta = payload.delta as string;
+        if (delta) {
+          this.pushOpenAISSE({
+            id: this.chatcmplId,
+            object: "chat.completion.chunk",
+            choices: [{ index: 0, delta: { content: delta }, finish_reason: null }],
+          });
+        }
+        break;
+      }
+
+      case "response.output_item.added": {
+        const item = payload.item as Record<string, unknown>;
+        const itemType = item?.type as string;
+
+        if (itemType === "function_call") {
+          this.ensureRoleSent();
+          this.hasFunctionCall = true;
+          const tcIndex = this.currentToolCallIndex++;
+          const callId = (item.call_id as string) ?? (item.id as string);
+          const name = (item.name as string) ?? "";
+          this.pushOpenAISSE({
+            id: this.chatcmplId,
+            object: "chat.completion.chunk",
+            choices: [{
+              index: 0,
+              delta: {
+                tool_calls: [{
+                  index: tcIndex,
+                  id: callId,
+                  type: "function",
+                  function: { name, arguments: "" },
+                }],
+              },
+              finish_reason: null,
+            }],
+          });
+        }
+        // Other item types (message, reasoning) — skip, content comes via delta events
+        break;
+      }
+
+      case "response.function_call_arguments.delta": {
+        const delta = payload.delta as string;
+        if (delta) {
+          // Use currentToolCallIndex - 1 because the tool call was already registered
+          const tcIndex = this.currentToolCallIndex - 1;
+          this.pushOpenAISSE({
+            id: this.chatcmplId,
+            object: "chat.completion.chunk",
+            choices: [{
+              index: 0,
+              delta: {
+                tool_calls: [{ index: tcIndex, function: { arguments: delta } }],
+              },
+              finish_reason: null,
+            }],
+          });
+        }
+        break;
+      }
+
+      case "response.reasoning_summary_text.delta": {
+        this.ensureRoleSent();
+        const delta = payload.delta as string;
+        if (delta) {
+          this.pushOpenAISSE({
+            id: this.chatcmplId,
+            object: "chat.completion.chunk",
+            choices: [{ index: 0, delta: { reasoning_content: delta }, finish_reason: null }],
+          });
+        }
+        break;
+      }
+
+      case "response.completed": {
+        const resp = payload.response as Record<string, unknown>;
+        if (resp?.usage) {
+          const usage = resp.usage as Record<string, unknown>;
+          this.inputTokens = (usage.input_tokens as number) ?? this.inputTokens;
+          this.outputTokens = (usage.output_tokens as number) ?? this.outputTokens;
+        }
+
+        if (!this.finishReasonEmitted) {
+          this.finishReasonEmitted = true;
+          const finishReason = this.hasFunctionCall ? "tool_calls" : "stop";
+          this.pushOpenAISSE({
+            id: this.chatcmplId,
+            object: "chat.completion.chunk",
+            choices: [{ index: 0, delta: {}, finish_reason: finishReason }],
+          });
+        }
+
+        // Emit usage chunk
+        this.pushOpenAISSE({
+          id: this.chatcmplId,
+          object: "chat.completion.chunk",
+          choices: [],
+          usage: {
+            prompt_tokens: this.inputTokens,
+            completion_tokens: this.outputTokens,
+            total_tokens: this.inputTokens + this.outputTokens,
+          },
+        });
+        this.pushDone();
+        break;
+      }
+
+      case "response.incomplete": {
+        if (!this.finishReasonEmitted) {
+          this.finishReasonEmitted = true;
+          this.pushOpenAISSE({
+            id: this.chatcmplId,
+            object: "chat.completion.chunk",
+            choices: [{ index: 0, delta: {}, finish_reason: "length" }],
+          });
+        }
+        this.pushOpenAISSE({
+          id: this.chatcmplId,
+          object: "chat.completion.chunk",
+          choices: [],
+          usage: {
+            prompt_tokens: this.inputTokens,
+            completion_tokens: this.outputTokens,
+            total_tokens: this.inputTokens + this.outputTokens,
+          },
+        });
+        this.pushDone();
+        break;
+      }
+
+      case "response.failed": {
+        const resp = payload.response as Record<string, unknown>;
+        const err = resp?.error as Record<string, unknown> | undefined;
+        this.pushOpenAISSE({
+          error: {
+            message: (err?.message as string) ?? "Upstream error",
+            type: (err?.type as string) ?? "api_error",
+            code: (err?.code as string) ?? "upstream_error",
+          },
+        });
+        this.pushDone();
+        break;
+      }
+
+      case "response.output_text.done":
+      case "response.content_part.added":
+      case "response.content_part.done":
+      case "response.output_item.done":
+      case "response.function_call_arguments.done":
+      case "response.reasoning_summary_part.added":
+      case "response.reasoning_summary_text.done":
+      case "response.reasoning_summary_part.done":
+      case "response.reasoning_text.delta":
+      case "response.reasoning_text.done":
+      case "response.refusal.delta":
+      case "response.refusal.done": {
+        // These events don't map to Chat SSE — skip
+        break;
+      }
+
+      case "error": {
+        this.pushOpenAISSE({
+          error: {
+            message: (payload.message as string) ?? "Stream error",
+            type: (payload.type as string) ?? "api_error",
+            code: "upstream_error",
+          },
+        });
+        this.pushDone();
+        break;
+      }
+
+      default: {
+        this.emit("warning", { event: "unknown_sse_event", eventType });
+        break;
+      }
+    }
+  }
+
+  protected flushPendingData(): void {
+    // No buffered data
+  }
+
+  protected ensureTerminated(): void {
+    if (!this.done) {
+      this.ensureRoleSent();
+      if (!this.finishReasonEmitted) {
+        this.finishReasonEmitted = true;
+        this.pushOpenAISSE({
+          id: this.chatcmplId,
+          object: "chat.completion.chunk",
+          choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+        });
+      }
+      this.pushDone();
+    }
+  }
+}

--- a/src/proxy/transform/stream-resp2ant.ts
+++ b/src/proxy/transform/stream-resp2ant.ts
@@ -76,7 +76,9 @@ export class ResponsesToAnthropicTransform extends BaseSSETransform {
           // Don't start content block yet — wait for content_part.added
         } else if (itemType === "function_call") {
           this.hasFunctionCall = true;
-          const toolId = tracked.callId ?? tracked.id;
+          const rawCallId = tracked.callId ?? tracked.id;
+          // Anthropic requires "toolu_" prefix on tool_use IDs
+          const toolId = rawCallId.startsWith("toolu_") ? rawCallId : `toolu_${rawCallId}`;
           const toolName = tracked.name ?? "";
           this.pushAnthropicSSE("content_block_start", {
             type: "content_block_start",

--- a/src/proxy/transform/stream-resp2ant.ts
+++ b/src/proxy/transform/stream-resp2ant.ts
@@ -164,28 +164,13 @@ export class ResponsesToAnthropicTransform extends BaseSSETransform {
       }
 
       case "response.output_item.done": {
-        const item = payload.item as Record<string, unknown>;
         const outputIdx = (payload.output_index as number) ?? this.currentOutputIndex;
-        const itemType = item?.type as string;
 
-        if (itemType === "function_call") {
-          // Send content_block_stop with tool_use id/name from the done event
-          const tracked = this.activeItems.get(outputIdx);
-          const toolId = item.call_id as string ?? tracked?.callId ?? tracked?.id ?? "";
-          const toolName = item.name as string ?? tracked?.name ?? "";
-          // Re-emit content_block_start if we need to update (but typically already done at added)
-          // Just emit stop
-          this.pushAnthropicSSE("content_block_stop", {
-            type: "content_block_stop",
-            index: this.blockIndex,
-          });
-        } else {
-          // message or reasoning — emit content_block_stop
-          this.pushAnthropicSSE("content_block_stop", {
-            type: "content_block_stop",
-            index: this.blockIndex,
-          });
-        }
+        // content_block_stop — same for all item types (index-only)
+        this.pushAnthropicSSE("content_block_stop", {
+          type: "content_block_stop",
+          index: this.blockIndex,
+        });
 
         this.activeItems.delete(outputIdx);
         this.blockIndex++;

--- a/src/proxy/transform/stream-resp2ant.ts
+++ b/src/proxy/transform/stream-resp2ant.ts
@@ -1,0 +1,273 @@
+import { BaseSSETransform } from "./stream-transform-base.js";
+import { generateMsgId } from "./id-utils.js";
+
+interface TrackedItem {
+  type: string;
+  id: string;
+  name?: string;
+  callId?: string;
+  outputIndex: number;
+}
+
+export class ResponsesToAnthropicTransform extends BaseSSETransform {
+  private hasSentMessageStart = false;
+  private blockIndex = 0;
+  private msgId = generateMsgId();
+  private inputTokens = 0;
+  private outputTokens = 0;
+  private currentOutputIndex = -1;
+  private hasSentMessageStop = false;
+  private hasFunctionCall = false;
+  // Track current items by output_index
+  private activeItems: Map<number, TrackedItem> = new Map();
+
+  private ensureMessageStart(): void {
+    if (this.hasSentMessageStart) return;
+    this.hasSentMessageStart = true;
+    this.pushAnthropicSSE("message_start", {
+      type: "message_start",
+      message: {
+        id: this.msgId,
+        type: "message",
+        role: "assistant",
+        content: [],
+        model: this.model,
+        status: "in_progress",
+        usage: { input_tokens: this.inputTokens },
+      },
+    });
+  }
+
+  protected processEvent(event: { event?: string; data?: string }): void {
+    const eventType = event.event;
+    let payload: Record<string, unknown>;
+    try { payload = JSON.parse(event.data!); } catch (err) { this.emit("warning", err); return; }
+
+    switch (eventType) {
+      case "response.created":
+      case "response.in_progress":
+      case "response.queued": {
+        // Extract usage from response object if present
+        const resp = payload.response as Record<string, unknown> | undefined;
+        if (resp?.usage) {
+          const usage = resp.usage as Record<string, unknown>;
+          this.inputTokens = (usage.input_tokens as number) ?? this.inputTokens;
+        }
+        break;
+      }
+
+      case "response.output_item.added": {
+        this.ensureMessageStart();
+        const item = payload.item as Record<string, unknown>;
+        const outputIdx = (payload.output_index as number) ?? this.blockIndex;
+        this.currentOutputIndex = outputIdx;
+        const itemType = item?.type as string;
+
+        const tracked: TrackedItem = {
+          type: itemType,
+          id: (item?.id as string) ?? "",
+          name: item?.name as string | undefined,
+          callId: (item?.call_id as string) ?? undefined,
+          outputIndex: outputIdx,
+        };
+        this.activeItems.set(outputIdx, tracked);
+
+        if (itemType === "message") {
+          // Don't start content block yet — wait for content_part.added
+        } else if (itemType === "function_call") {
+          this.hasFunctionCall = true;
+          const toolId = tracked.callId ?? tracked.id;
+          const toolName = tracked.name ?? "";
+          this.pushAnthropicSSE("content_block_start", {
+            type: "content_block_start",
+            index: this.blockIndex,
+            content_block: { type: "tool_use", id: toolId, name: toolName, input: {} },
+          });
+        } else if (itemType === "reasoning") {
+          this.pushAnthropicSSE("content_block_start", {
+            type: "content_block_start",
+            index: this.blockIndex,
+            content_block: { type: "thinking", thinking: "" },
+          });
+        }
+        break;
+      }
+
+      case "response.content_part.added": {
+        this.ensureMessageStart();
+        const part = payload.part as Record<string, unknown>;
+        const partType = part?.type as string;
+        if (partType === "output_text") {
+          this.pushAnthropicSSE("content_block_start", {
+            type: "content_block_start",
+            index: this.blockIndex,
+            content_block: { type: "text", text: "" },
+          });
+        }
+        break;
+      }
+
+      case "response.output_text.delta": {
+        const delta = payload.delta as string;
+        if (delta) {
+          this.pushAnthropicSSE("content_block_delta", {
+            type: "content_block_delta",
+            index: this.blockIndex,
+            delta: { type: "text_delta", text: delta },
+          });
+        }
+        break;
+      }
+
+      case "response.output_text.done":
+      case "response.content_part.done": {
+        // Nothing to emit — wait for output_item.done to send content_block_stop
+        break;
+      }
+
+      case "response.reasoning_summary_text.delta": {
+        const delta = payload.delta as string;
+        if (delta) {
+          this.pushAnthropicSSE("content_block_delta", {
+            type: "content_block_delta",
+            index: this.blockIndex,
+            delta: { type: "thinking_delta", thinking: delta },
+          });
+        }
+        break;
+      }
+
+      case "response.reasoning_summary_part.added":
+      case "response.reasoning_summary_text.done":
+      case "response.reasoning_summary_part.done": {
+        // Sub-events of reasoning — no Anthropic equivalent, handled at output_item.done
+        break;
+      }
+
+      case "response.function_call_arguments.delta": {
+        const delta = payload.delta as string;
+        if (delta) {
+          this.pushAnthropicSSE("content_block_delta", {
+            type: "content_block_delta",
+            index: this.blockIndex,
+            delta: { type: "input_json_delta", partial_json: delta },
+          });
+        }
+        break;
+      }
+
+      case "response.function_call_arguments.done": {
+        // Nothing — wait for output_item.done
+        break;
+      }
+
+      case "response.output_item.done": {
+        const item = payload.item as Record<string, unknown>;
+        const outputIdx = (payload.output_index as number) ?? this.currentOutputIndex;
+        const itemType = item?.type as string;
+
+        if (itemType === "function_call") {
+          // Send content_block_stop with tool_use id/name from the done event
+          const tracked = this.activeItems.get(outputIdx);
+          const toolId = item.call_id as string ?? tracked?.callId ?? tracked?.id ?? "";
+          const toolName = item.name as string ?? tracked?.name ?? "";
+          // Re-emit content_block_start if we need to update (but typically already done at added)
+          // Just emit stop
+          this.pushAnthropicSSE("content_block_stop", {
+            type: "content_block_stop",
+            index: this.blockIndex,
+          });
+        } else {
+          // message or reasoning — emit content_block_stop
+          this.pushAnthropicSSE("content_block_stop", {
+            type: "content_block_stop",
+            index: this.blockIndex,
+          });
+        }
+
+        this.activeItems.delete(outputIdx);
+        this.blockIndex++;
+        break;
+      }
+
+      case "response.completed": {
+        const resp = payload.response as Record<string, unknown>;
+        if (resp?.usage) {
+          const usage = resp.usage as Record<string, unknown>;
+          this.inputTokens = (usage.input_tokens as number) ?? this.inputTokens;
+          this.outputTokens = (usage.output_tokens as number) ?? this.outputTokens;
+        }
+        this.emitStopSequence(resp?.status as string);
+        break;
+      }
+
+      case "response.incomplete": {
+        const resp = payload.response as Record<string, unknown>;
+        if (resp?.usage) {
+          const usage = resp.usage as Record<string, unknown>;
+          this.outputTokens = (usage.output_tokens as number) ?? this.outputTokens;
+        }
+        this.emitStopSequence("incomplete");
+        break;
+      }
+
+      case "response.failed": {
+        const resp = payload.response as Record<string, unknown>;
+        const err = resp?.error as Record<string, unknown> | undefined;
+        this.pushAnthropicSSE("error", {
+          type: "error",
+          error: {
+            type: "api_error",
+            message: (err?.message as string) ?? "Upstream error",
+          },
+        });
+        break;
+      }
+
+      case "error": {
+        this.pushAnthropicSSE("error", {
+          type: "error",
+          error: {
+            type: "api_error",
+            message: (payload.message as string) ?? "Stream error",
+          },
+        });
+        break;
+      }
+
+      default: {
+        this.emit("warning", { event: "unknown_sse_event", eventType });
+        break;
+      }
+    }
+  }
+
+  private emitStopSequence(status?: string): void {
+    if (this.hasSentMessageStop) return;
+    const stopReason = this.resolveStopReason(status);
+    this.pushAnthropicSSE("message_delta", {
+      type: "message_delta",
+      delta: { stop_reason: stopReason, stop_sequence: null },
+      usage: { output_tokens: this.outputTokens },
+    });
+    this.pushAnthropicSSE("message_stop", { type: "message_stop" });
+    this.hasSentMessageStop = true;
+  }
+
+  private resolveStopReason(status?: string): string {
+    if (status === "incomplete") return "max_tokens";
+    if (this.hasFunctionCall) return "tool_use";
+    return "end_turn";
+  }
+
+  protected flushPendingData(): void {
+    // No buffered data
+  }
+
+  protected ensureTerminated(): void {
+    if (!this.hasSentMessageStop) {
+      this.ensureMessageStart();
+      this.emitStopSequence("completed");
+    }
+  }
+}

--- a/src/proxy/transform/stream-transform-base.ts
+++ b/src/proxy/transform/stream-transform-base.ts
@@ -54,6 +54,10 @@ export abstract class BaseSSETransform extends Transform {
     this.push(`data: ${JSON.stringify(data)}\n\n`);
   }
 
+  protected pushResponsesSSE(eventType: string, data: unknown): void {
+    this.push(`event: ${eventType}\ndata: ${JSON.stringify(data)}\n\n`);
+  }
+
   protected pushDone(): void {
     this.push("data: [DONE]\n\n");
     this.done = true;

--- a/src/proxy/transform/transform-coordinator.ts
+++ b/src/proxy/transform/transform-coordinator.ts
@@ -1,8 +1,31 @@
 import type { Transform } from "stream";
 import { transformRequestBody } from "./request-transform.js";
-import { transformResponseBody, transformErrorResponse } from "./response-transform.js";
+import {
+  transformResponseBody,
+  transformErrorResponse as transformErrorBody,
+} from "./response-transform.js";
 import { OpenAIToAnthropicTransform } from "./stream-oa2ant.js";
 import { AnthropicToOpenAITransform } from "./stream-ant2oa.js";
+import {
+  responsesToAnthropicRequest,
+  anthropicToResponsesRequest,
+} from "./request-transform-responses.js";
+import {
+  responsesToAnthropicResponse,
+  anthropicToResponsesResponse,
+} from "./response-transform-responses.js";
+import {
+  responsesToChatRequest,
+  chatToResponsesRequest,
+} from "./request-bridge-responses.js";
+import {
+  responsesToChatResponse,
+  chatToResponsesResponse,
+} from "./response-bridge-responses.js";
+import { AnthropicToResponsesTransform } from "./stream-ant2resp.js";
+import { ResponsesToAnthropicTransform } from "./stream-resp2ant.js";
+import { ChatToResponsesBridgeTransform } from "./stream-bridge-chat2resp.js";
+import { ResponsesToChatBridgeTransform } from "./stream-bridge-resp2chat.js";
 
 export class TransformCoordinator {
   needsTransform(entryApiType: string, providerApiType: string): boolean {
@@ -15,16 +38,114 @@ export class TransformCoordinator {
     providerApiType: string,
     model: string,
   ): { body: Record<string, unknown>; upstreamPath: string } {
-    const upstreamPath = providerApiType === "openai" ? "/v1/chat/completions" : "/v1/messages";
-    return { body: transformRequestBody(body, entryApiType, providerApiType, model), upstreamPath };
+    if (entryApiType === providerApiType) {
+      return { body, upstreamPath: this.getUpstreamPath(providerApiType) };
+    }
+
+    // Tier-1: Responses ↔ Anthropic
+    if (entryApiType === "openai-responses" && providerApiType === "anthropic") {
+      return { body: responsesToAnthropicRequest(body), upstreamPath: "/v1/messages" };
+    }
+    if (entryApiType === "anthropic" && providerApiType === "openai-responses") {
+      return { body: anthropicToResponsesRequest(body), upstreamPath: "/v1/responses" };
+    }
+
+    // Existing: OpenAI Chat ↔ Anthropic
+    if (entryApiType === "openai" && providerApiType === "anthropic") {
+      return { body: transformRequestBody(body, "openai", "anthropic", model), upstreamPath: "/v1/messages" };
+    }
+    if (entryApiType === "anthropic" && providerApiType === "openai") {
+      return { body: transformRequestBody(body, "anthropic", "openai", model), upstreamPath: "/v1/chat/completions" };
+    }
+
+    // Bridge: Responses ↔ Chat
+    if (entryApiType === "openai-responses" && providerApiType === "openai") {
+      return { body: responsesToChatRequest(body), upstreamPath: "/v1/chat/completions" };
+    }
+    if (entryApiType === "openai" && providerApiType === "openai-responses") {
+      return { body: chatToResponsesRequest(body), upstreamPath: "/v1/responses" };
+    }
+
+    return { body, upstreamPath: this.getUpstreamPath(providerApiType) };
   }
 
   transformResponse(bodyStr: string, sourceApiType: string, targetApiType: string): string {
-    return transformResponseBody(bodyStr, sourceApiType, targetApiType);
+    if (sourceApiType === targetApiType) return bodyStr;
+
+    // Tier-1
+    if (sourceApiType === "openai-responses" && targetApiType === "anthropic") {
+      return responsesToAnthropicResponse(bodyStr);
+    }
+    if (sourceApiType === "anthropic" && targetApiType === "openai-responses") {
+      return anthropicToResponsesResponse(bodyStr);
+    }
+
+    // Existing
+    if (sourceApiType === "openai" && targetApiType === "anthropic") {
+      return transformResponseBody(bodyStr, "openai", "anthropic");
+    }
+    if (sourceApiType === "anthropic" && targetApiType === "openai") {
+      return transformResponseBody(bodyStr, "anthropic", "openai");
+    }
+
+    // Bridge
+    if (sourceApiType === "openai-responses" && targetApiType === "openai") {
+      return responsesToChatResponse(bodyStr);
+    }
+    if (sourceApiType === "openai" && targetApiType === "openai-responses") {
+      return chatToResponsesResponse(bodyStr);
+    }
+
+    return bodyStr;
   }
 
   transformErrorResponse(bodyStr: string, sourceApiType: string, targetApiType: string): string {
-    return transformErrorResponse(bodyStr, sourceApiType, targetApiType);
+    if (sourceApiType === targetApiType) return bodyStr;
+    try {
+      const parsed = JSON.parse(bodyStr);
+
+      // Responses ↔ Anthropic error conversion
+      if (sourceApiType === "openai-responses" && targetApiType === "anthropic") {
+        const err = parsed.error ?? parsed;
+        return JSON.stringify({
+          type: "error",
+          error: { type: "api_error", message: err.message ?? String(err) },
+        });
+      }
+      if (sourceApiType === "anthropic" && targetApiType === "openai-responses") {
+        const err = parsed.error ?? parsed;
+        return JSON.stringify({
+          error: {
+            message: err.message ?? String(err),
+            type: "invalid_request_error",
+            code: "upstream_error",
+          },
+        });
+      }
+
+      // Responses ↔ Chat error conversion
+      if (sourceApiType === "openai-responses" && targetApiType === "openai") {
+        const err = parsed.error ?? parsed;
+        return JSON.stringify({
+          error: { message: err.message ?? String(err), type: "api_error", code: "upstream_error" },
+        });
+      }
+      if (sourceApiType === "openai" && targetApiType === "openai-responses") {
+        const err = parsed.error ?? parsed;
+        return JSON.stringify({
+          error: {
+            message: err.message ?? String(err),
+            type: "invalid_request_error",
+            code: "upstream_error",
+          },
+        });
+      }
+
+      // Fall through to existing Chat ↔ Anthropic error conversion
+      return transformErrorBody(bodyStr, sourceApiType, targetApiType);
+    } catch {
+      return bodyStr;
+    }
   }
 
   createFormatTransform(
@@ -32,15 +153,41 @@ export class TransformCoordinator {
     providerApiType: string,
     model: string,
   ): Transform | undefined {
-    if (!this.needsTransform(entryApiType, providerApiType)) return undefined;
-    // 上游=provider格式, 客户端=entry格式
-    // OA provider + Ant client → OpenAIToAnthropicTransform
+    if (entryApiType === providerApiType) return undefined;
+
+    // Tier-1 streaming
+    if (providerApiType === "anthropic" && entryApiType === "openai-responses") {
+      return new ResponsesToAnthropicTransform(model);
+    }
+    if (providerApiType === "openai-responses" && entryApiType === "anthropic") {
+      return new AnthropicToResponsesTransform(model);
+    }
+
+    // Existing streaming
     if (providerApiType === "openai" && entryApiType === "anthropic") {
       return new OpenAIToAnthropicTransform(model);
     }
     if (providerApiType === "anthropic" && entryApiType === "openai") {
       return new AnthropicToOpenAITransform(model);
     }
+
+    // Bridge streaming
+    if (providerApiType === "openai" && entryApiType === "openai-responses") {
+      return new ResponsesToChatBridgeTransform(model);
+    }
+    if (providerApiType === "openai-responses" && entryApiType === "openai") {
+      return new ChatToResponsesBridgeTransform(model);
+    }
+
     return undefined;
+  }
+
+  private getUpstreamPath(apiType: string): string {
+    switch (apiType) {
+      case "openai": return "/v1/chat/completions";
+      case "openai-responses": return "/v1/responses";
+      case "anthropic": return "/v1/messages";
+      default: return "/v1/chat/completions";
+    }
   }
 }

--- a/src/proxy/transform/types-responses.ts
+++ b/src/proxy/transform/types-responses.ts
@@ -1,0 +1,196 @@
+// ---------- Responses API 输入 item 类型 ----------
+
+export interface ResponseInputMessage {
+  type: "message";
+  role: "user" | "assistant" | "system" | "developer";
+  content: string | ResponseInputContentPart[];
+}
+
+export interface ResponseInputText {
+  type: "input_text";
+  text: string;
+}
+
+export interface ResponseInputImage {
+  type: "input_image";
+  image_url: string;
+  detail?: "auto" | "low" | "high";
+}
+
+export interface ResponseFunctionCallInput {
+  type: "function_call";
+  id: string;
+  call_id: string;
+  name: string;
+  arguments: string;
+}
+
+export interface ResponseFunctionCallOutputInput {
+  type: "function_call_output";
+  call_id: string;
+  output: string;
+}
+
+export interface ResponseReasoningInput {
+  type: "reasoning";
+  id: string;
+  summary: Array<{ type: "summary_text"; text: string }>;
+  encrypted_content?: string;
+}
+
+export type ResponseInputItem =
+  | ResponseInputMessage
+  | ResponseInputText
+  | ResponseInputImage
+  | ResponseFunctionCallInput
+  | ResponseFunctionCallOutputInput
+  | ResponseReasoningInput;
+
+export interface ResponseInputContentPart {
+  type: "input_text" | "input_image" | "input_file";
+  text?: string;
+  image_url?: string;
+  file_url?: string;
+  file_data?: string;
+  filename?: string;
+}
+
+// ---------- Responses API 工具类型 ----------
+
+export interface ResponseFunctionTool {
+  type: "function";
+  name: string;
+  description?: string;
+  parameters?: Record<string, unknown>;
+  strict?: boolean;
+}
+
+export interface ResponseWebSearchTool {
+  type: "web_search_preview";
+  search_context_size?: "low" | "medium" | "high";
+  user_location?: { type: "approximate"; city?: string; country?: string };
+}
+
+export interface ResponseFileSearchTool {
+  type: "file_search";
+  vector_store_ids?: string[];
+}
+
+export type ResponseTool =
+  | ResponseFunctionTool
+  | ResponseWebSearchTool
+  | ResponseFileSearchTool
+  | Record<string, unknown>;
+
+// ---------- Responses API 响应输出 ----------
+
+export interface ResponseOutputMessage {
+  type: "message";
+  id: string;
+  role: "assistant";
+  content: ResponseOutputContent[];
+  status?: string;
+}
+
+export interface ResponseOutputContent {
+  type: "output_text";
+  text: string;
+  annotations?: unknown[];
+}
+
+export interface ResponseFunctionCallOutput {
+  type: "function_call";
+  id: string;
+  call_id: string;
+  name: string;
+  arguments: string;
+  status?: string;
+}
+
+export interface ResponseReasoningOutput {
+  type: "reasoning";
+  id: string;
+  summary: Array<{ type: "summary_text"; text: string }>;
+  encrypted_content?: string;
+}
+
+export type ResponseOutputItem =
+  | ResponseOutputMessage
+  | ResponseFunctionCallOutput
+  | ResponseReasoningOutput
+  | Record<string, unknown>;
+
+// ---------- Responses API 完整请求 ----------
+
+export interface ResponsesApiRequest {
+  model: string;
+  input: string | ResponseInputItem[];
+  instructions?: string;
+  max_output_tokens?: number;
+  temperature?: number;
+  top_p?: number;
+  tools?: ResponseTool[];
+  tool_choice?: "auto" | "none" | "required" | { type: "function"; name: string };
+  stream?: boolean;
+  stream_options?: { include_usage?: boolean };
+  reasoning?: {
+    effort?: "low" | "medium" | "high";
+    max_tokens?: number;
+    summary?: "auto" | "concise" | "detailed";
+  };
+  previous_response_id?: string;
+  metadata?: Record<string, string>;
+  text?: { format: { type: "json_schema"; json_schema: unknown } };
+  parallel_tool_calls?: boolean;
+  store?: boolean;
+}
+
+// ---------- Responses API 完整响应 ----------
+
+export interface ResponsesApiResponse {
+  id: string;
+  object: "response";
+  model: string;
+  status: "completed" | "failed" | "in_progress" | "incomplete";
+  output: ResponseOutputItem[];
+  usage?: ResponsesApiUsage;
+  error?: { code: string; message: string };
+  created_at?: number;
+  completed_at?: number;
+}
+
+export interface ResponsesApiUsage {
+  input_tokens: number;
+  output_tokens: number;
+  total_tokens: number;
+  input_tokens_details?: { cached_tokens: number };
+  output_tokens_details?: { reasoning_tokens: number };
+}
+
+// ---------- Responses SSE 流式事件类型常量 ----------
+
+export const RESPONSES_SSE_EVENTS = {
+  CREATED: "response.created",
+  IN_PROGRESS: "response.in_progress",
+  QUEUED: "response.queued",
+  OUTPUT_ITEM_ADDED: "response.output_item.added",
+  OUTPUT_ITEM_DONE: "response.output_item.done",
+  CONTENT_PART_ADDED: "response.content_part.added",
+  CONTENT_PART_DONE: "response.content_part.done",
+  OUTPUT_TEXT_DELTA: "response.output_text.delta",
+  OUTPUT_TEXT_DONE: "response.output_text.done",
+  REFUSAL_DELTA: "response.refusal.delta",
+  REFUSAL_DONE: "response.refusal.done",
+  FUNCTION_CALL_ARGUMENTS_DELTA: "response.function_call_arguments.delta",
+  FUNCTION_CALL_ARGUMENTS_DONE: "response.function_call_arguments.done",
+  REASONING_SUMMARY_PART_ADDED: "response.reasoning_summary_part.added",
+  REASONING_SUMMARY_PART_DONE: "response.reasoning_summary_part.done",
+  REASONING_SUMMARY_TEXT_DELTA: "response.reasoning_summary_text.delta",
+  REASONING_SUMMARY_TEXT_DONE: "response.reasoning_summary_text.done",
+  REASONING_TEXT_DELTA: "response.reasoning_text.delta",
+  REASONING_TEXT_DONE: "response.reasoning_text.done",
+  COMPLETED: "response.completed",
+  FAILED: "response.failed",
+  INCOMPLETE: "response.incomplete",
+  ERROR: "error",
+} as const;

--- a/src/proxy/transform/types.ts
+++ b/src/proxy/transform/types.ts
@@ -1,5 +1,14 @@
 /** 格式转换方向 */
-export type TransformDirection = "openai-to-anthropic" | "anthropic-to-openai";
+export type TransformDirection =
+  // 现有
+  | "openai-to-anthropic" | "anthropic-to-openai"
+  // 一级：Responses ↔ Anthropic
+  | "openai-responses-to-anthropic" | "anthropic-to-openai-responses"
+  // 二级：Responses ↔ Chat
+  | "openai-to-openai-responses" | "openai-responses-to-openai";
+
+/** 所有支持的 API 格式类型 */
+export type ApiType = "openai" | "openai-responses" | "anthropic";
 
 // ---------- Anthropic Content Block 类型 ----------
 

--- a/src/proxy/transport/transport-fn.ts
+++ b/src/proxy/transport/transport-fn.ts
@@ -48,7 +48,7 @@ export interface TransportFnParams {
   cliHdrs: RawHeaders;
   reply: FastifyReply;
   upstreamPath: string;
-  apiType: "openai" | "anthropic";
+  apiType: "openai" | "openai-responses" | "anthropic";
   isStream: boolean;
   startTime: number;
   logId: string;

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -39,7 +39,7 @@ describe("initDatabase", () => {
       .prepare("SELECT name FROM migrations")
       .all() as { name: string }[];
 
-    expect(rows.length).toBe(36);
+    expect(rows.length).toBe(37);
     expect(rows[0].name).toBe("001_init.sql");
     expect(rows[1].name).toBe("002_add_request_response_body.sql");
     expect(rows[2].name).toBe("003_add_full_request_chain_log.sql");

--- a/tests/metrics.test.ts
+++ b/tests/metrics.test.ts
@@ -29,7 +29,7 @@ describe("request_metrics migration and insertMetrics", () => {
       .prepare("SELECT name FROM migrations")
       .all() as { name: string }[];
 
-    expect(rows).toHaveLength(36);
+    expect(rows).toHaveLength(37);
     expect(rows[5].name).toBe("006_create_request_metrics.sql");
     expect(rows[6].name).toBe("007_add_retry_fields.sql");
     expect(rows[7].name).toBe("008_create_router_keys.sql");

--- a/tests/proxy/transform/integration-responses.test.ts
+++ b/tests/proxy/transform/integration-responses.test.ts
@@ -1,0 +1,316 @@
+import { describe, it, expect } from "vitest";
+import { TransformCoordinator } from "../../../src/proxy/transform/transform-coordinator.js";
+
+const coordinator = new TransformCoordinator();
+
+describe("Responses API integration — full conversion pipeline", () => {
+  it("Responses → Anthropic → Responses (round-trip preserves intent)", () => {
+    const request = {
+      model: "gpt-4o",
+      input: [
+        { type: "message", role: "user", content: "What's the weather?" },
+      ],
+      instructions: "You are a weather assistant.",
+      tools: [
+        {
+          type: "function",
+          name: "get_weather",
+          parameters: {
+            type: "object",
+            properties: { city: { type: "string" } },
+          },
+        },
+      ],
+      max_output_tokens: 2048,
+    };
+
+    // Responses → Anthropic
+    const { body: antReq } = coordinator.transformRequest(
+      request,
+      "openai-responses",
+      "anthropic",
+      "gpt-4o",
+    );
+    expect(antReq.system).toBe("You are a weather assistant.");
+    expect(antReq.messages).toBeDefined();
+    expect(antReq.tools).toBeDefined();
+
+    // Anthropic → Responses (response direction)
+    const antResponse = JSON.stringify({
+      id: "msg_1",
+      type: "message",
+      role: "assistant",
+      model: "gpt-4o",
+      content: [{ type: "text", text: "The weather is sunny." }],
+      stop_reason: "end_turn",
+      usage: { input_tokens: 20, output_tokens: 10 },
+    });
+    const respResponse = coordinator.transformResponse(
+      antResponse,
+      "anthropic",
+      "openai-responses",
+    );
+    const parsed = JSON.parse(respResponse);
+    expect(parsed.object).toBe("response");
+    expect(parsed.status).toBe("completed");
+  });
+
+  it("Responses → Chat (bridge) → back to Responses (round-trip)", () => {
+    const request = {
+      model: "gpt-4o",
+      input: "Hello",
+      instructions: "Be helpful",
+      max_output_tokens: 1024,
+    };
+
+    // Responses → Chat
+    const { body: chatReq } = coordinator.transformRequest(
+      request,
+      "openai-responses",
+      "openai",
+      "gpt-4o",
+    );
+    expect(chatReq.messages).toBeDefined();
+    expect(chatReq.max_completion_tokens).toBe(1024);
+
+    // Chat → Responses
+    const { body: respReq } = coordinator.transformRequest(
+      chatReq,
+      "openai",
+      "openai-responses",
+      "gpt-4o",
+    );
+    expect(respReq.instructions).toBe("Be helpful");
+    expect(respReq.max_output_tokens).toBe(1024);
+  });
+
+  it("Chat → Responses → Chat (bridge round-trip)", () => {
+    const request = {
+      model: "gpt-4o",
+      messages: [
+        { role: "system", content: "Be helpful" },
+        { role: "user", content: "Hello" },
+      ],
+      max_completion_tokens: 1024,
+      temperature: 0.7,
+    };
+
+    // Chat → Responses
+    const { body: respReq } = coordinator.transformRequest(
+      request,
+      "openai",
+      "openai-responses",
+      "gpt-4o",
+    );
+    expect(respReq.instructions).toBe("Be helpful");
+    expect(respReq.max_output_tokens).toBe(1024);
+
+    // Responses → Chat
+    const { body: chatReq } = coordinator.transformRequest(
+      respReq,
+      "openai-responses",
+      "openai",
+      "gpt-4o",
+    );
+    expect(chatReq.messages).toBeDefined();
+    expect(chatReq.max_completion_tokens).toBe(1024);
+    expect(chatReq.temperature).toBe(0.7);
+  });
+
+  it("existing Anthropic ↔ Chat path still works (regression check)", () => {
+    const request = {
+      model: "claude",
+      system: "Be helpful",
+      messages: [{ role: "user", content: "Hello" }],
+      max_tokens: 1024,
+    };
+
+    const { body: chatReq } = coordinator.transformRequest(
+      request,
+      "anthropic",
+      "openai",
+      "claude",
+    );
+    expect(chatReq.messages).toBeDefined();
+
+    const { body: antReq } = coordinator.transformRequest(
+      chatReq,
+      "openai",
+      "anthropic",
+      "claude",
+    );
+    expect(antReq.messages).toBeDefined();
+  });
+
+  it("needsTransform returns false for same api_type", () => {
+    expect(coordinator.needsTransform("openai", "openai")).toBe(false);
+    expect(coordinator.needsTransform("anthropic", "anthropic")).toBe(false);
+    expect(
+      coordinator.needsTransform("openai-responses", "openai-responses"),
+    ).toBe(false);
+  });
+
+  it("needsTransform returns true for different api_types", () => {
+    expect(coordinator.needsTransform("openai", "anthropic")).toBe(true);
+    expect(coordinator.needsTransform("openai", "openai-responses")).toBe(true);
+    expect(
+      coordinator.needsTransform("openai-responses", "anthropic"),
+    ).toBe(true);
+    expect(coordinator.needsTransform("anthropic", "openai")).toBe(true);
+    expect(
+      coordinator.needsTransform("anthropic", "openai-responses"),
+    ).toBe(true);
+    expect(
+      coordinator.needsTransform("openai-responses", "openai"),
+    ).toBe(true);
+  });
+
+  it("error response transforms work for all directions", () => {
+    const anthropicError = JSON.stringify({
+      type: "error",
+      error: { type: "not_found_error", message: "Model not found" },
+    });
+
+    // Anthropic → Responses
+    const r1 = coordinator.transformErrorResponse(
+      anthropicError,
+      "anthropic",
+      "openai-responses",
+    );
+    const parsed1 = JSON.parse(r1);
+    expect(parsed1.error).toBeDefined();
+    expect(parsed1.error.message).toContain("Model not found");
+
+    // Anthropic → OpenAI (existing path)
+    const r2 = coordinator.transformErrorResponse(
+      anthropicError,
+      "anthropic",
+      "openai",
+    );
+    const parsed2 = JSON.parse(r2);
+    expect(parsed2.error).toBeDefined();
+  });
+
+  it("Responses request with function_call items converts to Anthropic tool_use", () => {
+    const request = {
+      model: "gpt-4o",
+      input: [
+        {
+          type: "message",
+          role: "user",
+          content: "What's the weather in Tokyo?",
+        },
+        {
+          type: "function_call",
+          id: "fc_001",
+          call_id: "call_001",
+          name: "get_weather",
+          arguments: '{"city":"Tokyo"}',
+        },
+        {
+          type: "function_call_output",
+          call_id: "call_001",
+          output: '{"temp":22,"condition":"sunny"}',
+        },
+      ],
+      tools: [
+        {
+          type: "function",
+          name: "get_weather",
+          parameters: {
+            type: "object",
+            properties: { city: { type: "string" } },
+          },
+        },
+      ],
+    };
+
+    const { body: antReq } = coordinator.transformRequest(
+      request,
+      "openai-responses",
+      "anthropic",
+      "gpt-4o",
+    );
+    expect(antReq.messages).toBeDefined();
+    // Should have tool_use and tool_result blocks
+    const msgs = antReq.messages as Array<Record<string, unknown>>;
+    expect(msgs.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("response transform preserves model info across all paths", () => {
+    const anthropicResp = JSON.stringify({
+      id: "msg_test",
+      type: "message",
+      role: "assistant",
+      model: "claude-3-opus",
+      content: [{ type: "text", text: "Hello!" }],
+      stop_reason: "end_turn",
+      usage: { input_tokens: 10, output_tokens: 5 },
+    });
+
+    // Anthropic → Responses
+    const respResp = coordinator.transformResponse(
+      anthropicResp,
+      "anthropic",
+      "openai-responses",
+    );
+    const parsed = JSON.parse(respResp);
+    expect(parsed.model).toBe("claude-3-opus");
+    expect(parsed.status).toBe("completed");
+
+    // Anthropic → Chat (existing path)
+    const chatResp = coordinator.transformResponse(
+      anthropicResp,
+      "anthropic",
+      "openai",
+    );
+    const chatParsed = JSON.parse(chatResp);
+    expect(chatParsed.model).toBe("claude-3-opus");
+  });
+
+  it("createFormatTransform returns correct stream transform for each direction", () => {
+    // Tier-1: Responses → Anthropic
+    const t1 = coordinator.createFormatTransform(
+      "openai-responses",
+      "anthropic",
+      "gpt-4o",
+    );
+    expect(t1).toBeDefined();
+    expect(t1!.constructor.name).toContain("ResponsesToAnthropic");
+
+    // Tier-1: Anthropic → Responses
+    const t2 = coordinator.createFormatTransform(
+      "anthropic",
+      "openai-responses",
+      "gpt-4o",
+    );
+    expect(t2).toBeDefined();
+    expect(t2!.constructor.name).toContain("AnthropicToResponses");
+
+    // Bridge: Responses → Chat
+    const t3 = coordinator.createFormatTransform(
+      "openai-responses",
+      "openai",
+      "gpt-4o",
+    );
+    expect(t3).toBeDefined();
+    expect(t3!.constructor.name).toContain("ResponsesToChat");
+
+    // Bridge: Chat → Responses
+    const t4 = coordinator.createFormatTransform(
+      "openai",
+      "openai-responses",
+      "gpt-4o",
+    );
+    expect(t4).toBeDefined();
+    expect(t4!.constructor.name).toContain("ChatToResponses");
+
+    // Identity: no transform
+    const t5 = coordinator.createFormatTransform(
+      "openai",
+      "openai",
+      "gpt-4o",
+    );
+    expect(t5).toBeUndefined();
+  });
+});

--- a/tests/proxy/transform/request-bridge-responses.test.ts
+++ b/tests/proxy/transform/request-bridge-responses.test.ts
@@ -1,0 +1,858 @@
+import { describe, it, expect } from "vitest";
+import {
+  responsesToChatRequest,
+  chatToResponsesRequest,
+} from "../../../src/proxy/transform/request-bridge-responses.js";
+
+// ============================================================
+// responsesToChatRequest
+// ============================================================
+
+describe("responsesToChatRequest", () => {
+  // --- 1. Basic: instructions → system, input string → user ---
+  describe("basic text input", () => {
+    it("converts instructions → system message and input string → user message", () => {
+      const result = responsesToChatRequest({
+        model: "gpt-4o",
+        input: "Hello, world!",
+        instructions: "Be helpful",
+      });
+
+      expect(result.model).toBe("gpt-4o");
+      const msgs = result.messages as Array<Record<string, unknown>>;
+      expect(msgs).toHaveLength(2);
+      expect(msgs[0]).toEqual({ role: "system", content: "Be helpful" });
+      expect(msgs[1]).toEqual({ role: "user", content: "Hello, world!" });
+    });
+
+    it("omits system message when instructions is empty", () => {
+      const result = responsesToChatRequest({
+        model: "gpt-4o",
+        input: "Hello",
+        instructions: "",
+      });
+
+      const msgs = result.messages as Array<Record<string, unknown>>;
+      expect(msgs).toHaveLength(1);
+      expect(msgs[0].role).toBe("user");
+    });
+
+    it("omits system message when instructions is undefined", () => {
+      const result = responsesToChatRequest({
+        model: "gpt-4o",
+        input: "Hello",
+      });
+
+      const msgs = result.messages as Array<Record<string, unknown>>;
+      expect(msgs).toHaveLength(1);
+      expect(msgs[0].role).toBe("user");
+    });
+
+    it("handles null input gracefully", () => {
+      const result = responsesToChatRequest({ model: "gpt-4o" });
+      const msgs = result.messages as Array<Record<string, unknown>>;
+      expect(msgs).toHaveLength(0);
+    });
+  });
+
+  // --- 2. Input array items → messages ---
+  describe("input array items", () => {
+    it("converts message items with roles", () => {
+      const result = responsesToChatRequest({
+        model: "gpt-4o",
+        input: [
+          { type: "message", role: "user", content: "What's the weather?" },
+          { type: "message", role: "assistant", content: "Let me check." },
+        ],
+      });
+
+      const msgs = result.messages as Array<Record<string, unknown>>;
+      expect(msgs).toHaveLength(2);
+      expect(msgs[0]).toEqual({ role: "user", content: "What's the weather?" });
+      expect(msgs[1]).toEqual({ role: "assistant", content: "Let me check." });
+    });
+
+    it("extracts text from content parts in message items", () => {
+      const result = responsesToChatRequest({
+        model: "gpt-4o",
+        input: [
+          {
+            type: "message",
+            role: "user",
+            content: [
+              { type: "input_text", text: "Hello " },
+              { type: "input_text", text: "World" },
+            ],
+          },
+        ],
+      });
+
+      const msgs = result.messages as Array<Record<string, unknown>>;
+      expect(msgs).toHaveLength(1);
+      expect(msgs[0]).toEqual({ role: "user", content: "Hello World" });
+    });
+
+    it("converts input_text items → user messages", () => {
+      const result = responsesToChatRequest({
+        model: "gpt-4o",
+        input: [
+          { type: "input_text", text: "Hello" },
+        ],
+      });
+
+      const msgs = result.messages as Array<Record<string, unknown>>;
+      expect(msgs).toHaveLength(1);
+      expect(msgs[0]).toEqual({ role: "user", content: "Hello" });
+    });
+
+    it("converts developer role messages", () => {
+      const result = responsesToChatRequest({
+        model: "gpt-4o",
+        input: [
+          { type: "message", role: "developer", content: "Be precise" },
+        ],
+      });
+
+      const msgs = result.messages as Array<Record<string, unknown>>;
+      expect(msgs).toHaveLength(1);
+      expect(msgs[0]).toEqual({ role: "developer", content: "Be precise" });
+    });
+  });
+
+  // --- 3. function_call items → tool_calls in assistant message ---
+  describe("function_call items", () => {
+    it("merges consecutive function_calls into one assistant message with tool_calls", () => {
+      const result = responsesToChatRequest({
+        model: "gpt-4o",
+        input: [
+          { type: "message", role: "user", content: "Check weather" },
+          {
+            type: "function_call",
+            id: "fc_1",
+            call_id: "call_1",
+            name: "get_weather",
+            arguments: '{"city":"SF"}',
+          },
+          {
+            type: "function_call",
+            id: "fc_2",
+            call_id: "call_2",
+            name: "get_time",
+            arguments: '{"tz":"PST"}',
+          },
+        ],
+      });
+
+      const msgs = result.messages as Array<Record<string, unknown>>;
+      expect(msgs).toHaveLength(2);
+
+      // Second message should be assistant with tool_calls
+      expect(msgs[1].role).toBe("assistant");
+      expect(msgs[1].content).toBeNull();
+      const toolCalls = msgs[1].tool_calls as Array<Record<string, unknown>>;
+      expect(toolCalls).toHaveLength(2);
+      expect(toolCalls[0]).toEqual({
+        id: "fc_1",
+        type: "function",
+        function: { name: "get_weather", arguments: '{"city":"SF"}' },
+      });
+      expect(toolCalls[1]).toEqual({
+        id: "fc_2",
+        type: "function",
+        function: { name: "get_time", arguments: '{"tz":"PST"}' },
+      });
+    });
+
+    it("handles single function_call", () => {
+      const result = responsesToChatRequest({
+        model: "gpt-4o",
+        input: [
+          { type: "message", role: "user", content: "Go" },
+          {
+            type: "function_call",
+            id: "fc_1",
+            call_id: "call_1",
+            name: "do_stuff",
+            arguments: "{}",
+          },
+        ],
+      });
+
+      const msgs = result.messages as Array<Record<string, unknown>>;
+      expect(msgs).toHaveLength(2);
+      expect(msgs[1].role).toBe("assistant");
+      const toolCalls = msgs[1].tool_calls as Array<Record<string, unknown>>;
+      expect(toolCalls).toHaveLength(1);
+    });
+
+    it("flushes function_calls at end of input array", () => {
+      const result = responsesToChatRequest({
+        model: "gpt-4o",
+        input: [
+          { type: "message", role: "user", content: "Go" },
+          {
+            type: "function_call",
+            id: "fc_last",
+            call_id: "call_last",
+            name: "last_fn",
+            arguments: "{}",
+          },
+          // No more items — function_calls should still be flushed
+        ],
+      });
+
+      const msgs = result.messages as Array<Record<string, unknown>>;
+      expect(msgs).toHaveLength(2);
+      expect(msgs[1].role).toBe("assistant");
+    });
+
+    it("flushes function_calls before non-function_call items", () => {
+      const result = responsesToChatRequest({
+        model: "gpt-4o",
+        input: [
+          { type: "message", role: "user", content: "Go" },
+          {
+            type: "function_call",
+            id: "fc_1",
+            call_id: "call_1",
+            name: "fn",
+            arguments: "{}",
+          },
+          { type: "message", role: "assistant", content: "Done" },
+        ],
+      });
+
+      const msgs = result.messages as Array<Record<string, unknown>>;
+      expect(msgs).toHaveLength(3);
+      expect(msgs[1].role).toBe("assistant");
+      expect(msgs[2]).toEqual({ role: "assistant", content: "Done" });
+    });
+  });
+
+  // --- 4. function_call_output → tool messages ---
+  describe("function_call_output items", () => {
+    it("converts function_call_output → tool message", () => {
+      const result = responsesToChatRequest({
+        model: "gpt-4o",
+        input: [
+          { type: "message", role: "user", content: "Check weather" },
+          {
+            type: "function_call",
+            id: "fc_1",
+            call_id: "call_1",
+            name: "get_weather",
+            arguments: "{}",
+          },
+          {
+            type: "function_call_output",
+            call_id: "call_1",
+            output: "Sunny, 72°F",
+          },
+        ],
+      });
+
+      const msgs = result.messages as Array<Record<string, unknown>>;
+      expect(msgs).toHaveLength(3);
+      expect(msgs[2]).toEqual({
+        role: "tool",
+        tool_call_id: "call_1",
+        content: "Sunny, 72°F",
+      });
+    });
+  });
+
+  // --- 5. Tools conversion ---
+  describe("tools conversion", () => {
+    it("wraps function tools in Chat Completions format", () => {
+      const result = responsesToChatRequest({
+        model: "gpt-4o",
+        input: "hi",
+        tools: [
+          {
+            type: "function",
+            name: "get_weather",
+            description: "Get weather",
+            parameters: { type: "object", properties: { city: { type: "string" } } },
+          },
+        ],
+      });
+
+      const tools = result.tools as Array<Record<string, unknown>>;
+      expect(tools).toHaveLength(1);
+      expect(tools[0]).toEqual({
+        type: "function",
+        function: {
+          name: "get_weather",
+          description: "Get weather",
+          parameters: { type: "object", properties: { city: { type: "string" } } },
+        },
+      });
+    });
+
+    it("filters out non-function tools", () => {
+      const result = responsesToChatRequest({
+        model: "gpt-4o",
+        input: "hi",
+        tools: [
+          { type: "function", name: "fn", parameters: {} },
+          { type: "web_search_preview" } as Record<string, unknown>,
+          { type: "file_search", vector_store_ids: ["vs_1"] } as Record<string, unknown>,
+        ],
+      });
+
+      const tools = result.tools as Array<Record<string, unknown>>;
+      expect(tools).toHaveLength(1);
+      expect((tools[0].function as Record<string, unknown>).name).toBe("fn");
+    });
+
+    it("omits tools when only non-function tools present", () => {
+      const result = responsesToChatRequest({
+        model: "gpt-4o",
+        input: "hi",
+        tools: [
+          { type: "web_search_preview" } as Record<string, unknown>,
+        ],
+      });
+
+      expect(result.tools).toBeUndefined();
+    });
+
+    it("passes tool_choice through", () => {
+      const result = responsesToChatRequest({
+        model: "gpt-4o",
+        input: "hi",
+        tools: [{ type: "function", name: "fn", parameters: {} }],
+        tool_choice: "auto",
+      });
+      expect(result.tool_choice).toBe("auto");
+    });
+
+    it("passes tool_choice {type:'function', name} through", () => {
+      const result = responsesToChatRequest({
+        model: "gpt-4o",
+        input: "hi",
+        tools: [{ type: "function", name: "fn", parameters: {} }],
+        tool_choice: { type: "function", name: "fn" },
+      });
+      expect(result.tool_choice).toEqual({ type: "function", name: "fn" });
+    });
+  });
+
+  // --- 6. Reasoning & other params ---
+  describe("pass-through fields", () => {
+    it("maps max_output_tokens → max_completion_tokens", () => {
+      const result = responsesToChatRequest({
+        model: "gpt-4o",
+        input: "hi",
+        max_output_tokens: 2048,
+      });
+      expect(result.max_completion_tokens).toBe(2048);
+    });
+
+    it("passes temperature, top_p, stream through", () => {
+      const result = responsesToChatRequest({
+        model: "gpt-4o",
+        input: "hi",
+        temperature: 0.5,
+        top_p: 0.9,
+        stream: true,
+      });
+      expect(result.temperature).toBe(0.5);
+      expect(result.top_p).toBe(0.9);
+      expect(result.stream).toBe(true);
+    });
+
+    it("passes reasoning through", () => {
+      const result = responsesToChatRequest({
+        model: "gpt-4o",
+        input: "hi",
+        reasoning: { effort: "high", max_tokens: 10000 },
+      });
+      expect(result.reasoning).toEqual({ effort: "high", max_tokens: 10000 });
+    });
+
+    it("maps text.format → response_format", () => {
+      const result = responsesToChatRequest({
+        model: "gpt-4o",
+        input: "hi",
+        text: { format: { type: "json_schema", json_schema: { name: "test" } } },
+      });
+      expect(result.response_format).toEqual({
+        type: "json_schema",
+        json_schema: { name: "test" },
+      });
+    });
+
+    it("passes stream_options through", () => {
+      const result = responsesToChatRequest({
+        model: "gpt-4o",
+        input: "hi",
+        stream: true,
+        stream_options: { include_usage: true },
+      });
+      expect(result.stream_options).toEqual({ include_usage: true });
+    });
+  });
+
+  // --- 7. Reasoning items → skip ---
+  describe("lossy conversions", () => {
+    it("skips reasoning items (no Chat equivalent)", () => {
+      const result = responsesToChatRequest({
+        model: "gpt-4o",
+        input: [
+          { type: "message", role: "user", content: "Think" },
+          {
+            type: "reasoning",
+            id: "rs_1",
+            summary: [{ type: "summary_text", text: "I thought about it" }],
+          },
+          { type: "message", role: "assistant", content: "Here's my answer" },
+        ],
+      });
+
+      const msgs = result.messages as Array<Record<string, unknown>>;
+      // Only user and assistant; reasoning is skipped
+      expect(msgs).toHaveLength(2);
+      expect(msgs[0].role).toBe("user");
+      expect(msgs[1].role).toBe("assistant");
+    });
+  });
+});
+
+// ============================================================
+// chatToResponsesRequest
+// ============================================================
+
+describe("chatToResponsesRequest", () => {
+  // --- 7. system → instructions ---
+  describe("instructions extraction", () => {
+    it("converts system messages → instructions", () => {
+      const result = chatToResponsesRequest({
+        model: "gpt-4o",
+        messages: [
+          { role: "system", content: "Be helpful" },
+          { role: "user", content: "Hello" },
+        ],
+      });
+
+      expect(result.model).toBe("gpt-4o");
+      expect(result.instructions).toBe("Be helpful");
+      const input = result.input as Array<Record<string, unknown>>;
+      expect(input).toHaveLength(1);
+      expect(input[0]).toEqual({
+        type: "message",
+        role: "user",
+        content: [{ type: "input_text", text: "Hello" }],
+      });
+    });
+
+    it("joins multiple system messages into instructions", () => {
+      const result = chatToResponsesRequest({
+        model: "gpt-4o",
+        messages: [
+          { role: "system", content: "Rule 1" },
+          { role: "system", content: "Rule 2" },
+          { role: "user", content: "Hi" },
+        ],
+      });
+
+      expect(result.instructions).toBe("Rule 1\nRule 2");
+    });
+
+    it("includes developer messages in instructions (prepended)", () => {
+      const result = chatToResponsesRequest({
+        model: "gpt-4o",
+        messages: [
+          { role: "developer", content: "Be precise" },
+          { role: "system", content: "Be helpful" },
+          { role: "user", content: "Hi" },
+        ],
+      });
+
+      expect(result.instructions).toBe("Be precise\nBe helpful");
+    });
+
+    it("omits instructions when no system/developer messages", () => {
+      const result = chatToResponsesRequest({
+        model: "gpt-4o",
+        messages: [
+          { role: "user", content: "Hi" },
+        ],
+      });
+
+      expect(result.instructions).toBeFalsy();
+    });
+  });
+
+  // --- 8. tool_calls → function_call items ---
+  describe("assistant tool_calls", () => {
+    it("converts tool_calls → function_call items", () => {
+      const result = chatToResponsesRequest({
+        model: "gpt-4o",
+        messages: [
+          { role: "user", content: "Check weather" },
+          {
+            role: "assistant",
+            content: null,
+            tool_calls: [
+              {
+                id: "call_abc",
+                type: "function",
+                function: { name: "get_weather", arguments: '{"city":"SF"}' },
+              },
+            ],
+          },
+        ],
+      });
+
+      const input = result.input as Array<Record<string, unknown>>;
+      expect(input).toHaveLength(2);
+      expect(input[1]).toEqual({
+        type: "function_call",
+        id: "call_abc",
+        call_id: "call_abc",
+        name: "get_weather",
+        arguments: '{"city":"SF"}',
+      });
+    });
+
+    it("converts multiple tool_calls to separate function_call items", () => {
+      const result = chatToResponsesRequest({
+        model: "gpt-4o",
+        messages: [
+          { role: "user", content: "Go" },
+          {
+            role: "assistant",
+            content: null,
+            tool_calls: [
+              { id: "call_1", type: "function", function: { name: "fn1", arguments: "{}" } },
+              { id: "call_2", type: "function", function: { name: "fn2", arguments: "{}" } },
+            ],
+          },
+        ],
+      });
+
+      const input = result.input as Array<Record<string, unknown>>;
+      expect(input).toHaveLength(3);
+      expect(input[1].type).toBe("function_call");
+      expect(input[2].type).toBe("function_call");
+    });
+  });
+
+  // --- 9. tool messages → function_call_output ---
+  describe("tool messages", () => {
+    it("converts tool messages → function_call_output", () => {
+      const result = chatToResponsesRequest({
+        model: "gpt-4o",
+        messages: [
+          { role: "user", content: "Check weather" },
+          {
+            role: "assistant",
+            content: null,
+            tool_calls: [
+              { id: "call_1", type: "function", function: { name: "get_weather", arguments: "{}" } },
+            ],
+          },
+          { role: "tool", tool_call_id: "call_1", content: "Sunny, 72°F" },
+        ],
+      });
+
+      const input = result.input as Array<Record<string, unknown>>;
+      expect(input).toHaveLength(3);
+      expect(input[2]).toEqual({
+        type: "function_call_output",
+        call_id: "call_1",
+        output: "Sunny, 72°F",
+      });
+    });
+  });
+
+  // --- 10. max_completion_tokens → max_output_tokens ---
+  describe("field mappings", () => {
+    it("maps max_completion_tokens → max_output_tokens", () => {
+      const result = chatToResponsesRequest({
+        model: "gpt-4o",
+        messages: [],
+        max_completion_tokens: 2048,
+      });
+      expect(result.max_output_tokens).toBe(2048);
+    });
+
+    it("falls back to max_tokens → max_output_tokens", () => {
+      const result = chatToResponsesRequest({
+        model: "gpt-4o",
+        messages: [],
+        max_tokens: 1024,
+      });
+      expect(result.max_output_tokens).toBe(1024);
+    });
+
+    it("prefers max_completion_tokens over max_tokens", () => {
+      const result = chatToResponsesRequest({
+        model: "gpt-4o",
+        messages: [],
+        max_completion_tokens: 2048,
+        max_tokens: 1024,
+      });
+      expect(result.max_output_tokens).toBe(2048);
+    });
+
+    it("passes temperature, top_p, stream through", () => {
+      const result = chatToResponsesRequest({
+        model: "gpt-4o",
+        messages: [],
+        temperature: 0.5,
+        top_p: 0.9,
+        stream: true,
+      });
+      expect(result.temperature).toBe(0.5);
+      expect(result.top_p).toBe(0.9);
+      expect(result.stream).toBe(true);
+    });
+  });
+
+  // --- Tools conversion ---
+  describe("tools conversion (reverse)", () => {
+    it("flattens function wrapper in tools", () => {
+      const result = chatToResponsesRequest({
+        model: "gpt-4o",
+        messages: [],
+        tools: [
+          {
+            type: "function",
+            function: {
+              name: "get_weather",
+              description: "Get weather",
+              parameters: { type: "object" },
+            },
+          },
+        ],
+      });
+
+      const tools = result.tools as Array<Record<string, unknown>>;
+      expect(tools).toHaveLength(1);
+      expect(tools[0]).toEqual({
+        type: "function",
+        name: "get_weather",
+        description: "Get weather",
+        parameters: { type: "object" },
+      });
+    });
+
+    it("passes tool_choice through", () => {
+      const result = chatToResponsesRequest({
+        model: "gpt-4o",
+        messages: [],
+        tools: [{ type: "function", function: { name: "fn" } }],
+        tool_choice: "auto",
+      });
+      expect(result.tool_choice).toBe("auto");
+    });
+  });
+
+  // --- response_format → text.format ---
+  describe("response_format conversion", () => {
+    it("maps response_format → text.format", () => {
+      const result = chatToResponsesRequest({
+        model: "gpt-4o",
+        messages: [],
+        response_format: { type: "json_schema", json_schema: { name: "test" } },
+      });
+      expect(result.text).toEqual({
+        format: { type: "json_schema", json_schema: { name: "test" } },
+      });
+    });
+  });
+
+  // --- Assistant text → message ---
+  describe("assistant text content", () => {
+    it("converts assistant text → message with output_text", () => {
+      const result = chatToResponsesRequest({
+        model: "gpt-4o",
+        messages: [
+          { role: "user", content: "Hi" },
+          { role: "assistant", content: "Hello!" },
+        ],
+      });
+
+      const input = result.input as Array<Record<string, unknown>>;
+      expect(input).toHaveLength(2);
+      expect(input[1]).toEqual({
+        type: "message",
+        role: "assistant",
+        content: [{ type: "output_text", text: "Hello!" }],
+      });
+    });
+
+    it("skips assistant message when content is null and no tool_calls", () => {
+      const result = chatToResponsesRequest({
+        model: "gpt-4o",
+        messages: [
+          { role: "user", content: "Hi" },
+          { role: "assistant", content: null },
+        ],
+      });
+
+      const input = result.input as Array<Record<string, unknown>>;
+      expect(input).toHaveLength(1);
+    });
+
+    it("includes assistant text alongside tool_calls", () => {
+      const result = chatToResponsesRequest({
+        model: "gpt-4o",
+        messages: [
+          { role: "user", content: "Go" },
+          {
+            role: "assistant",
+            content: "Let me check",
+            tool_calls: [
+              { id: "call_1", type: "function", function: { name: "fn", arguments: "{}" } },
+            ],
+          },
+        ],
+      });
+
+      const input = result.input as Array<Record<string, unknown>>;
+      expect(input).toHaveLength(3);
+      // First: assistant message with text
+      expect(input[1]).toEqual({
+        type: "message",
+        role: "assistant",
+        content: [{ type: "output_text", text: "Let me check" }],
+      });
+      // Second: function_call
+      expect(input[2].type).toBe("function_call");
+    });
+  });
+
+  // --- Reasoning pass-through ---
+  describe("reasoning pass-through", () => {
+    it("passes reasoning through", () => {
+      const result = chatToResponsesRequest({
+        model: "gpt-4o",
+        messages: [],
+        reasoning: { effort: "low" },
+      });
+      expect(result.reasoning).toEqual({ effort: "low" });
+    });
+  });
+});
+
+// ============================================================
+// Round-trip: Responses → Chat → Responses
+// ============================================================
+
+describe("round-trip: Responses → Chat → Responses", () => {
+  it("preserves basic fields", () => {
+    const original = {
+      model: "gpt-4o",
+      input: "Hello",
+      instructions: "Be helpful",
+      max_output_tokens: 2048,
+      temperature: 0.7,
+    };
+
+    const chat = responsesToChatRequest(original);
+    const roundTrip = chatToResponsesRequest(chat);
+
+    expect(roundTrip.model).toBe("gpt-4o");
+    expect(roundTrip.instructions).toBe("Be helpful");
+    expect(roundTrip.max_output_tokens).toBe(2048);
+    expect(roundTrip.temperature).toBe(0.7);
+
+    // input should come back as a message item
+    const input = roundTrip.input as Array<Record<string, unknown>>;
+    expect(input).toHaveLength(1);
+    expect(input[0]).toEqual({
+      type: "message",
+      role: "user",
+      content: [{ type: "input_text", text: "Hello" }],
+    });
+  });
+
+  it("preserves tool definitions in round-trip", () => {
+    const original = {
+      model: "gpt-4o",
+      input: "Use the tool",
+      tools: [
+        {
+          type: "function",
+          name: "my_fn",
+          description: "A function",
+          parameters: { type: "object" },
+        },
+      ],
+      tool_choice: "auto" as const,
+    };
+
+    const chat = responsesToChatRequest(original);
+    const roundTrip = chatToResponsesRequest(chat);
+
+    const tools = roundTrip.tools as Array<Record<string, unknown>>;
+    expect(tools).toHaveLength(1);
+    expect(tools[0].name).toBe("my_fn");
+    expect(tools[0].description).toBe("A function");
+    expect(tools[0].parameters).toEqual({ type: "object" });
+    expect(roundTrip.tool_choice).toBe("auto");
+  });
+
+  it("preserves reasoning in round-trip", () => {
+    const original = {
+      model: "gpt-4o",
+      input: "Think deeply",
+      reasoning: { effort: "high", max_tokens: 10000 },
+    };
+
+    const chat = responsesToChatRequest(original);
+    const roundTrip = chatToResponsesRequest(chat);
+
+    expect(roundTrip.reasoning).toEqual({ effort: "high", max_tokens: 10000 });
+  });
+
+  it("preserves multi-turn conversation structure", () => {
+    const original = {
+      model: "gpt-4o",
+      input: [
+        { type: "message", role: "user", content: "What's the weather?" },
+        {
+          type: "function_call",
+          id: "fc_1",
+          call_id: "call_1",
+          name: "get_weather",
+          arguments: '{"city":"SF"}',
+        },
+        {
+          type: "function_call_output",
+          call_id: "call_1",
+          output: "Sunny",
+        },
+        { type: "message", role: "assistant", content: "It's sunny in SF!" },
+      ],
+    };
+
+    const chat = responsesToChatRequest(original);
+    const roundTrip = chatToResponsesRequest(chat);
+
+    const input = roundTrip.input as Array<Record<string, unknown>>;
+    // Should have: user message, function_call, function_call_output, assistant message
+    expect(input.length).toBeGreaterThanOrEqual(4);
+
+    const types = input.map((i) => i.type as string);
+    expect(types).toContain("message");
+    expect(types).toContain("function_call");
+    expect(types).toContain("function_call_output");
+  });
+
+  it("preserves response_format / text.format in round-trip", () => {
+    const original = {
+      model: "gpt-4o",
+      input: "hi",
+      text: { format: { type: "json_object" } },
+    };
+
+    const chat = responsesToChatRequest(original);
+    const roundTrip = chatToResponsesRequest(chat);
+
+    expect(roundTrip.text).toEqual({ format: { type: "json_object" } });
+  });
+});

--- a/tests/proxy/transform/request-transform-responses.test.ts
+++ b/tests/proxy/transform/request-transform-responses.test.ts
@@ -1,0 +1,703 @@
+import { describe, it, expect } from "vitest";
+import {
+  responsesToAnthropicRequest,
+  anthropicToResponsesRequest,
+} from "../../../src/proxy/transform/request-transform-responses.js";
+
+// ============================================================
+// responsesToAnthropicRequest
+// ============================================================
+
+describe("responsesToAnthropicRequest", () => {
+  // --- 1. Basic text input ---
+  describe("basic text input", () => {
+    it("converts string input → user message and instructions → system", () => {
+      const result = responsesToAnthropicRequest({
+        model: "gpt-4o",
+        input: "Hello, world!",
+        instructions: "Be helpful",
+      });
+
+      expect(result.model).toBe("gpt-4o");
+      expect(result.system).toBe("Be helpful");
+      expect(result.messages).toEqual([
+        { role: "user", content: [{ type: "text", text: "Hello, world!" }] },
+      ]);
+    });
+
+    it("handles empty input gracefully", () => {
+      const result = responsesToAnthropicRequest({ model: "gpt-4o", input: "" });
+      expect(result.messages).toEqual([
+        { role: "user", content: [{ type: "text", text: "" }] },
+      ]);
+    });
+
+    it("passes through temperature, top_p, stream", () => {
+      const result = responsesToAnthropicRequest({
+        model: "gpt-4o",
+        input: "hi",
+        temperature: 0.5,
+        top_p: 0.9,
+        stream: true,
+      });
+      expect(result.temperature).toBe(0.5);
+      expect(result.top_p).toBe(0.9);
+      expect(result.stream).toBe(true);
+    });
+
+    it("maps max_output_tokens → max_tokens", () => {
+      const result = responsesToAnthropicRequest({
+        model: "gpt-4o",
+        input: "hi",
+        max_output_tokens: 2048,
+      });
+      expect(result.max_tokens).toBe(2048);
+    });
+
+    it("maps metadata.user_id", () => {
+      const result = responsesToAnthropicRequest({
+        model: "gpt-4o",
+        input: "hi",
+        metadata: { user_id: "user123" },
+      });
+      expect(result.metadata).toEqual({ user_id: "user123" });
+    });
+  });
+
+  // --- 2. Multi-turn with function_call / function_call_output ---
+  describe("multi-turn with function items", () => {
+    it("converts message items with roles", () => {
+      const result = responsesToAnthropicRequest({
+        model: "gpt-4o",
+        input: [
+          { type: "message", role: "user", content: "What's the weather?" },
+          { type: "message", role: "assistant", content: "Let me check." },
+        ],
+      });
+
+      const msgs = result.messages as Array<{ role: string; content: unknown }>;
+      expect(msgs).toHaveLength(2);
+      expect(msgs[0].role).toBe("user");
+      expect(msgs[1].role).toBe("assistant");
+    });
+
+    it("converts function_call → assistant tool_use", () => {
+      const result = responsesToAnthropicRequest({
+        model: "gpt-4o",
+        input: [
+          { type: "message", role: "user", content: "Check weather" },
+          {
+            type: "function_call",
+            id: "fc_123",
+            call_id: "call_abc",
+            name: "get_weather",
+            arguments: '{"city":"SF"}',
+          },
+        ],
+      });
+
+      const msgs = result.messages as Array<{ role: string; content: Array<Record<string, unknown>> }>;
+      expect(msgs).toHaveLength(2);
+      expect(msgs[1].role).toBe("assistant");
+      const toolUse = msgs[1].content[0];
+      expect(toolUse.type).toBe("tool_use");
+      expect(toolUse.name).toBe("get_weather");
+      expect(toolUse.id).toBe("toolu_call_abc");
+      expect(toolUse.input).toEqual({ city: "SF" });
+    });
+
+    it("converts function_call_output → user tool_result", () => {
+      const result = responsesToAnthropicRequest({
+        model: "gpt-4o",
+        input: [
+          { type: "message", role: "user", content: "Check weather" },
+          {
+            type: "function_call",
+            id: "fc_1",
+            call_id: "call_1",
+            name: "get_weather",
+            arguments: "{}",
+          },
+          {
+            type: "function_call_output",
+            call_id: "call_1",
+            output: "Sunny, 72°F",
+          },
+        ],
+      });
+
+      const msgs = result.messages as Array<{ role: string; content: Array<Record<string, unknown>> }>;
+      // After merge: user, assistant, user
+      expect(msgs).toHaveLength(3);
+      expect(msgs[2].role).toBe("user");
+      const toolResult = msgs[2].content[0];
+      expect(toolResult.type).toBe("tool_result");
+      expect(toolResult.tool_use_id).toBe("toolu_call_1");
+      expect(toolResult.content).toBe("Sunny, 72°F");
+    });
+
+    it("handles input_text items as user messages", () => {
+      const result = responsesToAnthropicRequest({
+        model: "gpt-4o",
+        input: [
+          { type: "input_text", text: "Hello" },
+          { type: "input_text", text: "World" },
+        ],
+      });
+
+      const msgs = result.messages as Array<{ role: string; content: Array<Record<string, unknown>> }>;
+      // Two consecutive user messages should be merged
+      expect(msgs).toHaveLength(1);
+      expect(msgs[0].role).toBe("user");
+      expect(msgs[0].content).toHaveLength(2);
+      expect(msgs[0].content[0]).toEqual({ type: "text", text: "Hello" });
+      expect(msgs[0].content[1]).toEqual({ type: "text", text: "World" });
+    });
+  });
+
+  // --- 3. Reasoning → thinking ---
+  describe("reasoning → thinking", () => {
+    it("maps reasoning.effort to thinking.budget_tokens", () => {
+      const result = responsesToAnthropicRequest({
+        model: "gpt-4o",
+        input: "hi",
+        reasoning: { effort: "high" },
+      });
+      expect(result.thinking).toEqual({ type: "enabled", budget_tokens: 32768 });
+    });
+
+    it("maps reasoning.effort=low correctly", () => {
+      const result = responsesToAnthropicRequest({
+        model: "gpt-4o",
+        input: "hi",
+        reasoning: { effort: "low" },
+      });
+      expect(result.thinking).toEqual({ type: "enabled", budget_tokens: 1024 });
+    });
+
+    it("maps reasoning.effort=medium correctly", () => {
+      const result = responsesToAnthropicRequest({
+        model: "gpt-4o",
+        input: "hi",
+        reasoning: { effort: "medium" },
+      });
+      expect(result.thinking).toEqual({ type: "enabled", budget_tokens: 8192 });
+    });
+
+    it("reasoning.max_tokens overrides effort mapping", () => {
+      const result = responsesToAnthropicRequest({
+        model: "gpt-4o",
+        input: "hi",
+        reasoning: { effort: "low", max_tokens: 5000 },
+      });
+      expect(result.thinking).toEqual({ type: "enabled", budget_tokens: 5000 });
+    });
+
+    it("defaults to 8192 budget when no effort specified", () => {
+      const result = responsesToAnthropicRequest({
+        model: "gpt-4o",
+        input: "hi",
+        reasoning: {},
+      });
+      expect(result.thinking).toEqual({ type: "enabled", budget_tokens: 8192 });
+    });
+
+    it("ensures max_tokens >= budget_tokens", () => {
+      const result = responsesToAnthropicRequest({
+        model: "gpt-4o",
+        input: "hi",
+        max_output_tokens: 100,
+        reasoning: { effort: "high" },
+      });
+      expect(result.max_tokens).toBe(32768);
+    });
+
+    it("converts reasoning input items to assistant thinking blocks", () => {
+      const result = responsesToAnthropicRequest({
+        model: "gpt-4o",
+        input: [
+          { type: "message", role: "user", content: "Think about this" },
+          {
+            type: "reasoning",
+            id: "rs_1",
+            summary: [{ type: "summary_text", text: "I considered the options" }],
+          },
+        ],
+      });
+
+      const msgs = result.messages as Array<{ role: string; content: Array<Record<string, unknown>> }>;
+      // user, assistant (thinking)
+      expect(msgs).toHaveLength(2);
+      expect(msgs[1].role).toBe("assistant");
+      expect(msgs[1].content[0].type).toBe("thinking");
+      expect(msgs[1].content[0].thinking).toBe("I considered the options");
+    });
+  });
+
+  // --- 4. Tool definitions and tool_choice ---
+  describe("tools and tool_choice", () => {
+    it("converts function tools and filters non-function tools", () => {
+      const result = responsesToAnthropicRequest({
+        model: "gpt-4o",
+        input: "hi",
+        tools: [
+          { type: "function", name: "get_weather", description: "Get weather", parameters: { type: "object" } },
+          { type: "web_search_preview" } as Record<string, unknown>,
+          { type: "file_search", vector_store_ids: ["vs_1"] } as Record<string, unknown>,
+        ],
+      });
+
+      const tools = result.tools as Array<Record<string, unknown>>;
+      expect(tools).toHaveLength(1);
+      expect(tools[0]).toEqual({
+        name: "get_weather",
+        description: "Get weather",
+        input_schema: { type: "object" },
+      });
+    });
+
+    it("maps tool_choice 'auto'", () => {
+      const result = responsesToAnthropicRequest({
+        model: "gpt-4o",
+        input: "hi",
+        tools: [{ type: "function", name: "fn", parameters: {} }],
+        tool_choice: "auto",
+      });
+      expect(result.tool_choice).toEqual({ type: "auto" });
+    });
+
+    it("maps tool_choice 'required' → {type:'any'}", () => {
+      const result = responsesToAnthropicRequest({
+        model: "gpt-4o",
+        input: "hi",
+        tools: [{ type: "function", name: "fn", parameters: {} }],
+        tool_choice: "required",
+      });
+      expect(result.tool_choice).toEqual({ type: "any" });
+    });
+
+    it("drops tools when tool_choice is 'none'", () => {
+      const result = responsesToAnthropicRequest({
+        model: "gpt-4o",
+        input: "hi",
+        tools: [{ type: "function", name: "fn", parameters: {} }],
+        tool_choice: "none",
+      });
+      expect(result.tools).toBeUndefined();
+      expect(result.tool_choice).toBeUndefined();
+    });
+
+    it("maps tool_choice {type:'function', name} → {type:'tool', name}", () => {
+      const result = responsesToAnthropicRequest({
+        model: "gpt-4o",
+        input: "hi",
+        tools: [{ type: "function", name: "my_fn", parameters: {} }],
+        tool_choice: { type: "function", name: "my_fn" },
+      });
+      expect(result.tool_choice).toEqual({ type: "tool", name: "my_fn" });
+    });
+  });
+
+  // --- 5. parallel_tool_calls ---
+  describe("parallel_tool_calls", () => {
+    it("adds disable_parallel_tool_use when parallel_tool_calls=false", () => {
+      const result = responsesToAnthropicRequest({
+        model: "gpt-4o",
+        input: "hi",
+        tools: [{ type: "function", name: "fn", parameters: {} }],
+        tool_choice: "auto",
+        parallel_tool_calls: false,
+      });
+      expect(result.tool_choice).toEqual({ type: "auto", disable_parallel_tool_use: true });
+    });
+
+    it("adds disable_parallel_tool_use with tool_choice=function", () => {
+      const result = responsesToAnthropicRequest({
+        model: "gpt-4o",
+        input: "hi",
+        tools: [{ type: "function", name: "my_fn", parameters: {} }],
+        tool_choice: { type: "function", name: "my_fn" },
+        parallel_tool_calls: false,
+      });
+      expect(result.tool_choice).toEqual({ type: "tool", name: "my_fn", disable_parallel_tool_use: true });
+    });
+
+    it("creates auto tool_choice when parallel_tool_calls=false without explicit tool_choice", () => {
+      const result = responsesToAnthropicRequest({
+        model: "gpt-4o",
+        input: "hi",
+        tools: [{ type: "function", name: "fn", parameters: {} }],
+        parallel_tool_calls: false,
+      });
+      expect(result.tool_choice).toEqual({ type: "auto", disable_parallel_tool_use: true });
+    });
+  });
+
+  // --- 6. Message merge and alternation ---
+  describe("message alternation", () => {
+    it("merges consecutive same-role messages", () => {
+      const result = responsesToAnthropicRequest({
+        model: "gpt-4o",
+        input: [
+          { type: "message", role: "user", content: "Hello" },
+          { type: "input_text", text: "Additional" },
+        ],
+      });
+
+      const msgs = result.messages as Array<{ role: string }>;
+      expect(msgs).toHaveLength(1);
+      expect(msgs[0].role).toBe("user");
+    });
+
+    it("prepends empty user message when first message is assistant", () => {
+      const result = responsesToAnthropicRequest({
+        model: "gpt-4o",
+        input: [
+          { type: "message", role: "assistant", content: "Hi there" },
+        ],
+      });
+
+      const msgs = result.messages as Array<{ role: string }>;
+      expect(msgs[0].role).toBe("user");
+      expect(msgs[1].role).toBe("assistant");
+    });
+  });
+});
+
+// ============================================================
+// anthropicToResponsesRequest
+// ============================================================
+
+describe("anthropicToResponsesRequest", () => {
+  // --- 7. Basic text ---
+  describe("basic text conversion", () => {
+    it("converts system → instructions and messages → input items", () => {
+      const result = anthropicToResponsesRequest({
+        model: "claude-3",
+        system: "Be helpful",
+        messages: [
+          { role: "user", content: [{ type: "text", text: "Hello" }] },
+        ],
+      });
+
+      expect(result.model).toBe("claude-3");
+      expect(result.instructions).toBe("Be helpful");
+      expect(result.input).toEqual([
+        {
+          type: "message",
+          role: "user",
+          content: [{ type: "input_text", text: "Hello" }],
+        },
+      ]);
+    });
+
+    it("joins system array into instructions", () => {
+      const result = anthropicToResponsesRequest({
+        model: "claude-3",
+        system: [
+          { type: "text", text: "Rule 1" },
+          { type: "text", text: "Rule 2" },
+        ],
+        messages: [],
+      });
+
+      expect(result.instructions).toBe("Rule 1\nRule 2");
+    });
+
+    it("maps max_tokens → max_output_tokens", () => {
+      const result = anthropicToResponsesRequest({
+        model: "claude-3",
+        messages: [],
+        max_tokens: 4096,
+      });
+      expect(result.max_output_tokens).toBe(4096);
+    });
+
+    it("passes through temperature, top_p, stream", () => {
+      const result = anthropicToResponsesRequest({
+        model: "claude-3",
+        messages: [],
+        temperature: 0.7,
+        top_p: 0.95,
+        stream: true,
+      });
+      expect(result.temperature).toBe(0.7);
+      expect(result.top_p).toBe(0.95);
+      expect(result.stream).toBe(true);
+    });
+
+    it("maps metadata.user_id", () => {
+      const result = anthropicToResponsesRequest({
+        model: "claude-3",
+        messages: [],
+        metadata: { user_id: "user456" },
+      });
+      expect(result.metadata).toEqual({ user_id: "user456" });
+    });
+  });
+
+  // --- 8. Tool_use and tool_result ---
+  describe("tool_use and tool_result conversion", () => {
+    it("converts assistant tool_use → function_call items", () => {
+      const result = anthropicToResponsesRequest({
+        model: "claude-3",
+        messages: [
+          { role: "user", content: [{ type: "text", text: "Check weather" }] },
+          {
+            role: "assistant",
+            content: [{
+              type: "tool_use",
+              id: "toolu_call_abc",
+              name: "get_weather",
+              input: { city: "SF" },
+            }],
+          },
+        ],
+      });
+
+      const input = result.input as Array<Record<string, unknown>>;
+      expect(input).toHaveLength(2);
+      // Second item should be function_call
+      expect(input[1].type).toBe("function_call");
+      expect(input[1].call_id).toBe("call_abc");
+      expect(input[1].name).toBe("get_weather");
+      expect(input[1].arguments).toBe('{"city":"SF"}');
+    });
+
+    it("converts user tool_result → function_call_output items", () => {
+      const result = anthropicToResponsesRequest({
+        model: "claude-3",
+        messages: [
+          { role: "user", content: [{ type: "text", text: "Check weather" }] },
+          {
+            role: "assistant",
+            content: [{
+              type: "tool_use",
+              id: "toolu_call_1",
+              name: "get_weather",
+              input: {},
+            }],
+          },
+          {
+            role: "user",
+            content: [{
+              type: "tool_result",
+              tool_use_id: "toolu_call_1",
+              content: "Sunny, 72°F",
+            }],
+          },
+        ],
+      });
+
+      const input = result.input as Array<Record<string, unknown>>;
+      // user message, function_call, function_call_output
+      expect(input).toHaveLength(3);
+      expect(input[2].type).toBe("function_call_output");
+      expect(input[2].call_id).toBe("call_1");
+      expect(input[2].output).toBe("Sunny, 72°F");
+    });
+
+    it("converts assistant text → assistant message with output_text", () => {
+      const result = anthropicToResponsesRequest({
+        model: "claude-3",
+        messages: [
+          { role: "user", content: [{ type: "text", text: "Hi" }] },
+          { role: "assistant", content: [{ type: "text", text: "Hello!" }] },
+        ],
+      });
+
+      const input = result.input as Array<Record<string, unknown>>;
+      expect(input[1].type).toBe("message");
+      expect(input[1].role).toBe("assistant");
+      expect((input[1].content as Array<Record<string, unknown>>[])[0].type).toBe("output_text");
+    });
+  });
+
+  // --- 9. Thinking ---
+  describe("thinking → reasoning", () => {
+    it("converts thinking blocks → reasoning items", () => {
+      const result = anthropicToResponsesRequest({
+        model: "claude-3",
+        messages: [
+          { role: "user", content: [{ type: "text", text: "Think" }] },
+          {
+            role: "assistant",
+            content: [
+              { type: "thinking", thinking: "Deep thoughts..." },
+              { type: "text", text: "Here's my answer" },
+            ],
+          },
+        ],
+      });
+
+      const input = result.input as Array<Record<string, unknown>>;
+      // user message, reasoning, assistant message
+      expect(input).toHaveLength(3);
+      expect(input[1].type).toBe("reasoning");
+      const summary = input[1].summary as Array<Record<string, unknown>>;
+      expect(summary[0].type).toBe("summary_text");
+      expect(summary[0].text).toBe("Deep thoughts...");
+    });
+
+    it("maps thinking.budget_tokens → reasoning.max_tokens", () => {
+      const result = anthropicToResponsesRequest({
+        model: "claude-3",
+        messages: [],
+        thinking: { type: "enabled", budget_tokens: 10000 },
+      });
+      expect(result.reasoning).toEqual({ max_tokens: 10000 });
+    });
+
+    it("does not map thinking when type is not 'enabled'", () => {
+      const result = anthropicToResponsesRequest({
+        model: "claude-3",
+        messages: [],
+        thinking: { type: "disabled" },
+      });
+      expect(result.reasoning).toBeUndefined();
+    });
+  });
+
+  // --- Tool mapping ---
+  describe("tools and tool_choice (reverse)", () => {
+    it("converts Anthropic tools → Responses function tools", () => {
+      const result = anthropicToResponsesRequest({
+        model: "claude-3",
+        messages: [],
+        tools: [
+          { name: "get_weather", description: "Get weather", input_schema: { type: "object" } },
+        ],
+      });
+
+      const tools = result.tools as Array<Record<string, unknown>>;
+      expect(tools).toHaveLength(1);
+      expect(tools[0].type).toBe("function");
+      expect(tools[0].name).toBe("get_weather");
+      expect(tools[0].parameters).toEqual({ type: "object" });
+    });
+
+    it("maps tool_choice auto → 'auto'", () => {
+      const result = anthropicToResponsesRequest({
+        model: "claude-3",
+        messages: [],
+        tool_choice: { type: "auto" },
+      });
+      expect(result.tool_choice).toBe("auto");
+    });
+
+    it("maps tool_choice any → 'required'", () => {
+      const result = anthropicToResponsesRequest({
+        model: "claude-3",
+        messages: [],
+        tool_choice: { type: "any" },
+      });
+      expect(result.tool_choice).toBe("required");
+    });
+
+    it("maps tool_choice tool+name → {type:'function', name}", () => {
+      const result = anthropicToResponsesRequest({
+        model: "claude-3",
+        messages: [],
+        tool_choice: { type: "tool", name: "my_fn" },
+      });
+      expect(result.tool_choice).toEqual({ type: "function", name: "my_fn" });
+    });
+  });
+});
+
+// ============================================================
+// Round-trip: Responses → Anthropic → Responses
+// ============================================================
+
+describe("round-trip: Responses → Anthropic → Responses", () => {
+  it("preserves core fields for a basic text conversation", () => {
+    const original = {
+      model: "gpt-4o",
+      input: "Hello",
+      instructions: "Be helpful",
+      max_output_tokens: 2048,
+      temperature: 0.7,
+    };
+
+    const anthropic = responsesToAnthropicRequest(original);
+    const roundTrip = anthropicToResponsesRequest(anthropic);
+
+    expect(roundTrip.model).toBe("gpt-4o");
+    expect(roundTrip.instructions).toBe("Be helpful");
+    expect(roundTrip.max_output_tokens).toBe(2048);
+    expect(roundTrip.temperature).toBe(0.7);
+
+    // input should come back as message items with same text
+    const input = roundTrip.input as Array<Record<string, unknown>>;
+    expect(input[0].type).toBe("message");
+    expect(input[0].role).toBe("user");
+    const content = (input[0].content as Array<Record<string, unknown>>)[0];
+    expect(content.text).toBe("Hello");
+  });
+
+  it("preserves tool definitions and tool_choice in round-trip", () => {
+    const original = {
+      model: "gpt-4o",
+      input: "Use the tool",
+      tools: [
+        { type: "function", name: "my_fn", description: "A function", parameters: { type: "object" } },
+      ],
+      tool_choice: "auto" as const,
+    };
+
+    const anthropic = responsesToAnthropicRequest(original);
+    const roundTrip = anthropicToResponsesRequest(anthropic);
+
+    const tools = roundTrip.tools as Array<Record<string, unknown>>;
+    expect(tools).toHaveLength(1);
+    expect(tools[0].name).toBe("my_fn");
+    expect(roundTrip.tool_choice).toBe("auto");
+  });
+
+  it("preserves reasoning budget in round-trip", () => {
+    const original = {
+      model: "gpt-4o",
+      input: "Think deeply",
+      reasoning: { max_tokens: 5000 },
+    };
+
+    const anthropic = responsesToAnthropicRequest(original);
+    const roundTrip = anthropicToResponsesRequest(anthropic);
+
+    expect(roundTrip.reasoning).toEqual({ max_tokens: 5000 });
+  });
+
+  it("preserves multi-turn conversation structure", () => {
+    const original = {
+      model: "gpt-4o",
+      input: [
+        { type: "message", role: "user", content: "What's the weather?" },
+        {
+          type: "function_call",
+          id: "fc_1",
+          call_id: "call_1",
+          name: "get_weather",
+          arguments: '{"city":"SF"}',
+        },
+        {
+          type: "function_call_output",
+          call_id: "call_1",
+          output: "Sunny",
+        },
+        { type: "message", role: "assistant", content: "It's sunny in SF!" },
+      ],
+    };
+
+    const anthropic = responsesToAnthropicRequest(original);
+    const roundTrip = anthropicToResponsesRequest(anthropic);
+
+    const input = roundTrip.input as Array<Record<string, unknown>>;
+    // Should have: user message, function_call, function_call_output, assistant message
+    expect(input.length).toBeGreaterThanOrEqual(4);
+
+    const types = input.map(i => i.type);
+    expect(types).toContain("message");
+    expect(types).toContain("function_call");
+    expect(types).toContain("function_call_output");
+  });
+});

--- a/tests/proxy/transform/response-bridge-responses.test.ts
+++ b/tests/proxy/transform/response-bridge-responses.test.ts
@@ -1,0 +1,318 @@
+import { describe, it, expect } from "vitest";
+import {
+  responsesToChatResponse,
+  chatToResponsesResponse,
+} from "../../../src/proxy/transform/response-bridge-responses.js";
+
+// ---------- Fixtures: Responses API responses ----------
+
+const RESP_TEXT = JSON.stringify({
+  id: "resp_abc123",
+  object: "response",
+  model: "gpt-4o",
+  status: "completed",
+  output: [
+    {
+      type: "message",
+      id: "msg_001",
+      role: "assistant",
+      content: [{ type: "output_text", text: "Hello, world!" }],
+    },
+  ],
+  usage: { input_tokens: 15, output_tokens: 8, total_tokens: 23 },
+});
+
+const RESP_FUNCTION_CALL = JSON.stringify({
+  id: "resp_def456",
+  object: "response",
+  model: "gpt-4o",
+  status: "completed",
+  output: [
+    {
+      type: "function_call",
+      id: "fc_001",
+      call_id: "call_abc",
+      name: "get_weather",
+      arguments: '{"city":"NYC"}',
+    },
+  ],
+  usage: { input_tokens: 20, output_tokens: 12, total_tokens: 32 },
+});
+
+const RESP_REASONING = JSON.stringify({
+  id: "resp_ghi789",
+  object: "response",
+  model: "o3",
+  status: "completed",
+  output: [
+    {
+      type: "reasoning",
+      id: "rs_001",
+      summary: [
+        { type: "summary_text", text: "Step 1: " },
+        { type: "summary_text", text: "Analyze the problem." },
+      ],
+    },
+    {
+      type: "message",
+      id: "msg_002",
+      role: "assistant",
+      content: [{ type: "output_text", text: "The answer is 42." }],
+    },
+  ],
+  usage: { input_tokens: 30, output_tokens: 50, total_tokens: 80 },
+});
+
+const RESP_INCOMPLETE = JSON.stringify({
+  id: "resp_inc",
+  object: "response",
+  model: "gpt-4o",
+  status: "incomplete",
+  output: [
+    {
+      type: "message",
+      id: "msg_003",
+      role: "assistant",
+      content: [{ type: "output_text", text: "Partial..." }],
+    },
+  ],
+  usage: { input_tokens: 10, output_tokens: 3, total_tokens: 13 },
+});
+
+const RESP_WITH_SKIP_ITEMS = JSON.stringify({
+  id: "resp_skip",
+  object: "response",
+  model: "gpt-4o",
+  status: "completed",
+  output: [
+    { type: "web_search_call", id: "ws_001", status: "completed" },
+    {
+      type: "message",
+      id: "msg_004",
+      role: "assistant",
+      content: [{ type: "output_text", text: "Search result." }],
+    },
+  ],
+  usage: { input_tokens: 25, output_tokens: 10, total_tokens: 35 },
+});
+
+// ---------- Fixtures: Chat Completions responses ----------
+
+const CHAT_TEXT = JSON.stringify({
+  id: "chatcmpl-abc123",
+  object: "chat.completion",
+  created: 1700000000,
+  model: "gpt-4o",
+  choices: [{
+    index: 0,
+    message: { role: "assistant", content: "Hello from Chat!" },
+    finish_reason: "stop",
+  }],
+  usage: { prompt_tokens: 15, completion_tokens: 8, total_tokens: 23 },
+});
+
+const CHAT_TOOL_CALLS = JSON.stringify({
+  id: "chatcmpl-def456",
+  object: "chat.completion",
+  created: 1700000000,
+  model: "gpt-4o",
+  choices: [{
+    index: 0,
+    message: {
+      role: "assistant",
+      content: null,
+      tool_calls: [{
+        id: "call_abc",
+        type: "function",
+        function: { name: "get_weather", arguments: '{"city":"NYC"}' },
+      }],
+    },
+    finish_reason: "tool_calls",
+  }],
+  usage: { prompt_tokens: 20, completion_tokens: 12, total_tokens: 32 },
+});
+
+const CHAT_REASONING = JSON.stringify({
+  id: "chatcmpl-ghi789",
+  object: "chat.completion",
+  created: 1700000000,
+  model: "o3",
+  choices: [{
+    index: 0,
+    message: {
+      role: "assistant",
+      reasoning_content: "Let me think about this step by step...",
+      content: "The answer is 42.",
+    },
+    finish_reason: "stop",
+  }],
+  usage: { prompt_tokens: 30, completion_tokens: 50, total_tokens: 80 },
+});
+
+const CHAT_LENGTH = JSON.stringify({
+  id: "chatcmpl-length",
+  object: "chat.completion",
+  created: 1700000000,
+  model: "gpt-4o",
+  choices: [{
+    index: 0,
+    message: { role: "assistant", content: "Cut off..." },
+    finish_reason: "length",
+  }],
+  usage: { prompt_tokens: 10, completion_tokens: 3, total_tokens: 13 },
+});
+
+// ========== responsesToChatResponse ==========
+
+describe("responsesToChatResponse", () => {
+  it("converts basic text output", () => {
+    const result = JSON.parse(responsesToChatResponse(RESP_TEXT));
+    expect(result.object).toBe("chat.completion");
+    expect(result.id).toMatch(/^chatcmpl-/);
+    expect(result.model).toBe("gpt-4o");
+    expect(result.created).toBeTypeOf("number");
+    expect(result.choices).toHaveLength(1);
+    expect(result.choices[0].message.role).toBe("assistant");
+    expect(result.choices[0].message.content).toBe("Hello, world!");
+    expect(result.choices[0].finish_reason).toBe("stop");
+  });
+
+  it("converts function_call output to tool_calls", () => {
+    const result = JSON.parse(responsesToChatResponse(RESP_FUNCTION_CALL));
+    const msg = result.choices[0].message;
+    expect(msg.tool_calls).toHaveLength(1);
+    expect(msg.tool_calls[0]).toEqual({
+      id: "fc_001",
+      type: "function",
+      function: { name: "get_weather", arguments: '{"city":"NYC"}' },
+    });
+    expect(result.choices[0].finish_reason).toBe("tool_calls");
+  });
+
+  it("converts reasoning output to reasoning_content (flattened)", () => {
+    const result = JSON.parse(responsesToChatResponse(RESP_REASONING));
+    const msg = result.choices[0].message;
+    // Structured summaries are LOSSY joined into a single string
+    expect(msg.reasoning_content).toBe("Step 1: Analyze the problem.");
+    expect(msg.content).toBe("The answer is 42.");
+  });
+
+  it("maps status completed → stop", () => {
+    const result = JSON.parse(responsesToChatResponse(RESP_TEXT));
+    expect(result.choices[0].finish_reason).toBe("stop");
+  });
+
+  it("maps status incomplete → length", () => {
+    const result = JSON.parse(responsesToChatResponse(RESP_INCOMPLETE));
+    expect(result.choices[0].finish_reason).toBe("length");
+  });
+
+  it("overrides finish_reason to tool_calls when function_call present", () => {
+    // Even if status were incomplete, function_call forces tool_calls
+    const result = JSON.parse(responsesToChatResponse(RESP_FUNCTION_CALL));
+    expect(result.choices[0].finish_reason).toBe("tool_calls");
+  });
+
+  it("skips non-convertible output types (web_search_call)", () => {
+    const result = JSON.parse(responsesToChatResponse(RESP_WITH_SKIP_ITEMS));
+    expect(result.choices[0].message.content).toBe("Search result.");
+  });
+
+  it("maps usage correctly", () => {
+    const result = JSON.parse(responsesToChatResponse(RESP_TEXT));
+    expect(result.usage).toEqual({
+      prompt_tokens: 15,
+      completion_tokens: 8,
+      total_tokens: 23,
+    });
+  });
+});
+
+// ========== chatToResponsesResponse ==========
+
+describe("chatToResponsesResponse", () => {
+  it("converts basic Chat text to Responses output message", () => {
+    const result = JSON.parse(chatToResponsesResponse(CHAT_TEXT));
+    expect(result.object).toBe("response");
+    expect(result.id).toMatch(/^resp_/);
+    expect(result.model).toBe("gpt-4o");
+    expect(result.status).toBe("completed");
+    expect(result.output).toHaveLength(1);
+    expect(result.output[0].type).toBe("message");
+    expect(result.output[0].role).toBe("assistant");
+    expect(result.output[0].content).toEqual([{ type: "output_text", text: "Hello from Chat!" }]);
+  });
+
+  it("converts Chat tool_calls to Responses function_call items", () => {
+    const result = JSON.parse(chatToResponsesResponse(CHAT_TOOL_CALLS));
+    const fc = result.output.find((o: Record<string, unknown>) => o.type === "function_call");
+    expect(fc).toBeDefined();
+    expect(fc.call_id).toBe("call_abc");
+    expect(fc.id).toBe("call_abc");
+    expect(fc.name).toBe("get_weather");
+    expect(fc.arguments).toBe('{"city":"NYC"}');
+    expect(result.status).toBe("completed");
+  });
+
+  it("converts Chat reasoning_content to Responses reasoning output", () => {
+    const result = JSON.parse(chatToResponsesResponse(CHAT_REASONING));
+    const reasoning = result.output.find((o: Record<string, unknown>) => o.type === "reasoning");
+    expect(reasoning).toBeDefined();
+    expect(reasoning.summary).toEqual([{ type: "summary_text", text: "Let me think about this step by step..." }]);
+
+    const message = result.output.find((o: Record<string, unknown>) => o.type === "message");
+    expect(message).toBeDefined();
+    expect(message.content).toEqual([{ type: "output_text", text: "The answer is 42." }]);
+  });
+
+  it("maps finish_reason stop → completed", () => {
+    const result = JSON.parse(chatToResponsesResponse(CHAT_TEXT));
+    expect(result.status).toBe("completed");
+  });
+
+  it("maps finish_reason length → incomplete", () => {
+    const result = JSON.parse(chatToResponsesResponse(CHAT_LENGTH));
+    expect(result.status).toBe("incomplete");
+  });
+
+  it("maps finish_reason tool_calls → completed", () => {
+    const result = JSON.parse(chatToResponsesResponse(CHAT_TOOL_CALLS));
+    expect(result.status).toBe("completed");
+  });
+
+  it("maps usage correctly", () => {
+    const result = JSON.parse(chatToResponsesResponse(CHAT_TEXT));
+    expect(result.usage).toEqual({
+      input_tokens: 15,
+      output_tokens: 8,
+      total_tokens: 23,
+    });
+  });
+
+  it("handles multiple tool_calls", () => {
+    const multiToolChat = JSON.stringify({
+      id: "chatcmpl-multi",
+      object: "chat.completion",
+      model: "gpt-4o",
+      choices: [{
+        index: 0,
+        message: {
+          role: "assistant",
+          content: null,
+          tool_calls: [
+            { id: "call_1", type: "function", function: { name: "fn1", arguments: "{}" } },
+            { id: "call_2", type: "function", function: { name: "fn2", arguments: '{"a":1}' } },
+          ],
+        },
+        finish_reason: "tool_calls",
+      }],
+      usage: { prompt_tokens: 10, completion_tokens: 20, total_tokens: 30 },
+    });
+
+    const result = JSON.parse(chatToResponsesResponse(multiToolChat));
+    const fcItems = result.output.filter((o: Record<string, unknown>) => o.type === "function_call");
+    expect(fcItems).toHaveLength(2);
+    expect(fcItems[0].name).toBe("fn1");
+    expect(fcItems[1].name).toBe("fn2");
+  });
+});

--- a/tests/proxy/transform/response-transform-responses.test.ts
+++ b/tests/proxy/transform/response-transform-responses.test.ts
@@ -1,0 +1,294 @@
+import { describe, it, expect } from "vitest";
+import {
+  responsesToAnthropicResponse,
+  anthropicToResponsesResponse,
+} from "../../../src/proxy/transform/response-transform-responses.js";
+
+// ---------- Fixtures: Responses API responses ----------
+
+const RESP_TEXT = JSON.stringify({
+  id: "resp_abc123",
+  object: "response",
+  model: "gpt-4o",
+  status: "completed",
+  output: [
+    {
+      type: "message",
+      id: "msg_001",
+      role: "assistant",
+      content: [{ type: "output_text", text: "Hello, world!" }],
+    },
+  ],
+  usage: { input_tokens: 15, output_tokens: 8, total_tokens: 23 },
+});
+
+const RESP_FUNCTION_CALL = JSON.stringify({
+  id: "resp_def456",
+  object: "response",
+  model: "gpt-4o",
+  status: "completed",
+  output: [
+    {
+      type: "function_call",
+      id: "fc_001",
+      call_id: "call_abc",
+      name: "get_weather",
+      arguments: '{"city":"NYC"}',
+    },
+  ],
+  usage: { input_tokens: 20, output_tokens: 12, total_tokens: 32 },
+});
+
+const RESP_REASONING = JSON.stringify({
+  id: "resp_ghi789",
+  object: "response",
+  model: "o3",
+  status: "completed",
+  output: [
+    {
+      type: "reasoning",
+      id: "rs_001",
+      summary: [
+        { type: "summary_text", text: "Step 1: " },
+        { type: "summary_text", text: "Analyze the problem." },
+      ],
+    },
+    {
+      type: "message",
+      id: "msg_002",
+      role: "assistant",
+      content: [{ type: "output_text", text: "The answer is 42." }],
+    },
+  ],
+  usage: { input_tokens: 30, output_tokens: 50, total_tokens: 80 },
+});
+
+const RESP_INCOMPLETE = JSON.stringify({
+  id: "resp_inc",
+  object: "response",
+  model: "gpt-4o",
+  status: "incomplete",
+  output: [
+    {
+      type: "message",
+      id: "msg_003",
+      role: "assistant",
+      content: [{ type: "output_text", text: "Partial..." }],
+    },
+  ],
+  usage: { input_tokens: 10, output_tokens: 3, total_tokens: 13 },
+});
+
+const RESP_FAILED = JSON.stringify({
+  id: "resp_fail",
+  object: "response",
+  model: "gpt-4o",
+  status: "failed",
+  output: [],
+  usage: { input_tokens: 5, output_tokens: 0, total_tokens: 5 },
+});
+
+const RESP_WITH_SKIP_ITEMS = JSON.stringify({
+  id: "resp_skip",
+  object: "response",
+  model: "gpt-4o",
+  status: "completed",
+  output: [
+    { type: "web_search_call", id: "ws_001", status: "completed" },
+    {
+      type: "message",
+      id: "msg_004",
+      role: "assistant",
+      content: [{ type: "output_text", text: "Search result." }],
+    },
+  ],
+  usage: { input_tokens: 25, output_tokens: 10, total_tokens: 35 },
+});
+
+// ---------- Fixtures: Anthropic Messages responses ----------
+
+const ANT_TEXT = JSON.stringify({
+  id: "msg_ant1",
+  type: "message",
+  role: "assistant",
+  model: "claude-3",
+  content: [{ type: "text", text: "Hello from Claude!" }],
+  stop_reason: "end_turn",
+  usage: { input_tokens: 15, output_tokens: 8 },
+});
+
+const ANT_TOOL_USE = JSON.stringify({
+  id: "msg_ant2",
+  type: "message",
+  role: "assistant",
+  model: "claude-3",
+  content: [
+    { type: "tool_use", id: "toolu_call_xyz", name: "get_weather", input: { city: "NYC" } },
+  ],
+  stop_reason: "tool_use",
+  usage: { input_tokens: 20, output_tokens: 12 },
+});
+
+const ANT_THINKING = JSON.stringify({
+  id: "msg_ant3",
+  type: "message",
+  role: "assistant",
+  model: "claude-3",
+  content: [
+    { type: "thinking", thinking: "Let me reason about this..." },
+    { type: "text", text: "The result." },
+  ],
+  stop_reason: "end_turn",
+  usage: { input_tokens: 30, output_tokens: 50 },
+});
+
+const ANT_MAX_TOKENS = JSON.stringify({
+  id: "msg_ant4",
+  type: "message",
+  role: "assistant",
+  model: "claude-3",
+  content: [{ type: "text", text: "Cut off..." }],
+  stop_reason: "max_tokens",
+  usage: { input_tokens: 10, output_tokens: 5 },
+});
+
+const ANT_WITH_CACHE = JSON.stringify({
+  id: "msg_ant5",
+  type: "message",
+  role: "assistant",
+  model: "claude-3",
+  content: [{ type: "text", text: "cached" }],
+  stop_reason: "end_turn",
+  usage: { input_tokens: 100, output_tokens: 10, cache_read_input_tokens: 50, cache_creation_input_tokens: 20 },
+});
+
+// ========== responsesToAnthropicResponse ==========
+
+describe("responsesToAnthropicResponse", () => {
+  it("converts basic text output", () => {
+    const result = JSON.parse(responsesToAnthropicResponse(RESP_TEXT));
+    expect(result.type).toBe("message");
+    expect(result.role).toBe("assistant");
+    expect(result.content).toEqual([{ type: "text", text: "Hello, world!" }]);
+    expect(result.model).toBe("gpt-4o");
+    expect(result.stop_reason).toBe("end_turn");
+    expect(result.usage.input_tokens).toBe(15);
+    expect(result.usage.output_tokens).toBe(8);
+    expect(result.id).toMatch(/^msg_/);
+    expect(result.stop_sequence).toBeNull();
+  });
+
+  it("converts function_call output to tool_use block", () => {
+    const result = JSON.parse(responsesToAnthropicResponse(RESP_FUNCTION_CALL));
+    expect(result.content).toEqual([
+      { type: "tool_use", id: "toolu_call_abc", name: "get_weather", input: { city: "NYC" } },
+    ]);
+    expect(result.stop_reason).toBe("end_turn");
+  });
+
+  it("converts reasoning output to thinking block", () => {
+    const result = JSON.parse(responsesToAnthropicResponse(RESP_REASONING));
+    expect(result.content[0]).toEqual({ type: "thinking", thinking: "Step 1: Analyze the problem." });
+    expect(result.content[1]).toEqual({ type: "text", text: "The answer is 42." });
+  });
+
+  it("maps status completed → end_turn", () => {
+    const result = JSON.parse(responsesToAnthropicResponse(RESP_TEXT));
+    expect(result.stop_reason).toBe("end_turn");
+  });
+
+  it("maps status incomplete → max_tokens", () => {
+    const result = JSON.parse(responsesToAnthropicResponse(RESP_INCOMPLETE));
+    expect(result.stop_reason).toBe("max_tokens");
+  });
+
+  it("maps status failed → end_turn", () => {
+    const result = JSON.parse(responsesToAnthropicResponse(RESP_FAILED));
+    expect(result.stop_reason).toBe("end_turn");
+  });
+
+  it("adds empty text block when no content produced", () => {
+    const result = JSON.parse(responsesToAnthropicResponse(RESP_FAILED));
+    expect(result.content).toEqual([{ type: "text", text: "" }]);
+  });
+
+  it("skips non-convertible output types (web_search_call, etc.)", () => {
+    const result = JSON.parse(responsesToAnthropicResponse(RESP_WITH_SKIP_ITEMS));
+    expect(result.content).toEqual([{ type: "text", text: "Search result." }]);
+  });
+
+  it("maps usage correctly", () => {
+    const result = JSON.parse(responsesToAnthropicResponse(RESP_TEXT));
+    expect(result.usage).toEqual({ input_tokens: 15, output_tokens: 8 });
+  });
+});
+
+// ========== anthropicToResponsesResponse ==========
+
+describe("anthropicToResponsesResponse", () => {
+  it("converts basic Anthropic text to Responses output message", () => {
+    const result = JSON.parse(anthropicToResponsesResponse(ANT_TEXT));
+    expect(result.object).toBe("response");
+    expect(result.model).toBe("claude-3");
+    expect(result.status).toBe("completed");
+    expect(result.id).toMatch(/^resp_/);
+    expect(result.output).toHaveLength(1);
+    expect(result.output[0].type).toBe("message");
+    expect(result.output[0].role).toBe("assistant");
+    expect(result.output[0].content).toEqual([{ type: "output_text", text: "Hello from Claude!" }]);
+  });
+
+  it("converts Anthropic tool_use to Responses function_call", () => {
+    const result = JSON.parse(anthropicToResponsesResponse(ANT_TOOL_USE));
+    expect(result.output).toHaveLength(1);
+    const fc = result.output[0];
+    expect(fc.type).toBe("function_call");
+    expect(fc.call_id).toBe("call_xyz");
+    expect(fc.id).toBe("fc_call_xyz");
+    expect(fc.name).toBe("get_weather");
+    expect(JSON.parse(fc.arguments)).toEqual({ city: "NYC" });
+    expect(result.status).toBe("completed");
+  });
+
+  it("converts Anthropic thinking to Responses reasoning", () => {
+    const result = JSON.parse(anthropicToResponsesResponse(ANT_THINKING));
+    expect(result.output).toHaveLength(2);
+    const reasoning = result.output[0];
+    expect(reasoning.type).toBe("reasoning");
+    expect(reasoning.id).toMatch(/^rs_/);
+    expect(reasoning.summary).toEqual([{ type: "summary_text", text: "Let me reason about this..." }]);
+    const message = result.output[1];
+    expect(message.type).toBe("message");
+    expect(message.content).toEqual([{ type: "output_text", text: "The result." }]);
+  });
+
+  it("maps stop_reason end_turn → completed", () => {
+    const result = JSON.parse(anthropicToResponsesResponse(ANT_TEXT));
+    expect(result.status).toBe("completed");
+  });
+
+  it("maps stop_reason tool_use → completed", () => {
+    const result = JSON.parse(anthropicToResponsesResponse(ANT_TOOL_USE));
+    expect(result.status).toBe("completed");
+  });
+
+  it("maps stop_reason max_tokens → incomplete", () => {
+    const result = JSON.parse(anthropicToResponsesResponse(ANT_MAX_TOKENS));
+    expect(result.status).toBe("incomplete");
+  });
+
+  it("remaps usage with cache tokens included in input_tokens", () => {
+    const result = JSON.parse(anthropicToResponsesResponse(ANT_WITH_CACHE));
+    // input_tokens = 100 + 50 (cache_read) + 20 (cache_creation) = 170
+    expect(result.usage.input_tokens).toBe(170);
+    expect(result.usage.output_tokens).toBe(10);
+    expect(result.usage.total_tokens).toBe(180);
+  });
+
+  it("handles usage without cache fields", () => {
+    const result = JSON.parse(anthropicToResponsesResponse(ANT_TEXT));
+    expect(result.usage.input_tokens).toBe(15);
+    expect(result.usage.output_tokens).toBe(8);
+    expect(result.usage.total_tokens).toBe(23);
+  });
+});

--- a/tests/proxy/transform/stream-ant2resp.test.ts
+++ b/tests/proxy/transform/stream-ant2resp.test.ts
@@ -1,0 +1,295 @@
+import { describe, it, expect } from "vitest";
+import { AnthropicToResponsesTransform } from "../../../src/proxy/transform/stream-ant2resp.js";
+import { RESPONSES_SSE_EVENTS } from "../../../src/proxy/transform/types-responses.js";
+
+function collectOutput(transform: NodeJS.ReadWriteStream): Promise<string> {
+  return new Promise((resolve) => {
+    const chunks: string[] = [];
+    transform.on("data", (c: Buffer) => chunks.push(c.toString()));
+    transform.on("end", () => resolve(chunks.join("")));
+  });
+}
+
+function parseSSEEvents(output: string): Array<{ event: string; data: unknown }> {
+  const results: Array<{ event: string; data: unknown }> = [];
+  const chunks = output.split("\n\n").filter(Boolean);
+  for (const chunk of chunks) {
+    const lines = chunk.split("\n");
+    let eventType = "";
+    let dataStr = "";
+    for (const line of lines) {
+      if (line.startsWith("event: ")) eventType = line.slice(7);
+      else if (line.startsWith("data: ")) dataStr = line.slice(6);
+    }
+    if (eventType === "" && dataStr === "[DONE]") continue;
+    if (eventType === "" || !dataStr) continue;
+    try {
+      results.push({ event: eventType, data: JSON.parse(dataStr) });
+    } catch {
+      // skip unparseable
+    }
+  }
+  return results;
+}
+
+describe("AnthropicToResponsesTransform", () => {
+  it("emits response.created and response.in_progress on message_start", async () => {
+    const t = new AnthropicToResponsesTransform("claude-3");
+    const output = collectOutput(t);
+    t.write('event: message_start\ndata: {"type":"message_start","message":{"id":"msg_1","role":"assistant","content":[],"usage":{"input_tokens":10}}}\n\n');
+    t.write('event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n');
+    t.write('event: content_block_stop\ndata: {"type":"content_block_stop","index":0}\n\n');
+    t.write('event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":5}}\n\n');
+    t.write('event: message_stop\ndata: {"type":"message_stop"}\n\n');
+    t.end();
+    const result = await output;
+    const events = parseSSEEvents(result);
+    const eventTypes = events.map((e) => e.event);
+    expect(eventTypes).toContain(RESPONSES_SSE_EVENTS.CREATED);
+    expect(eventTypes).toContain(RESPONSES_SSE_EVENTS.IN_PROGRESS);
+    const created = events.find((e) => e.event === RESPONSES_SSE_EVENTS.CREATED);
+    expect((created?.data as Record<string, unknown>)?.response).toBeDefined();
+  });
+
+  it("converts text delta flow", async () => {
+    const t = new AnthropicToResponsesTransform("claude-3");
+    const output = collectOutput(t);
+    t.write('event: message_start\ndata: {"type":"message_start","message":{"id":"msg_1","role":"assistant","content":[],"usage":{"input_tokens":10}}}\n\n');
+    t.write('event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n');
+    t.write('event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}\n\n');
+    t.write('event: content_block_stop\ndata: {"type":"content_block_stop","index":0}\n\n');
+    t.write('event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":5}}\n\n');
+    t.write('event: message_stop\ndata: {"type":"message_stop"}\n\n');
+    t.end();
+    const result = await output;
+    const events = parseSSEEvents(result);
+    const eventTypes = events.map((e) => e.event);
+
+    // Should emit output_item.added for message type
+    expect(eventTypes).toContain(RESPONSES_SSE_EVENTS.OUTPUT_ITEM_ADDED);
+    const itemAdded = events.find((e) => e.event === RESPONSES_SSE_EVENTS.OUTPUT_ITEM_ADDED);
+    const item = (itemAdded?.data as Record<string, unknown>)?.item as Record<string, unknown>;
+    expect(item?.type).toBe("message");
+
+    // Should emit content_part.added
+    expect(eventTypes).toContain(RESPONSES_SSE_EVENTS.CONTENT_PART_ADDED);
+
+    // Should emit output_text.delta
+    expect(eventTypes).toContain(RESPONSES_SSE_EVENTS.OUTPUT_TEXT_DELTA);
+    const textDelta = events.find((e) => e.event === RESPONSES_SSE_EVENTS.OUTPUT_TEXT_DELTA);
+    expect((textDelta?.data as Record<string, unknown>)?.delta).toBe("Hello");
+
+    // Should emit output_text.done, content_part.done, output_item.done
+    expect(eventTypes).toContain(RESPONSES_SSE_EVENTS.OUTPUT_TEXT_DONE);
+    expect(eventTypes).toContain(RESPONSES_SSE_EVENTS.CONTENT_PART_DONE);
+    expect(eventTypes).toContain(RESPONSES_SSE_EVENTS.OUTPUT_ITEM_DONE);
+
+    // Should emit response.completed
+    expect(eventTypes).toContain(RESPONSES_SSE_EVENTS.COMPLETED);
+  });
+
+  it("converts tool_use flow to function_call events", async () => {
+    const t = new AnthropicToResponsesTransform("claude-3");
+    const output = collectOutput(t);
+    t.write('event: message_start\ndata: {"type":"message_start","message":{"id":"msg_2","role":"assistant","content":[],"usage":{"input_tokens":10}}}\n\n');
+    t.write('event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_abc123","name":"get_weather","input":{}}}\n\n');
+    t.write('event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\\"city\\":\\"NYC\\"}"}}\n\n');
+    t.write('event: content_block_stop\ndata: {"type":"content_block_stop","index":0}\n\n');
+    t.write('event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":20}}\n\n');
+    t.write('event: message_stop\ndata: {"type":"message_stop"}\n\n');
+    t.end();
+    const result = await output;
+    const events = parseSSEEvents(result);
+    const eventTypes = events.map((e) => e.event);
+
+    // Should emit output_item.added with function_call type
+    const itemAdded = events.find((e) => e.event === RESPONSES_SSE_EVENTS.OUTPUT_ITEM_ADDED);
+    const item = (itemAdded?.data as Record<string, unknown>)?.item as Record<string, unknown>;
+    expect(item?.type).toBe("function_call");
+    expect(item?.call_id).toContain("fc_");
+    expect(item?.name).toBe("get_weather");
+
+    // Should emit function_call_arguments.delta
+    expect(eventTypes).toContain(RESPONSES_SSE_EVENTS.FUNCTION_CALL_ARGUMENTS_DELTA);
+    const argsDelta = events.find((e) => e.event === RESPONSES_SSE_EVENTS.FUNCTION_CALL_ARGUMENTS_DELTA);
+    expect((argsDelta?.data as Record<string, unknown>)?.delta).toBe('{"city":"NYC"}');
+
+    // Should emit function_call_arguments.done
+    expect(eventTypes).toContain(RESPONSES_SSE_EVENTS.FUNCTION_CALL_ARGUMENTS_DONE);
+
+    // Should emit output_item.done
+    expect(eventTypes).toContain(RESPONSES_SSE_EVENTS.OUTPUT_ITEM_DONE);
+
+    // response.completed should have status "completed"
+    const completed = events.find((e) => e.event === RESPONSES_SSE_EVENTS.COMPLETED);
+    const resp = (completed?.data as Record<string, unknown>)?.response as Record<string, unknown>;
+    expect(resp?.status).toBe("completed");
+  });
+
+  it("converts thinking flow to reasoning events", async () => {
+    const t = new AnthropicToResponsesTransform("claude-3");
+    const output = collectOutput(t);
+    t.write('event: message_start\ndata: {"type":"message_start","message":{"id":"msg_3","role":"assistant","content":[],"usage":{"input_tokens":10}}}\n\n');
+    t.write('event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}\n\n');
+    t.write('event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"Let me think..."}}\n\n');
+    t.write('event: content_block_stop\ndata: {"type":"content_block_stop","index":0}\n\n');
+    t.write('event: content_block_start\ndata: {"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}\n\n');
+    t.write('event: content_block_delta\ndata: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"The answer is 42"}}\n\n');
+    t.write('event: content_block_stop\ndata: {"type":"content_block_stop","index":1}\n\n');
+    t.write('event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":15}}\n\n');
+    t.write('event: message_stop\ndata: {"type":"message_stop"}\n\n');
+    t.end();
+    const result = await output;
+    const events = parseSSEEvents(result);
+    const eventTypes = events.map((e) => e.event);
+
+    // Reasoning events
+    expect(eventTypes).toContain(RESPONSES_SSE_EVENTS.REASONING_SUMMARY_PART_ADDED);
+    expect(eventTypes).toContain(RESPONSES_SSE_EVENTS.REASONING_SUMMARY_TEXT_DELTA);
+    const reasoningDelta = events.find((e) => e.event === RESPONSES_SSE_EVENTS.REASONING_SUMMARY_TEXT_DELTA);
+    expect((reasoningDelta?.data as Record<string, unknown>)?.delta).toBe("Let me think...");
+    expect(eventTypes).toContain(RESPONSES_SSE_EVENTS.REASONING_SUMMARY_TEXT_DONE);
+    expect(eventTypes).toContain(RESPONSES_SSE_EVENTS.REASONING_SUMMARY_PART_DONE);
+
+    // Text events
+    expect(eventTypes).toContain(RESPONSES_SSE_EVENTS.OUTPUT_TEXT_DELTA);
+    const textDelta = events.find((e) => e.event === RESPONSES_SSE_EVENTS.OUTPUT_TEXT_DELTA);
+    expect((textDelta?.data as Record<string, unknown>)?.delta).toBe("The answer is 42");
+
+    // Should have two output_item.done events (reasoning + message)
+    const itemDoneEvents = events.filter((e) => e.event === RESPONSES_SSE_EVENTS.OUTPUT_ITEM_DONE);
+    expect(itemDoneEvents.length).toBe(2);
+  });
+
+  it("maps max_tokens stop_reason to incomplete status", async () => {
+    const t = new AnthropicToResponsesTransform("claude-3");
+    const output = collectOutput(t);
+    t.write('event: message_start\ndata: {"type":"message_start","message":{"id":"msg_4","role":"assistant","content":[],"usage":{"input_tokens":10}}}\n\n');
+    t.write('event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n');
+    t.write('event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Partial..."}}\n\n');
+    t.write('event: content_block_stop\ndata: {"type":"content_block_stop","index":0}\n\n');
+    t.write('event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"max_tokens"},"usage":{"output_tokens":100}}\n\n');
+    t.write('event: message_stop\ndata: {"type":"message_stop"}\n\n');
+    t.end();
+    const result = await output;
+    const events = parseSSEEvents(result);
+    const completed = events.find((e) => e.event === RESPONSES_SSE_EVENTS.COMPLETED);
+    const resp = (completed?.data as Record<string, unknown>)?.response as Record<string, unknown>;
+    expect(resp?.status).toBe("incomplete");
+  });
+
+  it("includes usage in response.completed", async () => {
+    const t = new AnthropicToResponsesTransform("claude-3");
+    const output = collectOutput(t);
+    t.write('event: message_start\ndata: {"type":"message_start","message":{"id":"msg_5","role":"assistant","content":[],"usage":{"input_tokens":42}}}\n\n');
+    t.write('event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n');
+    t.write('event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}\n\n');
+    t.write('event: content_block_stop\ndata: {"type":"content_block_stop","index":0}\n\n');
+    t.write('event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":7}}\n\n');
+    t.write('event: message_stop\ndata: {"type":"message_stop"}\n\n');
+    t.end();
+    const result = await output;
+    const events = parseSSEEvents(result);
+    const completed = events.find((e) => e.event === RESPONSES_SSE_EVENTS.COMPLETED);
+    const resp = (completed?.data as Record<string, unknown>)?.response as Record<string, unknown>;
+    const usage = resp?.usage as Record<string, unknown>;
+    expect(usage?.input_tokens).toBe(42);
+    expect(usage?.output_tokens).toBe(7);
+    expect(usage?.total_tokens).toBe(49);
+  });
+
+  it("increments sequence_number monotonically", async () => {
+    const t = new AnthropicToResponsesTransform("claude-3");
+    const output = collectOutput(t);
+    t.write('event: message_start\ndata: {"type":"message_start","message":{"id":"msg_6","role":"assistant","content":[],"usage":{"input_tokens":5}}}\n\n');
+    t.write('event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n');
+    t.write('event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hi"}}\n\n');
+    t.write('event: content_block_stop\ndata: {"type":"content_block_stop","index":0}\n\n');
+    t.write('event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":1}}\n\n');
+    t.write('event: message_stop\ndata: {"type":"message_stop"}\n\n');
+    t.end();
+    const result = await output;
+    const events = parseSSEEvents(result);
+    const seqNums = events.map((e) => (e.data as Record<string, unknown>)?.sequence_number as number);
+    // Check monotonically increasing
+    for (let i = 1; i < seqNums.length; i++) {
+      expect(seqNums[i]).toBeGreaterThan(seqNums[i - 1]);
+    }
+  });
+
+  it("ignores ping events", async () => {
+    const t = new AnthropicToResponsesTransform("claude-3");
+    const output = collectOutput(t);
+    t.write('event: ping\ndata: {"type":"ping"}\n\n');
+    t.write('event: message_start\ndata: {"type":"message_start","message":{"id":"msg_7","role":"assistant","content":[],"usage":{"input_tokens":5}}}\n\n');
+    t.write('event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n');
+    t.write('event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hi"}}\n\n');
+    t.write('event: content_block_stop\ndata: {"type":"content_block_stop","index":0}\n\n');
+    t.write('event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":1}}\n\n');
+    t.write('event: message_stop\ndata: {"type":"message_stop"}\n\n');
+    t.end();
+    const result = await output;
+    expect(result).not.toContain("ping");
+    expect(result).toContain(RESPONSES_SSE_EVENTS.COMPLETED);
+  });
+
+  it("handles error events", async () => {
+    const t = new AnthropicToResponsesTransform("claude-3");
+    const output = collectOutput(t);
+    t.write('event: error\ndata: {"type":"error","error":{"type":"invalid_request_error","message":"Bad request"}}\n\n');
+    t.end();
+    const result = await output;
+    expect(result).toContain(RESPONSES_SSE_EVENTS.ERROR);
+    expect(result).toContain('"message":"Bad request"');
+    expect(result).toContain("[DONE]");
+  });
+
+  it("handles full flow with mixed content types", async () => {
+    const t = new AnthropicToResponsesTransform("claude-3");
+    const output = collectOutput(t);
+    // message_start
+    t.write('event: message_start\ndata: {"type":"message_start","message":{"id":"msg_8","role":"assistant","content":[],"usage":{"input_tokens":100}}}\n\n');
+    // thinking block
+    t.write('event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}\n\n');
+    t.write('event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"Hmm..."}}\n\n');
+    t.write('event: content_block_stop\ndata: {"type":"content_block_stop","index":0}\n\n');
+    // text block
+    t.write('event: content_block_start\ndata: {"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}\n\n');
+    t.write('event: content_block_delta\ndata: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"Here is the answer."}}\n\n');
+    t.write('event: content_block_stop\ndata: {"type":"content_block_stop","index":1}\n\n');
+    // tool_use block
+    t.write('event: content_block_start\ndata: {"type":"content_block_start","index":2,"content_block":{"type":"tool_use","id":"toolu_xyz","name":"search","input":{}}}\n\n');
+    t.write('event: content_block_delta\ndata: {"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":"{\\"q\\":\\"test\\"}"}}\n\n');
+    t.write('event: content_block_stop\ndata: {"type":"content_block_stop","index":2}\n\n');
+    // end
+    t.write('event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":50}}\n\n');
+    t.write('event: message_stop\ndata: {"type":"message_stop"}\n\n');
+    t.end();
+    const result = await output;
+    const events = parseSSEEvents(result);
+    const eventTypes = events.map((e) => e.event);
+
+    // Should have 3 output_item.added (reasoning, message, function_call)
+    const itemAddedEvents = events.filter((e) => e.event === RESPONSES_SSE_EVENTS.OUTPUT_ITEM_ADDED);
+    expect(itemAddedEvents.length).toBe(3);
+
+    // Should have 3 output_item.done
+    const itemDoneEvents = events.filter((e) => e.event === RESPONSES_SSE_EVENTS.OUTPUT_ITEM_DONE);
+    expect(itemDoneEvents.length).toBe(3);
+
+    // Verify each type appeared
+    const addedTypes = itemAddedEvents.map((e) => {
+      const item = ((e.data as Record<string, unknown>)?.item as Record<string, unknown>)?.type;
+      return item;
+    });
+    expect(addedTypes).toContain("reasoning");
+    expect(addedTypes).toContain("message");
+    expect(addedTypes).toContain("function_call");
+
+    // Completed with tool_use → status "completed"
+    const completed = events.find((e) => e.event === RESPONSES_SSE_EVENTS.COMPLETED);
+    const resp = (completed?.data as Record<string, unknown>)?.response as Record<string, unknown>;
+    expect(resp?.status).toBe("completed");
+    expect((resp?.output as unknown[])?.length).toBe(3);
+  });
+});

--- a/tests/proxy/transform/stream-bridge.test.ts
+++ b/tests/proxy/transform/stream-bridge.test.ts
@@ -1,0 +1,590 @@
+import { describe, it, expect } from "vitest";
+import { ChatToResponsesBridgeTransform } from "../../../src/proxy/transform/stream-bridge-chat2resp.js";
+import { ResponsesToChatBridgeTransform } from "../../../src/proxy/transform/stream-bridge-resp2chat.js";
+import { RESPONSES_SSE_EVENTS } from "../../../src/proxy/transform/types-responses.js";
+
+// ---------- Helpers ----------
+
+function collectOutput(transform: NodeJS.ReadWriteStream): Promise<string> {
+  return new Promise((resolve) => {
+    const chunks: string[] = [];
+    transform.on("data", (c: Buffer) => chunks.push(c.toString()));
+    transform.on("end", () => resolve(chunks.join("")));
+  });
+}
+
+function parseSSEEvents(output: string): Array<{ event: string; data: unknown }> {
+  const results: Array<{ event: string; data: unknown }> = [];
+  const chunks = output.split("\n\n").filter(Boolean);
+  for (const chunk of chunks) {
+    const lines = chunk.split("\n");
+    let eventType = "";
+    let dataStr = "";
+    for (const line of lines) {
+      if (line.startsWith("event: ")) eventType = line.slice(7);
+      else if (line.startsWith("data: ")) dataStr = line.slice(6);
+    }
+    if (eventType === "" && dataStr === "[DONE]") continue;
+    if (!eventType || !dataStr) continue;
+    try {
+      results.push({ event: eventType, data: JSON.parse(dataStr) });
+    } catch {
+      // skip unparseable
+    }
+  }
+  return results;
+}
+
+function parseOpenAIChunks(output: string): Array<Record<string, unknown>> {
+  const results: Array<Record<string, unknown>> = [];
+  const chunks = output.split("\n\n").filter(Boolean);
+  for (const chunk of chunks) {
+    const lines = chunk.split("\n");
+    for (const line of lines) {
+      if (line.startsWith("data: ")) {
+        const dataStr = line.slice(6);
+        if (dataStr === "[DONE]") continue;
+        try { results.push(JSON.parse(dataStr)); } catch { /* skip */ }
+      }
+    }
+  }
+  return results;
+}
+
+function chatSSE(data: unknown): string {
+  return `data: ${JSON.stringify(data)}\n\n`;
+}
+
+function respSSE(eventType: string, data: unknown): string {
+  return `event: ${eventType}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+// ---------- ChatToResponsesBridgeTransform ----------
+
+describe("ChatToResponsesBridgeTransform", () => {
+  it("emits response.created + response.in_progress on first role chunk", async () => {
+    const t = new ChatToResponsesBridgeTransform("gpt-4o");
+    const output = collectOutput(t);
+    t.write(chatSSE({ id: "chatcmpl-1", object: "chat.completion.chunk", choices: [{ index: 0, delta: { role: "assistant" }, finish_reason: null }] }));
+    t.write(chatSSE({ id: "chatcmpl-1", object: "chat.completion.chunk", choices: [{ index: 0, delta: {}, finish_reason: "stop" }], usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 } }));
+    t.end();
+    const result = await output;
+    const events = parseSSEEvents(result);
+    const eventTypes = events.map((e) => e.event);
+    expect(eventTypes).toContain(RESPONSES_SSE_EVENTS.CREATED);
+    expect(eventTypes).toContain(RESPONSES_SSE_EVENTS.IN_PROGRESS);
+
+    const created = events.find((e) => e.event === RESPONSES_SSE_EVENTS.CREATED);
+    const resp = (created?.data as Record<string, unknown>)?.response as Record<string, unknown>;
+    expect(resp?.status).toBe("queued");
+
+    const inProgress = events.find((e) => e.event === RESPONSES_SSE_EVENTS.IN_PROGRESS);
+    const resp2 = (inProgress?.data as Record<string, unknown>)?.response as Record<string, unknown>;
+    expect(resp2?.status).toBe("in_progress");
+  });
+
+  it("converts text delta to output_text.delta events", async () => {
+    const t = new ChatToResponsesBridgeTransform("gpt-4o");
+    const output = collectOutput(t);
+    t.write(chatSSE({ id: "chatcmpl-1", object: "chat.completion.chunk", choices: [{ index: 0, delta: { role: "assistant" }, finish_reason: null }] }));
+    t.write(chatSSE({ id: "chatcmpl-1", object: "chat.completion.chunk", choices: [{ index: 0, delta: { content: "Hello" }, finish_reason: null }] }));
+    t.write(chatSSE({ id: "chatcmpl-1", object: "chat.completion.chunk", choices: [{ index: 0, delta: { content: " world" }, finish_reason: null }] }));
+    t.write(chatSSE({ id: "chatcmpl-1", object: "chat.completion.chunk", choices: [{ index: 0, delta: {}, finish_reason: "stop" }], usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 } }));
+    t.end();
+    const result = await output;
+    const events = parseSSEEvents(result);
+    const eventTypes = events.map((e) => e.event);
+
+    // Should emit output_item.added for message type
+    expect(eventTypes).toContain(RESPONSES_SSE_EVENTS.OUTPUT_ITEM_ADDED);
+    const itemAdded = events.find((e) => e.event === RESPONSES_SSE_EVENTS.OUTPUT_ITEM_ADDED);
+    const item = (itemAdded?.data as Record<string, unknown>)?.item as Record<string, unknown>;
+    expect(item?.type).toBe("message");
+
+    // Should emit content_part.added
+    expect(eventTypes).toContain(RESPONSES_SSE_EVENTS.CONTENT_PART_ADDED);
+
+    // Should emit two output_text.delta events
+    const textDeltas = events.filter((e) => e.event === RESPONSES_SSE_EVENTS.OUTPUT_TEXT_DELTA);
+    expect(textDeltas.length).toBe(2);
+    expect((textDeltas[0]?.data as Record<string, unknown>)?.delta).toBe("Hello");
+    expect((textDeltas[1]?.data as Record<string, unknown>)?.delta).toBe(" world");
+
+    // Should close items and emit response.completed
+    expect(eventTypes).toContain(RESPONSES_SSE_EVENTS.OUTPUT_TEXT_DONE);
+    expect(eventTypes).toContain(RESPONSES_SSE_EVENTS.CONTENT_PART_DONE);
+    expect(eventTypes).toContain(RESPONSES_SSE_EVENTS.OUTPUT_ITEM_DONE);
+    expect(eventTypes).toContain(RESPONSES_SSE_EVENTS.COMPLETED);
+  });
+
+  it("converts tool_calls to function_call events", async () => {
+    const t = new ChatToResponsesBridgeTransform("gpt-4o");
+    const output = collectOutput(t);
+    t.write(chatSSE({ id: "chatcmpl-1", object: "chat.completion.chunk", choices: [{ index: 0, delta: { role: "assistant" }, finish_reason: null }] }));
+    t.write(chatSSE({
+      id: "chatcmpl-1", object: "chat.completion.chunk",
+      choices: [{
+        index: 0,
+        delta: { tool_calls: [{ index: 0, id: "call_abc", type: "function", function: { name: "get_weather", arguments: "" } }] },
+        finish_reason: null,
+      }],
+    }));
+    t.write(chatSSE({
+      id: "chatcmpl-1", object: "chat.completion.chunk",
+      choices: [{
+        index: 0,
+        delta: { tool_calls: [{ index: 0, function: { arguments: '{"city":"NYC"}' } }] },
+        finish_reason: null,
+      }],
+    }));
+    t.write(chatSSE({ id: "chatcmpl-1", object: "chat.completion.chunk", choices: [{ index: 0, delta: {}, finish_reason: "tool_calls" }], usage: { prompt_tokens: 10, completion_tokens: 20, total_tokens: 30 } }));
+    t.end();
+    const result = await output;
+    const events = parseSSEEvents(result);
+    const eventTypes = events.map((e) => e.event);
+
+    // Should emit output_item.added with function_call type
+    const itemAdded = events.find((e) => e.event === RESPONSES_SSE_EVENTS.OUTPUT_ITEM_ADDED);
+    const item = (itemAdded?.data as Record<string, unknown>)?.item as Record<string, unknown>;
+    expect(item?.type).toBe("function_call");
+    expect(item?.call_id).toBe("call_abc");
+    expect(item?.name).toBe("get_weather");
+
+    // Should emit function_call_arguments.delta
+    expect(eventTypes).toContain(RESPONSES_SSE_EVENTS.FUNCTION_CALL_ARGUMENTS_DELTA);
+    const argsDelta = events.find((e) => e.event === RESPONSES_SSE_EVENTS.FUNCTION_CALL_ARGUMENTS_DELTA);
+    expect((argsDelta?.data as Record<string, unknown>)?.delta).toBe('{"city":"NYC"}');
+
+    // Should emit function_call_arguments.done
+    expect(eventTypes).toContain(RESPONSES_SSE_EVENTS.FUNCTION_CALL_ARGUMENTS_DONE);
+
+    // Should emit output_item.done
+    expect(eventTypes).toContain(RESPONSES_SSE_EVENTS.OUTPUT_ITEM_DONE);
+
+    // response.completed
+    expect(eventTypes).toContain(RESPONSES_SSE_EVENTS.COMPLETED);
+  });
+
+  it("converts reasoning_content to reasoning events", async () => {
+    const t = new ChatToResponsesBridgeTransform("gpt-4o");
+    const output = collectOutput(t);
+    t.write(chatSSE({ id: "chatcmpl-1", object: "chat.completion.chunk", choices: [{ index: 0, delta: { role: "assistant" }, finish_reason: null }] }));
+    t.write(chatSSE({ id: "chatcmpl-1", object: "chat.completion.chunk", choices: [{ index: 0, delta: { reasoning_content: "Let me think..." }, finish_reason: null }] }));
+    t.write(chatSSE({ id: "chatcmpl-1", object: "chat.completion.chunk", choices: [{ index: 0, delta: { content: "The answer is 42" }, finish_reason: null }] }));
+    t.write(chatSSE({ id: "chatcmpl-1", object: "chat.completion.chunk", choices: [{ index: 0, delta: {}, finish_reason: "stop" }], usage: { prompt_tokens: 10, completion_tokens: 15, total_tokens: 25 } }));
+    t.end();
+    const result = await output;
+    const events = parseSSEEvents(result);
+    const eventTypes = events.map((e) => e.event);
+
+    // Reasoning events
+    expect(eventTypes).toContain(RESPONSES_SSE_EVENTS.REASONING_SUMMARY_PART_ADDED);
+    expect(eventTypes).toContain(RESPONSES_SSE_EVENTS.REASONING_SUMMARY_TEXT_DELTA);
+    const reasoningDelta = events.find((e) => e.event === RESPONSES_SSE_EVENTS.REASONING_SUMMARY_TEXT_DELTA);
+    expect((reasoningDelta?.data as Record<string, unknown>)?.delta).toBe("Let me think...");
+
+    // Text events
+    expect(eventTypes).toContain(RESPONSES_SSE_EVENTS.OUTPUT_TEXT_DELTA);
+    const textDelta = events.find((e) => e.event === RESPONSES_SSE_EVENTS.OUTPUT_TEXT_DELTA);
+    expect((textDelta?.data as Record<string, unknown>)?.delta).toBe("The answer is 42");
+
+    // Should have 2 output_item.done events (reasoning + message)
+    const itemDoneEvents = events.filter((e) => e.event === RESPONSES_SSE_EVENTS.OUTPUT_ITEM_DONE);
+    expect(itemDoneEvents.length).toBe(2);
+  });
+
+  it("emits response.completed with usage", async () => {
+    const t = new ChatToResponsesBridgeTransform("gpt-4o");
+    const output = collectOutput(t);
+    t.write(chatSSE({ id: "chatcmpl-1", object: "chat.completion.chunk", choices: [{ index: 0, delta: { role: "assistant" }, finish_reason: null }] }));
+    t.write(chatSSE({ id: "chatcmpl-1", object: "chat.completion.chunk", choices: [{ index: 0, delta: { content: "Hi" }, finish_reason: null }] }));
+    t.write(chatSSE({ id: "chatcmpl-1", object: "chat.completion.chunk", choices: [{ index: 0, delta: {}, finish_reason: "stop" }], usage: { prompt_tokens: 42, completion_tokens: 7, total_tokens: 49 } }));
+    t.end();
+    const result = await output;
+    const events = parseSSEEvents(result);
+    const completed = events.find((e) => e.event === RESPONSES_SSE_EVENTS.COMPLETED);
+    const resp = (completed?.data as Record<string, unknown>)?.response as Record<string, unknown>;
+    expect(resp?.status).toBe("completed");
+    const usage = resp?.usage as Record<string, unknown>;
+    expect(usage?.input_tokens).toBe(42);
+    expect(usage?.output_tokens).toBe(7);
+    expect(usage?.total_tokens).toBe(49);
+  });
+
+  it("increments sequence_number monotonically", async () => {
+    const t = new ChatToResponsesBridgeTransform("gpt-4o");
+    const output = collectOutput(t);
+    t.write(chatSSE({ id: "chatcmpl-1", object: "chat.completion.chunk", choices: [{ index: 0, delta: { role: "assistant" }, finish_reason: null }] }));
+    t.write(chatSSE({ id: "chatcmpl-1", object: "chat.completion.chunk", choices: [{ index: 0, delta: { content: "Hi" }, finish_reason: null }] }));
+    t.write(chatSSE({ id: "chatcmpl-1", object: "chat.completion.chunk", choices: [{ index: 0, delta: {}, finish_reason: "stop" }], usage: { prompt_tokens: 5, completion_tokens: 1, total_tokens: 6 } }));
+    t.end();
+    const result = await output;
+    const events = parseSSEEvents(result);
+    const seqNums = events.map((e) => (e.data as Record<string, unknown>)?.sequence_number as number);
+    for (let i = 1; i < seqNums.length; i++) {
+      expect(seqNums[i]).toBeGreaterThan(seqNums[i - 1]);
+    }
+  });
+
+  it("handles usage-only chunk after finish_reason", async () => {
+    const t = new ChatToResponsesBridgeTransform("gpt-4o");
+    const output = collectOutput(t);
+    t.write(chatSSE({ id: "chatcmpl-1", object: "chat.completion.chunk", choices: [{ index: 0, delta: { role: "assistant" }, finish_reason: null }] }));
+    t.write(chatSSE({ id: "chatcmpl-1", object: "chat.completion.chunk", choices: [{ index: 0, delta: { content: "Hi" }, finish_reason: null }] }));
+    // finish_reason without usage
+    t.write(chatSSE({ id: "chatcmpl-1", object: "chat.completion.chunk", choices: [{ index: 0, delta: {}, finish_reason: "stop" }] }));
+    // Separate usage chunk (no choices)
+    t.write(chatSSE({ id: "chatcmpl-1", object: "chat.completion.chunk", usage: { prompt_tokens: 10, completion_tokens: 2, total_tokens: 12 } }));
+    t.end();
+    const result = await output;
+    const events = parseSSEEvents(result);
+    const eventTypes = events.map((e) => e.event);
+    expect(eventTypes).toContain(RESPONSES_SSE_EVENTS.COMPLETED);
+
+    const completed = events.find((e) => e.event === RESPONSES_SSE_EVENTS.COMPLETED);
+    const resp = (completed?.data as Record<string, unknown>)?.response as Record<string, unknown>;
+    const usage = resp?.usage as Record<string, unknown>;
+    expect(usage?.input_tokens).toBe(10);
+    expect(usage?.output_tokens).toBe(2);
+  });
+
+  it("handles multiple tool calls", async () => {
+    const t = new ChatToResponsesBridgeTransform("gpt-4o");
+    const output = collectOutput(t);
+    t.write(chatSSE({ id: "chatcmpl-1", object: "chat.completion.chunk", choices: [{ index: 0, delta: { role: "assistant" }, finish_reason: null }] }));
+    // First tool call
+    t.write(chatSSE({
+      id: "chatcmpl-1", object: "chat.completion.chunk",
+      choices: [{ index: 0, delta: { tool_calls: [{ index: 0, id: "call_1", type: "function", function: { name: "get_weather", arguments: "" } }] }, finish_reason: null }],
+    }));
+    t.write(chatSSE({
+      id: "chatcmpl-1", object: "chat.completion.chunk",
+      choices: [{ index: 0, delta: { tool_calls: [{ index: 0, function: { arguments: '{"city":"NYC"}' } }] }, finish_reason: null }],
+    }));
+    // Second tool call
+    t.write(chatSSE({
+      id: "chatcmpl-1", object: "chat.completion.chunk",
+      choices: [{ index: 0, delta: { tool_calls: [{ index: 1, id: "call_2", type: "function", function: { name: "get_time", arguments: "" } }] }, finish_reason: null }],
+    }));
+    t.write(chatSSE({
+      id: "chatcmpl-1", object: "chat.completion.chunk",
+      choices: [{ index: 0, delta: { tool_calls: [{ index: 1, function: { arguments: '{"tz":"EST"}' } }] }, finish_reason: null }],
+    }));
+    t.write(chatSSE({ id: "chatcmpl-1", object: "chat.completion.chunk", choices: [{ index: 0, delta: {}, finish_reason: "tool_calls" }], usage: { prompt_tokens: 10, completion_tokens: 20, total_tokens: 30 } }));
+    t.end();
+    const result = await output;
+    const events = parseSSEEvents(result);
+    const itemAddedEvents = events.filter((e) => e.event === RESPONSES_SSE_EVENTS.OUTPUT_ITEM_ADDED);
+    expect(itemAddedEvents.length).toBe(2);
+    const names = itemAddedEvents.map((e) => ((e.data as Record<string, unknown>)?.item as Record<string, unknown>)?.name);
+    expect(names).toContain("get_weather");
+    expect(names).toContain("get_time");
+
+    const itemDoneEvents = events.filter((e) => e.event === RESPONSES_SSE_EVENTS.OUTPUT_ITEM_DONE);
+    expect(itemDoneEvents.length).toBe(2);
+  });
+});
+
+// ---------- ResponsesToChatBridgeTransform ----------
+
+describe("ResponsesToChatBridgeTransform", () => {
+  it("emits role chunk on first content delta", async () => {
+    const t = new ResponsesToChatBridgeTransform("gpt-4o");
+    const output = collectOutput(t);
+    t.write(respSSE("response.output_text.delta", {
+      type: "response.output_text.delta", output_index: 0, content_index: 0, delta: "Hello",
+    }));
+    t.write(respSSE("response.completed", {
+      type: "response.completed",
+      response: { id: "resp_1", object: "response", model: "gpt-4o", status: "completed", output: [], usage: { input_tokens: 10, output_tokens: 5, total_tokens: 15 } },
+    }));
+    t.end();
+    const result = await output;
+    const chunks = parseOpenAIChunks(result);
+
+    // First chunk should have role
+    expect(chunks[0]).toBeDefined();
+    const firstChoice = (chunks[0] as Record<string, unknown>)?.choices as Array<Record<string, unknown>>;
+    expect(firstChoice?.[0]?.delta).toEqual({ role: "assistant" });
+  });
+
+  it("converts output_text.delta to content delta", async () => {
+    const t = new ResponsesToChatBridgeTransform("gpt-4o");
+    const output = collectOutput(t);
+    t.write(respSSE("response.output_text.delta", {
+      type: "response.output_text.delta", output_index: 0, content_index: 0, delta: "Hello world",
+    }));
+    t.write(respSSE("response.completed", {
+      type: "response.completed",
+      response: { id: "resp_1", object: "response", model: "gpt-4o", status: "completed", output: [], usage: { input_tokens: 10, output_tokens: 5, total_tokens: 15 } },
+    }));
+    t.end();
+    const result = await output;
+    const chunks = parseOpenAIChunks(result);
+
+    // Find content delta chunk
+    const contentChunk = chunks.find((c) => {
+      const choices = c.choices as Array<Record<string, unknown>> | undefined;
+      const delta = choices?.[0]?.delta as Record<string, unknown> | undefined;
+      return delta?.content != null;
+    });
+    expect(contentChunk).toBeDefined();
+    const delta = ((contentChunk as Record<string, unknown>)?.choices as Array<Record<string, unknown>>)?.[0]?.delta as Record<string, unknown>;
+    expect(delta?.content).toBe("Hello world");
+  });
+
+  it("converts function_call to tool_calls delta", async () => {
+    const t = new ResponsesToChatBridgeTransform("gpt-4o");
+    const output = collectOutput(t);
+    t.write(respSSE("response.output_item.added", {
+      type: "response.output_item.added", output_index: 0,
+      item: { type: "function_call", id: "fc_1", call_id: "fc_1", name: "get_weather", arguments: "", status: "in_progress" },
+    }));
+    t.write(respSSE("response.function_call_arguments.delta", {
+      type: "response.function_call_arguments.delta", output_index: 0, item_id: "fc_1", call_id: "fc_1", delta: '{"city":"NYC"}',
+    }));
+    t.write(respSSE("response.completed", {
+      type: "response.completed",
+      response: { id: "resp_1", object: "response", model: "gpt-4o", status: "completed", output: [], usage: { input_tokens: 10, output_tokens: 20, total_tokens: 30 } },
+    }));
+    t.end();
+    const result = await output;
+    const chunks = parseOpenAIChunks(result);
+
+    // Find tool_calls init chunk
+    const tcChunk = chunks.find((c) => {
+      const choices = c.choices as Array<Record<string, unknown>> | undefined;
+      const delta = choices?.[0]?.delta as Record<string, unknown> | undefined;
+      const tcs = delta?.tool_calls as Array<Record<string, unknown>> | undefined;
+      return tcs?.some((tc) => tc.id != null) ?? false;
+    });
+    expect(tcChunk).toBeDefined();
+    const tcDelta = ((tcChunk as Record<string, unknown>)?.choices as Array<Record<string, unknown>>)?.[0]?.delta as Record<string, unknown>;
+    const tc = (tcDelta?.tool_calls as Array<Record<string, unknown>>)?.[0] as Record<string, unknown>;
+    expect(tc?.id).toBe("fc_1");
+    const fn = tc?.function as Record<string, unknown>;
+    expect(fn?.name).toBe("get_weather");
+
+    // Find arguments delta chunk
+    const argsChunk = chunks.find((c) => {
+      const choices = c.choices as Array<Record<string, unknown>> | undefined;
+      const delta = choices?.[0]?.delta as Record<string, unknown> | undefined;
+      const tcs = delta?.tool_calls as Array<Record<string, unknown>> | undefined;
+      const tcFn = tcs?.[0]?.function as Record<string, unknown> | undefined;
+      return tcFn?.arguments != null && tcFn.arguments !== "";
+    });
+    expect(argsChunk).toBeDefined();
+    const argsDelta = ((argsChunk as Record<string, unknown>)?.choices as Array<Record<string, unknown>>)?.[0]?.delta as Record<string, unknown>;
+    const argsFn = ((argsDelta?.tool_calls as Array<Record<string, unknown>>)?.[0]?.function as Record<string, unknown>);
+    expect(argsFn?.arguments).toBe('{"city":"NYC"}');
+
+    // finish_reason should be "tool_calls"
+    const finishChunk = chunks.find((c) => {
+      const choices = c.choices as Array<Record<string, unknown>> | undefined;
+      return choices?.[0]?.finish_reason != null;
+    });
+    expect(finishChunk).toBeDefined();
+    const finishChoice = ((finishChunk as Record<string, unknown>)?.choices as Array<Record<string, unknown>>)?.[0];
+    expect(finishChoice?.finish_reason).toBe("tool_calls");
+  });
+
+  it("converts reasoning to reasoning_content delta", async () => {
+    const t = new ResponsesToChatBridgeTransform("gpt-4o");
+    const output = collectOutput(t);
+    t.write(respSSE("response.reasoning_summary_text.delta", {
+      type: "response.reasoning_summary_text.delta", output_index: 0, summary_index: 0, delta: "Let me think about this...",
+    }));
+    t.write(respSSE("response.output_text.delta", {
+      type: "response.output_text.delta", output_index: 0, content_index: 0, delta: "The answer is 42",
+    }));
+    t.write(respSSE("response.completed", {
+      type: "response.completed",
+      response: { id: "resp_1", object: "response", model: "gpt-4o", status: "completed", output: [], usage: { input_tokens: 10, output_tokens: 30, total_tokens: 40 } },
+    }));
+    t.end();
+    const result = await output;
+    const chunks = parseOpenAIChunks(result);
+
+    // Find reasoning chunk
+    const reasoningChunk = chunks.find((c) => {
+      const choices = c.choices as Array<Record<string, unknown>> | undefined;
+      const delta = choices?.[0]?.delta as Record<string, unknown> | undefined;
+      return delta?.reasoning_content != null;
+    });
+    expect(reasoningChunk).toBeDefined();
+    const rDelta = ((reasoningChunk as Record<string, unknown>)?.choices as Array<Record<string, unknown>>)?.[0]?.delta as Record<string, unknown>;
+    expect(rDelta?.reasoning_content).toBe("Let me think about this...");
+
+    // Find content chunk
+    const contentChunk = chunks.find((c) => {
+      const choices = c.choices as Array<Record<string, unknown>> | undefined;
+      const delta = choices?.[0]?.delta as Record<string, unknown> | undefined;
+      return delta?.content === "The answer is 42";
+    });
+    expect(contentChunk).toBeDefined();
+  });
+
+  it("emits finish_reason + usage + [DONE] on response.completed", async () => {
+    const t = new ResponsesToChatBridgeTransform("gpt-4o");
+    const output = collectOutput(t);
+    t.write(respSSE("response.output_text.delta", {
+      type: "response.output_text.delta", output_index: 0, content_index: 0, delta: "Hi",
+    }));
+    t.write(respSSE("response.completed", {
+      type: "response.completed",
+      response: { id: "resp_1", object: "response", model: "gpt-4o", status: "completed", output: [], usage: { input_tokens: 42, output_tokens: 7, total_tokens: 49 } },
+    }));
+    t.end();
+    const result = await output;
+
+    // Should contain [DONE]
+    expect(result).toContain("[DONE]");
+
+    const chunks = parseOpenAIChunks(result);
+
+    // Should have finish_reason: "stop"
+    const finishChunk = chunks.find((c) => {
+      const choices = c.choices as Array<Record<string, unknown>> | undefined;
+      return choices?.[0]?.finish_reason != null;
+    });
+    expect(finishChunk).toBeDefined();
+    const finishChoice = ((finishChunk as Record<string, unknown>)?.choices as Array<Record<string, unknown>>)?.[0];
+    expect(finishChoice?.finish_reason).toBe("stop");
+
+    // Should have usage chunk
+    const usageChunk = chunks.find((c) => (c as Record<string, unknown>)?.usage != null);
+    expect(usageChunk).toBeDefined();
+    const usage = (usageChunk as Record<string, unknown>)?.usage as Record<string, number>;
+    expect(usage?.prompt_tokens).toBe(42);
+    expect(usage?.completion_tokens).toBe(7);
+    expect(usage?.total_tokens).toBe(49);
+  });
+
+  it("emits finish_reason: length on response.incomplete", async () => {
+    const t = new ResponsesToChatBridgeTransform("gpt-4o");
+    const output = collectOutput(t);
+    t.write(respSSE("response.output_text.delta", {
+      type: "response.output_text.delta", output_index: 0, content_index: 0, delta: "Partial",
+    }));
+    t.write(respSSE("response.incomplete", {
+      type: "response.incomplete",
+      response: { id: "resp_1", object: "response", model: "gpt-4o", status: "incomplete", output: [], usage: { input_tokens: 10, output_tokens: 100, total_tokens: 110 } },
+    }));
+    t.end();
+    const result = await output;
+    const chunks = parseOpenAIChunks(result);
+    const finishChunk = chunks.find((c) => {
+      const choices = c.choices as Array<Record<string, unknown>> | undefined;
+      return choices?.[0]?.finish_reason != null;
+    });
+    expect(finishChunk).toBeDefined();
+    const finishChoice = ((finishChunk as Record<string, unknown>)?.choices as Array<Record<string, unknown>>)?.[0];
+    expect(finishChoice?.finish_reason).toBe("length");
+  });
+
+  it("handles error events", async () => {
+    const t = new ResponsesToChatBridgeTransform("gpt-4o");
+    const output = collectOutput(t);
+    t.write(respSSE("response.failed", {
+      type: "response.failed",
+      response: { id: "resp_1", object: "response", model: "gpt-4o", status: "failed", error: { code: "server_error", message: "Internal error" } },
+    }));
+    t.end();
+    const result = await output;
+    const chunks = parseOpenAIChunks(result);
+    const errorChunk = chunks.find((c) => (c as Record<string, unknown>)?.error != null);
+    expect(errorChunk).toBeDefined();
+    const error = (errorChunk as Record<string, unknown>)?.error as Record<string, string>;
+    expect(error?.message).toBe("Internal error");
+  });
+
+  it("skips non-mappable events", async () => {
+    const t = new ResponsesToChatBridgeTransform("gpt-4o");
+    const output = collectOutput(t);
+    t.write(respSSE("response.output_item.added", {
+      type: "response.output_item.added", output_index: 0,
+      item: { type: "message", id: "msg_1", role: "assistant", content: [], status: "in_progress" },
+    }));
+    t.write(respSSE("response.content_part.added", {
+      type: "response.content_part.added", output_index: 0, content_index: 0,
+      part: { type: "output_text", text: "", annotations: [] },
+    }));
+    t.write(respSSE("response.output_text.delta", {
+      type: "response.output_text.delta", output_index: 0, content_index: 0, delta: "Hello",
+    }));
+    t.write(respSSE("response.output_text.done", {
+      type: "response.output_text.done", output_index: 0, content_index: 0, text: "Hello",
+    }));
+    t.write(respSSE("response.content_part.done", {
+      type: "response.content_part.done", output_index: 0, content_index: 0,
+      part: { type: "output_text", text: "Hello", annotations: [] },
+    }));
+    t.write(respSSE("response.output_item.done", {
+      type: "response.output_item.done", output_index: 0,
+      item: { type: "message", id: "msg_1", role: "assistant", content: [{ type: "output_text", text: "Hello" }], status: "completed" },
+    }));
+    t.write(respSSE("response.completed", {
+      type: "response.completed",
+      response: { id: "resp_1", object: "response", model: "gpt-4o", status: "completed", output: [], usage: { input_tokens: 10, output_tokens: 5, total_tokens: 15 } },
+    }));
+    t.end();
+    const result = await output;
+    const chunks = parseOpenAIChunks(result);
+
+    // Only relevant chunks: role, content delta, finish_reason, usage
+    const contentChunks = chunks.filter((c) => {
+      const choices = c.choices as Array<Record<string, unknown>> | undefined;
+      const delta = choices?.[0]?.delta as Record<string, unknown> | undefined;
+      return delta?.content != null;
+    });
+    expect(contentChunks.length).toBe(1);
+  });
+
+  it("handles multiple tool calls", async () => {
+    const t = new ResponsesToChatBridgeTransform("gpt-4o");
+    const output = collectOutput(t);
+    // First function call
+    t.write(respSSE("response.output_item.added", {
+      type: "response.output_item.added", output_index: 0,
+      item: { type: "function_call", id: "fc_1", call_id: "fc_1", name: "get_weather", arguments: "", status: "in_progress" },
+    }));
+    t.write(respSSE("response.function_call_arguments.delta", {
+      type: "response.function_call_arguments.delta", output_index: 0, item_id: "fc_1", call_id: "fc_1", delta: '{"city":"NYC"}',
+    }));
+    // Second function call
+    t.write(respSSE("response.output_item.added", {
+      type: "response.output_item.added", output_index: 1,
+      item: { type: "function_call", id: "fc_2", call_id: "fc_2", name: "get_time", arguments: "", status: "in_progress" },
+    }));
+    t.write(respSSE("response.function_call_arguments.delta", {
+      type: "response.function_call_arguments.delta", output_index: 1, item_id: "fc_2", call_id: "fc_2", delta: '{"tz":"EST"}',
+    }));
+    t.write(respSSE("response.completed", {
+      type: "response.completed",
+      response: { id: "resp_1", object: "response", model: "gpt-4o", status: "completed", output: [], usage: { input_tokens: 10, output_tokens: 20, total_tokens: 30 } },
+    }));
+    t.end();
+    const result = await output;
+    const chunks = parseOpenAIChunks(result);
+
+    // Find tool_calls init chunks
+    const tcInitChunks = chunks.filter((c) => {
+      const choices = c.choices as Array<Record<string, unknown>> | undefined;
+      const delta = choices?.[0]?.delta as Record<string, unknown> | undefined;
+      const tcs = delta?.tool_calls as Array<Record<string, unknown>> | undefined;
+      return tcs?.some((tc) => tc.id != null) ?? false;
+    });
+    expect(tcInitChunks.length).toBe(2);
+
+    // Verify indices
+    const tc0 = ((tcInitChunks[0] as Record<string, unknown>)?.choices as Array<Record<string, unknown>>)?.[0]?.delta as Record<string, unknown>;
+    const tc0Data = (tc0?.tool_calls as Array<Record<string, unknown>>)?.[0] as Record<string, unknown>;
+    expect(tc0Data?.index).toBe(0);
+    expect((tc0Data?.function as Record<string, unknown>)?.name).toBe("get_weather");
+
+    const tc1 = ((tcInitChunks[1] as Record<string, unknown>)?.choices as Array<Record<string, unknown>>)?.[0]?.delta as Record<string, unknown>;
+    const tc1Data = (tc1?.tool_calls as Array<Record<string, unknown>>)?.[0] as Record<string, unknown>;
+    expect(tc1Data?.index).toBe(1);
+    expect((tc1Data?.function as Record<string, unknown>)?.name).toBe("get_time");
+  });
+});

--- a/tests/proxy/transform/stream-resp2ant.test.ts
+++ b/tests/proxy/transform/stream-resp2ant.test.ts
@@ -213,7 +213,7 @@ describe("ResponsesToAnthropicTransform", () => {
     const blockStart = events.find((e) => e.event === "content_block_start");
     const block = (blockStart?.data as Record<string, unknown>)?.content_block as Record<string, unknown>;
     expect(block?.type).toBe("tool_use");
-    expect(block?.id).toBe("fc_1");
+    expect(block?.id).toBe("toolu_fc_1");
     expect(block?.name).toBe("get_weather");
 
     // input_json_delta

--- a/tests/proxy/transform/stream-resp2ant.test.ts
+++ b/tests/proxy/transform/stream-resp2ant.test.ts
@@ -1,0 +1,490 @@
+import { describe, it, expect } from "vitest";
+import { ResponsesToAnthropicTransform } from "../../../src/proxy/transform/stream-resp2ant.js";
+
+function collectOutput(transform: NodeJS.ReadWriteStream): Promise<string> {
+  return new Promise((resolve) => {
+    const chunks: string[] = [];
+    transform.on("data", (c: Buffer) => chunks.push(c.toString()));
+    transform.on("end", () => resolve(chunks.join("")));
+  });
+}
+
+function parseAnthropicEvents(output: string): Array<{ event: string; data: unknown }> {
+  const results: Array<{ event: string; data: unknown }> = [];
+  const chunks = output.split("\n\n").filter(Boolean);
+  for (const chunk of chunks) {
+    const lines = chunk.split("\n");
+    let eventType = "";
+    let dataStr = "";
+    for (const line of lines) {
+      if (line.startsWith("event: ")) eventType = line.slice(7);
+      else if (line.startsWith("data: ")) dataStr = line.slice(6);
+    }
+    if (eventType === "" && dataStr === "[DONE]") continue;
+    if (!eventType || !dataStr) continue;
+    try {
+      results.push({ event: eventType, data: JSON.parse(dataStr) });
+    } catch {
+      // skip unparseable
+    }
+  }
+  return results;
+}
+
+// Helper to build Responses SSE event strings
+function respSSE(eventType: string, data: unknown): string {
+  return `event: ${eventType}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+describe("ResponsesToAnthropicTransform", () => {
+  it("emits message_start on first output_item event", async () => {
+    const t = new ResponsesToAnthropicTransform("claude-3");
+    const output = collectOutput(t);
+    t.write(respSSE("response.created", {
+      type: "response.created",
+      response: { id: "resp_1", object: "response", model: "gpt-4o", status: "queued", output: [] },
+    }));
+    t.write(respSSE("response.in_progress", {
+      type: "response.in_progress",
+      response: { id: "resp_1", object: "response", model: "gpt-4o", status: "in_progress", output: [] },
+    }));
+    t.write(respSSE("response.output_item.added", {
+      type: "response.output_item.added",
+      output_index: 0,
+      item: { type: "message", id: "msg_1", role: "assistant", content: [], status: "in_progress" },
+    }));
+    t.write(respSSE("response.content_part.added", {
+      type: "response.content_part.added",
+      output_index: 0,
+      content_index: 0,
+      part: { type: "output_text", text: "", annotations: [] },
+    }));
+    t.write(respSSE("response.output_text.done", {
+      type: "response.output_text.done",
+      output_index: 0,
+      content_index: 0,
+      text: "",
+    }));
+    t.write(respSSE("response.content_part.done", {
+      type: "response.content_part.done",
+      output_index: 0,
+      content_index: 0,
+      part: { type: "output_text", text: "", annotations: [] },
+    }));
+    t.write(respSSE("response.output_item.done", {
+      type: "response.output_item.done",
+      output_index: 0,
+      item: { type: "message", id: "msg_1", role: "assistant", content: [{ type: "output_text", text: "", annotations: [] }], status: "completed" },
+    }));
+    t.write(respSSE("response.completed", {
+      type: "response.completed",
+      response: {
+        id: "resp_1", object: "response", model: "gpt-4o", status: "completed",
+        output: [], usage: { input_tokens: 10, output_tokens: 5, total_tokens: 15 },
+      },
+    }));
+    t.end();
+    const result = await output;
+    const events = parseAnthropicEvents(result);
+    const eventTypes = events.map((e) => e.event);
+
+    expect(eventTypes).toContain("message_start");
+    const msgStart = events.find((e) => e.event === "message_start");
+    const msg = (msgStart?.data as Record<string, unknown>)?.message as Record<string, unknown>;
+    expect(msg?.role).toBe("assistant");
+    expect(msg?.model).toBe("claude-3");
+  });
+
+  it("converts output_text.delta to text_delta content_block", async () => {
+    const t = new ResponsesToAnthropicTransform("claude-3");
+    const output = collectOutput(t);
+    t.write(respSSE("response.output_item.added", {
+      type: "response.output_item.added",
+      output_index: 0,
+      item: { type: "message", id: "msg_1", role: "assistant", content: [], status: "in_progress" },
+    }));
+    t.write(respSSE("response.content_part.added", {
+      type: "response.content_part.added",
+      output_index: 0,
+      content_index: 0,
+      part: { type: "output_text", text: "", annotations: [] },
+    }));
+    t.write(respSSE("response.output_text.delta", {
+      type: "response.output_text.delta",
+      output_index: 0,
+      content_index: 0,
+      delta: "Hello world",
+    }));
+    t.write(respSSE("response.output_text.done", {
+      type: "response.output_text.done",
+      output_index: 0,
+      content_index: 0,
+      text: "Hello world",
+    }));
+    t.write(respSSE("response.content_part.done", {
+      type: "response.content_part.done",
+      output_index: 0,
+      content_index: 0,
+      part: { type: "output_text", text: "Hello world", annotations: [] },
+    }));
+    t.write(respSSE("response.output_item.done", {
+      type: "response.output_item.done",
+      output_index: 0,
+      item: { type: "message", id: "msg_1", role: "assistant", content: [{ type: "output_text", text: "Hello world", annotations: [] }], status: "completed" },
+    }));
+    t.write(respSSE("response.completed", {
+      type: "response.completed",
+      response: {
+        id: "resp_1", object: "response", model: "gpt-4o", status: "completed",
+        output: [], usage: { input_tokens: 10, output_tokens: 5, total_tokens: 15 },
+      },
+    }));
+    t.end();
+    const result = await output;
+    const events = parseAnthropicEvents(result);
+    const eventTypes = events.map((e) => e.event);
+
+    // Should have content_block_start with text type
+    expect(eventTypes).toContain("content_block_start");
+    const blockStart = events.find((e) => e.event === "content_block_start");
+    const block = (blockStart?.data as Record<string, unknown>)?.content_block as Record<string, unknown>;
+    expect(block?.type).toBe("text");
+
+    // Should have text_delta
+    expect(eventTypes).toContain("content_block_delta");
+    const blockDelta = events.find((e) => e.event === "content_block_delta");
+    const delta = (blockDelta?.data as Record<string, unknown>)?.delta as Record<string, unknown>;
+    expect(delta?.type).toBe("text_delta");
+    expect(delta?.text).toBe("Hello world");
+
+    // Should have content_block_stop
+    expect(eventTypes).toContain("content_block_stop");
+
+    // Should have message_delta with end_turn
+    expect(eventTypes).toContain("message_delta");
+    const msgDelta = events.find((e) => e.event === "message_delta");
+    const deltaData = (msgDelta?.data as Record<string, unknown>)?.delta as Record<string, unknown>;
+    expect(deltaData?.stop_reason).toBe("end_turn");
+
+    expect(eventTypes).toContain("message_stop");
+  });
+
+  it("converts function_call to tool_use content block", async () => {
+    const t = new ResponsesToAnthropicTransform("claude-3");
+    const output = collectOutput(t);
+    t.write(respSSE("response.output_item.added", {
+      type: "response.output_item.added",
+      output_index: 0,
+      item: { type: "function_call", id: "fc_1", call_id: "fc_1", name: "get_weather", arguments: "", status: "in_progress" },
+    }));
+    t.write(respSSE("response.function_call_arguments.delta", {
+      type: "response.function_call_arguments.delta",
+      output_index: 0,
+      item_id: "fc_1",
+      call_id: "fc_1",
+      delta: '{"city":"NYC"}',
+    }));
+    t.write(respSSE("response.function_call_arguments.done", {
+      type: "response.function_call_arguments.done",
+      output_index: 0,
+      item_id: "fc_1",
+      call_id: "fc_1",
+      arguments: '{"city":"NYC"}',
+    }));
+    t.write(respSSE("response.output_item.done", {
+      type: "response.output_item.done",
+      output_index: 0,
+      item: { type: "function_call", id: "fc_1", call_id: "fc_1", name: "get_weather", arguments: '{"city":"NYC"}', status: "completed" },
+    }));
+    t.write(respSSE("response.completed", {
+      type: "response.completed",
+      response: {
+        id: "resp_1", object: "response", model: "gpt-4o", status: "completed",
+        output: [], usage: { input_tokens: 10, output_tokens: 20, total_tokens: 30 },
+      },
+    }));
+    t.end();
+    const result = await output;
+    const events = parseAnthropicEvents(result);
+    const eventTypes = events.map((e) => e.event);
+
+    // content_block_start with tool_use
+    expect(eventTypes).toContain("content_block_start");
+    const blockStart = events.find((e) => e.event === "content_block_start");
+    const block = (blockStart?.data as Record<string, unknown>)?.content_block as Record<string, unknown>;
+    expect(block?.type).toBe("tool_use");
+    expect(block?.id).toBe("fc_1");
+    expect(block?.name).toBe("get_weather");
+
+    // input_json_delta
+    expect(eventTypes).toContain("content_block_delta");
+    const blockDelta = events.find((e) => e.event === "content_block_delta");
+    const delta = (blockDelta?.data as Record<string, unknown>)?.delta as Record<string, unknown>;
+    expect(delta?.type).toBe("input_json_delta");
+    expect(delta?.partial_json).toBe('{"city":"NYC"}');
+
+    // content_block_stop
+    expect(eventTypes).toContain("content_block_stop");
+
+    // message_delta with tool_use stop_reason
+    const msgDelta = events.find((e) => e.event === "message_delta");
+    const deltaData = (msgDelta?.data as Record<string, unknown>)?.delta as Record<string, unknown>;
+    expect(deltaData?.stop_reason).toBe("tool_use");
+  });
+
+  it("converts reasoning to thinking block", async () => {
+    const t = new ResponsesToAnthropicTransform("claude-3");
+    const output = collectOutput(t);
+    t.write(respSSE("response.output_item.added", {
+      type: "response.output_item.added",
+      output_index: 0,
+      item: { type: "reasoning", id: "rs_1", summary: [] },
+    }));
+    t.write(respSSE("response.reasoning_summary_text.delta", {
+      type: "response.reasoning_summary_text.delta",
+      output_index: 0,
+      summary_index: 0,
+      delta: "Let me think about this...",
+    }));
+    t.write(respSSE("response.reasoning_summary_text.done", {
+      type: "response.reasoning_summary_text.done",
+      output_index: 0,
+      summary_index: 0,
+      text: "Let me think about this...",
+    }));
+    t.write(respSSE("response.output_item.done", {
+      type: "response.output_item.done",
+      output_index: 0,
+      item: { type: "reasoning", id: "rs_1", summary: [{ type: "summary_text", text: "Let me think about this..." }] },
+    }));
+    t.write(respSSE("response.output_item.added", {
+      type: "response.output_item.added",
+      output_index: 1,
+      item: { type: "message", id: "msg_1", role: "assistant", content: [], status: "in_progress" },
+    }));
+    t.write(respSSE("response.content_part.added", {
+      type: "response.content_part.added",
+      output_index: 1,
+      content_index: 0,
+      part: { type: "output_text", text: "", annotations: [] },
+    }));
+    t.write(respSSE("response.output_text.delta", {
+      type: "response.output_text.delta",
+      output_index: 1,
+      content_index: 0,
+      delta: "The answer is 42",
+    }));
+    t.write(respSSE("response.output_item.done", {
+      type: "response.output_item.done",
+      output_index: 1,
+      item: { type: "message", id: "msg_1", role: "assistant", content: [{ type: "output_text", text: "The answer is 42" }], status: "completed" },
+    }));
+    t.write(respSSE("response.completed", {
+      type: "response.completed",
+      response: {
+        id: "resp_1", object: "response", model: "gpt-4o", status: "completed",
+        output: [], usage: { input_tokens: 10, output_tokens: 30, total_tokens: 40 },
+      },
+    }));
+    t.end();
+    const result = await output;
+    const events = parseAnthropicEvents(result);
+    const eventTypes = events.map((e) => e.event);
+
+    // Should have thinking block
+    const blockStarts = events.filter((e) => e.event === "content_block_start");
+    expect(blockStarts.length).toBe(2);
+
+    const thinkingBlock = (blockStarts[0]?.data as Record<string, unknown>)?.content_block as Record<string, unknown>;
+    expect(thinkingBlock?.type).toBe("thinking");
+
+    const textBlock = (blockStarts[1]?.data as Record<string, unknown>)?.content_block as Record<string, unknown>;
+    expect(textBlock?.type).toBe("text");
+
+    // thinking_delta
+    const deltas = events.filter((e) => e.event === "content_block_delta");
+    const thinkingDelta = (deltas[0]?.data as Record<string, unknown>)?.delta as Record<string, unknown>;
+    expect(thinkingDelta?.type).toBe("thinking_delta");
+    expect(thinkingDelta?.thinking).toBe("Let me think about this...");
+
+    // text_delta
+    const textDelta = (deltas[1]?.data as Record<string, unknown>)?.delta as Record<string, unknown>;
+    expect(textDelta?.type).toBe("text_delta");
+    expect(textDelta?.text).toBe("The answer is 42");
+
+    // Two content_block_stop events
+    const blockStops = events.filter((e) => e.event === "content_block_stop");
+    expect(blockStops.length).toBe(2);
+  });
+
+  it("maps incomplete status to max_tokens stop_reason", async () => {
+    const t = new ResponsesToAnthropicTransform("claude-3");
+    const output = collectOutput(t);
+    t.write(respSSE("response.output_item.added", {
+      type: "response.output_item.added",
+      output_index: 0,
+      item: { type: "message", id: "msg_1", role: "assistant", content: [], status: "in_progress" },
+    }));
+    t.write(respSSE("response.content_part.added", {
+      type: "response.content_part.added",
+      output_index: 0,
+      content_index: 0,
+      part: { type: "output_text", text: "", annotations: [] },
+    }));
+    t.write(respSSE("response.output_text.delta", {
+      type: "response.output_text.delta",
+      output_index: 0,
+      content_index: 0,
+      delta: "Partial",
+    }));
+    t.write(respSSE("response.output_item.done", {
+      type: "response.output_item.done",
+      output_index: 0,
+      item: { type: "message", id: "msg_1", role: "assistant", content: [{ type: "output_text", text: "Partial" }], status: "completed" },
+    }));
+    t.write(respSSE("response.incomplete", {
+      type: "response.incomplete",
+      response: {
+        id: "resp_1", object: "response", model: "gpt-4o", status: "incomplete",
+        output: [], usage: { input_tokens: 10, output_tokens: 100, total_tokens: 110 },
+      },
+    }));
+    t.end();
+    const result = await output;
+    const events = parseAnthropicEvents(result);
+    const msgDelta = events.find((e) => e.event === "message_delta");
+    const deltaData = (msgDelta?.data as Record<string, unknown>)?.delta as Record<string, unknown>;
+    expect(deltaData?.stop_reason).toBe("max_tokens");
+  });
+
+  it("includes output_tokens from usage in message_delta", async () => {
+    const t = new ResponsesToAnthropicTransform("claude-3");
+    const output = collectOutput(t);
+    t.write(respSSE("response.output_item.added", {
+      type: "response.output_item.added",
+      output_index: 0,
+      item: { type: "message", id: "msg_1", role: "assistant", content: [], status: "in_progress" },
+    }));
+    t.write(respSSE("response.content_part.added", {
+      type: "response.content_part.added",
+      output_index: 0,
+      content_index: 0,
+      part: { type: "output_text", text: "", annotations: [] },
+    }));
+    t.write(respSSE("response.output_text.delta", {
+      type: "response.output_text.delta",
+      output_index: 0,
+      content_index: 0,
+      delta: "Hi",
+    }));
+    t.write(respSSE("response.output_item.done", {
+      type: "response.output_item.done",
+      output_index: 0,
+      item: { type: "message", id: "msg_1", role: "assistant", content: [{ type: "output_text", text: "Hi" }], status: "completed" },
+    }));
+    t.write(respSSE("response.completed", {
+      type: "response.completed",
+      response: {
+        id: "resp_1", object: "response", model: "gpt-4o", status: "completed",
+        output: [], usage: { input_tokens: 42, output_tokens: 7, total_tokens: 49 },
+      },
+    }));
+    t.end();
+    const result = await output;
+    const events = parseAnthropicEvents(result);
+    const msgDelta = events.find((e) => e.event === "message_delta");
+    const usage = (msgDelta?.data as Record<string, unknown>)?.usage as Record<string, unknown>;
+    expect(usage?.output_tokens).toBe(7);
+  });
+
+  it("handles error events", async () => {
+    const t = new ResponsesToAnthropicTransform("claude-3");
+    const output = collectOutput(t);
+    t.write(respSSE("response.failed", {
+      type: "response.failed",
+      response: {
+        id: "resp_1", object: "response", model: "gpt-4o", status: "failed",
+        error: { code: "server_error", message: "Internal error" },
+      },
+    }));
+    t.end();
+    const result = await output;
+    const events = parseAnthropicEvents(result);
+    const errorEvent = events.find((e) => e.event === "error");
+    expect(errorEvent).toBeDefined();
+    const error = (errorEvent?.data as Record<string, unknown>)?.error as Record<string, unknown>;
+    expect(error?.message).toBe("Internal error");
+  });
+
+  it("handles mixed content: text + function_call", async () => {
+    const t = new ResponsesToAnthropicTransform("claude-3");
+    const output = collectOutput(t);
+
+    // Text output
+    t.write(respSSE("response.output_item.added", {
+      type: "response.output_item.added",
+      output_index: 0,
+      item: { type: "message", id: "msg_1", role: "assistant", content: [], status: "in_progress" },
+    }));
+    t.write(respSSE("response.content_part.added", {
+      type: "response.content_part.added",
+      output_index: 0,
+      content_index: 0,
+      part: { type: "output_text", text: "", annotations: [] },
+    }));
+    t.write(respSSE("response.output_text.delta", {
+      type: "response.output_text.delta",
+      output_index: 0,
+      content_index: 0,
+      delta: "Let me search for that.",
+    }));
+    t.write(respSSE("response.output_item.done", {
+      type: "response.output_item.done",
+      output_index: 0,
+      item: { type: "message", id: "msg_1", role: "assistant", content: [{ type: "output_text", text: "Let me search for that." }], status: "completed" },
+    }));
+    // Function call
+    t.write(respSSE("response.output_item.added", {
+      type: "response.output_item.added",
+      output_index: 1,
+      item: { type: "function_call", id: "fc_1", call_id: "fc_1", name: "search", arguments: "", status: "in_progress" },
+    }));
+    t.write(respSSE("response.function_call_arguments.delta", {
+      type: "response.function_call_arguments.delta",
+      output_index: 1,
+      item_id: "fc_1",
+      call_id: "fc_1",
+      delta: '{"query":"test"}',
+    }));
+    t.write(respSSE("response.output_item.done", {
+      type: "response.output_item.done",
+      output_index: 1,
+      item: { type: "function_call", id: "fc_1", call_id: "fc_1", name: "search", arguments: '{"query":"test"}', status: "completed" },
+    }));
+    t.write(respSSE("response.completed", {
+      type: "response.completed",
+      response: {
+        id: "resp_1", object: "response", model: "gpt-4o", status: "completed",
+        output: [], usage: { input_tokens: 50, output_tokens: 25, total_tokens: 75 },
+      },
+    }));
+    t.end();
+    const result = await output;
+    const events = parseAnthropicEvents(result);
+    const eventTypes = events.map((e) => e.event);
+
+    // Should have 2 content_block_start (text + tool_use)
+    const blockStarts = events.filter((e) => e.event === "content_block_start");
+    expect(blockStarts.length).toBe(2);
+
+    // Tool use block
+    const toolBlock = (blockStarts[1]?.data as Record<string, unknown>)?.content_block as Record<string, unknown>;
+    expect(toolBlock?.type).toBe("tool_use");
+    expect(toolBlock?.name).toBe("search");
+
+    // Should end with tool_use stop_reason (because function_call was present)
+    const msgDelta = events.find((e) => e.event === "message_delta");
+    const deltaData = (msgDelta?.data as Record<string, unknown>)?.delta as Record<string, unknown>;
+    expect(deltaData?.stop_reason).toBe("tool_use");
+  });
+});

--- a/tests/proxy/transform/transform-coordinator-responses.test.ts
+++ b/tests/proxy/transform/transform-coordinator-responses.test.ts
@@ -1,0 +1,366 @@
+import { describe, it, expect } from "vitest";
+import { TransformCoordinator } from "../../../src/proxy/transform/transform-coordinator.js";
+import { ResponsesToAnthropicTransform } from "../../../src/proxy/transform/stream-resp2ant.js";
+import { AnthropicToResponsesTransform } from "../../../src/proxy/transform/stream-ant2resp.js";
+import { OpenAIToAnthropicTransform } from "../../../src/proxy/transform/stream-oa2ant.js";
+import { AnthropicToOpenAITransform } from "../../../src/proxy/transform/stream-ant2oa.js";
+import { ResponsesToChatBridgeTransform } from "../../../src/proxy/transform/stream-bridge-resp2chat.js";
+import { ChatToResponsesBridgeTransform } from "../../../src/proxy/transform/stream-bridge-chat2resp.js";
+
+describe("TransformCoordinator — 3×3 matrix", () => {
+  const coord = new TransformCoordinator();
+
+  // ----------------------------------------------------------------
+  // needsTransform
+  // ----------------------------------------------------------------
+  describe("needsTransform", () => {
+    it("returns false when apiTypes match (openai)", () => {
+      expect(coord.needsTransform("openai", "openai")).toBe(false);
+    });
+    it("returns false when apiTypes match (anthropic)", () => {
+      expect(coord.needsTransform("anthropic", "anthropic")).toBe(false);
+    });
+    it("returns false when apiTypes match (openai-responses)", () => {
+      expect(coord.needsTransform("openai-responses", "openai-responses")).toBe(false);
+    });
+    it("returns true for all cross-format pairs", () => {
+      const types = ["openai", "anthropic", "openai-responses"];
+      for (const entry of types) {
+        for (const provider of types) {
+          if (entry !== provider) {
+            expect(coord.needsTransform(entry, provider)).toBe(true);
+          }
+        }
+      }
+    });
+  });
+
+  // ----------------------------------------------------------------
+  // transformRequest — identity (no transform)
+  // ----------------------------------------------------------------
+  describe("transformRequest — identity", () => {
+    it("openai → openai: returns body unchanged", () => {
+      const body = { model: "gpt-4", messages: [] };
+      const result = coord.transformRequest(body, "openai", "openai", "gpt-4");
+      expect(result.body).toBe(body);
+      expect(result.upstreamPath).toBe("/v1/chat/completions");
+    });
+
+    it("anthropic → anthropic: returns body unchanged", () => {
+      const body = { model: "claude-3", messages: [] };
+      const result = coord.transformRequest(body, "anthropic", "anthropic", "claude-3");
+      expect(result.body).toBe(body);
+      expect(result.upstreamPath).toBe("/v1/messages");
+    });
+
+    it("openai-responses → openai-responses: returns body unchanged", () => {
+      const body = { model: "gpt-4o", input: "hi" };
+      const result = coord.transformRequest(body, "openai-responses", "openai-responses", "gpt-4o");
+      expect(result.body).toBe(body);
+      expect(result.upstreamPath).toBe("/v1/responses");
+    });
+  });
+
+  // ----------------------------------------------------------------
+  // transformRequest — Tier-1 (Responses ↔ Anthropic)
+  // ----------------------------------------------------------------
+  describe("transformRequest — Tier-1 Responses ↔ Anthropic", () => {
+    it("openai-responses → anthropic: converts request", () => {
+      const body = {
+        model: "gpt-4o",
+        input: [{ role: "user", content: "Hello" }],
+        stream: true,
+      };
+      const result = coord.transformRequest(body, "openai-responses", "anthropic", "gpt-4o");
+      expect(result.upstreamPath).toBe("/v1/messages");
+      expect(result.body.model).toBe("gpt-4o");
+      expect(result.body.messages).toBeDefined();
+      expect(result.body.stream).toBe(true);
+    });
+
+    it("anthropic → openai-responses: converts request", () => {
+      const body = {
+        model: "claude-3",
+        messages: [{ role: "user", content: [{ type: "text", text: "Hello" }] }],
+        max_tokens: 1024,
+        stream: true,
+      };
+      const result = coord.transformRequest(body, "anthropic", "openai-responses", "claude-3");
+      expect(result.upstreamPath).toBe("/v1/responses");
+      expect(result.body.model).toBe("claude-3");
+      expect(result.body.input).toBeDefined();
+    });
+  });
+
+  // ----------------------------------------------------------------
+  // transformRequest — Existing (Chat ↔ Anthropic)
+  // ----------------------------------------------------------------
+  describe("transformRequest — Existing Chat ↔ Anthropic", () => {
+    it("openai → anthropic: converts request", () => {
+      const body = {
+        model: "gpt-4",
+        messages: [{ role: "user", content: "Hi" }],
+        stream: true,
+      };
+      const result = coord.transformRequest(body, "openai", "anthropic", "gpt-4");
+      expect(result.upstreamPath).toBe("/v1/messages");
+      expect(result.body.max_tokens).toBeDefined();
+    });
+
+    it("anthropic → openai: converts request", () => {
+      const body = {
+        model: "claude-3",
+        messages: [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
+        stream: true,
+        max_tokens: 4096,
+      };
+      const result = coord.transformRequest(body, "anthropic", "openai", "claude-3");
+      expect(result.upstreamPath).toBe("/v1/chat/completions");
+      expect(result.body.stream_options).toEqual({ include_usage: true });
+    });
+  });
+
+  // ----------------------------------------------------------------
+  // transformRequest — Bridge (Responses ↔ Chat)
+  // ----------------------------------------------------------------
+  describe("transformRequest — Bridge Responses ↔ Chat", () => {
+    it("openai-responses → openai: converts request", () => {
+      const body = {
+        model: "gpt-4o",
+        input: [{ role: "user", content: "Hello" }],
+        stream: true,
+      };
+      const result = coord.transformRequest(body, "openai-responses", "openai", "gpt-4o");
+      expect(result.upstreamPath).toBe("/v1/chat/completions");
+      expect(result.body.model).toBe("gpt-4o");
+      expect(result.body.messages).toBeDefined();
+    });
+
+    it("openai → openai-responses: converts request", () => {
+      const body = {
+        model: "gpt-4o",
+        messages: [{ role: "user", content: "Hello" }],
+        stream: true,
+      };
+      const result = coord.transformRequest(body, "openai", "openai-responses", "gpt-4o");
+      expect(result.upstreamPath).toBe("/v1/responses");
+      expect(result.body.model).toBe("gpt-4o");
+      expect(result.body.input).toBeDefined();
+    });
+  });
+
+  // ----------------------------------------------------------------
+  // transformResponse — identity
+  // ----------------------------------------------------------------
+  describe("transformResponse — identity", () => {
+    it("returns body unchanged when same apiType", () => {
+      const body = '{"id":"test","output":[]}';
+      expect(coord.transformResponse(body, "openai-responses", "openai-responses")).toBe(body);
+      expect(coord.transformResponse(body, "openai", "openai")).toBe(body);
+      expect(coord.transformResponse(body, "anthropic", "anthropic")).toBe(body);
+    });
+  });
+
+  // ----------------------------------------------------------------
+  // transformResponse — Tier-1 (Responses ↔ Anthropic)
+  // ----------------------------------------------------------------
+  describe("transformResponse — Tier-1 Responses ↔ Anthropic", () => {
+    it("openai-responses → anthropic: converts response", () => {
+      const respBody = JSON.stringify({
+        id: "resp-1",
+        status: "completed",
+        output: [{ type: "message", content: [{ type: "output_text", text: "Hi" }] }],
+        model: "gpt-4o",
+      });
+      const result = JSON.parse(coord.transformResponse(respBody, "openai-responses", "anthropic"));
+      expect(result.type).toBe("message");
+      expect(result.content).toBeDefined();
+    });
+
+    it("anthropic → openai-responses: converts response", () => {
+      const antBody = JSON.stringify({
+        id: "msg-1",
+        type: "message",
+        role: "assistant",
+        content: [{ type: "text", text: "Hi" }],
+        model: "claude-3",
+        stop_reason: "end_turn",
+      });
+      const result = JSON.parse(coord.transformResponse(antBody, "anthropic", "openai-responses"));
+      expect(result.output).toBeDefined();
+    });
+  });
+
+  // ----------------------------------------------------------------
+  // transformResponse — Existing (Chat ↔ Anthropic)
+  // ----------------------------------------------------------------
+  describe("transformResponse — Existing Chat ↔ Anthropic", () => {
+    it("openai → anthropic: converts response", () => {
+      const oaiBody = JSON.stringify({
+        id: "chatcmpl-1",
+        model: "gpt-4",
+        choices: [{ message: { role: "assistant", content: "Hi" }, finish_reason: "stop" }],
+        usage: { prompt_tokens: 10, completion_tokens: 5 },
+      });
+      const result = JSON.parse(coord.transformResponse(oaiBody, "openai", "anthropic"));
+      expect(result.type).toBe("message");
+    });
+
+    it("anthropic → openai: converts response", () => {
+      const antBody = JSON.stringify({
+        id: "msg-1",
+        type: "message",
+        role: "assistant",
+        content: [{ type: "text", text: "Hi" }],
+        model: "claude-3",
+        stop_reason: "end_turn",
+      });
+      const result = JSON.parse(coord.transformResponse(antBody, "anthropic", "openai"));
+      expect(result.choices).toBeDefined();
+    });
+  });
+
+  // ----------------------------------------------------------------
+  // transformResponse — Bridge (Responses ↔ Chat)
+  // ----------------------------------------------------------------
+  describe("transformResponse — Bridge Responses ↔ Chat", () => {
+    it("openai-responses → openai: converts response", () => {
+      const respBody = JSON.stringify({
+        id: "resp-1",
+        status: "completed",
+        output: [{ type: "message", content: [{ type: "output_text", text: "Hi" }] }],
+        model: "gpt-4o",
+      });
+      const result = JSON.parse(coord.transformResponse(respBody, "openai-responses", "openai"));
+      expect(result.choices).toBeDefined();
+    });
+
+    it("openai → openai-responses: converts response", () => {
+      const oaiBody = JSON.stringify({
+        id: "chatcmpl-1",
+        model: "gpt-4o",
+        choices: [{ message: { role: "assistant", content: "Hi" }, finish_reason: "stop" }],
+        usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+      });
+      const result = JSON.parse(coord.transformResponse(oaiBody, "openai", "openai-responses"));
+      expect(result.output).toBeDefined();
+    });
+  });
+
+  // ----------------------------------------------------------------
+  // transformErrorResponse
+  // ----------------------------------------------------------------
+  describe("transformErrorResponse", () => {
+    it("returns body unchanged when same apiType", () => {
+      const err = '{"error":{"message":"fail"}}';
+      expect(coord.transformErrorResponse(err, "openai", "openai")).toBe(err);
+      expect(coord.transformErrorResponse(err, "openai-responses", "openai-responses")).toBe(err);
+      expect(coord.transformErrorResponse(err, "anthropic", "anthropic")).toBe(err);
+    });
+
+    it("openai-responses → anthropic: converts error", () => {
+      const err = JSON.stringify({ error: { message: "rate limited" } });
+      const result = JSON.parse(coord.transformErrorResponse(err, "openai-responses", "anthropic"));
+      expect(result.type).toBe("error");
+      expect(result.error.message).toBe("rate limited");
+    });
+
+    it("anthropic → openai-responses: converts error", () => {
+      const err = JSON.stringify({ type: "error", error: { type: "api_error", message: "overloaded" } });
+      const result = JSON.parse(coord.transformErrorResponse(err, "anthropic", "openai-responses"));
+      expect(result.error.message).toBe("overloaded");
+      expect(result.error.code).toBe("upstream_error");
+    });
+
+    it("openai-responses → openai: converts error", () => {
+      const err = JSON.stringify({ error: { message: "bad request" } });
+      const result = JSON.parse(coord.transformErrorResponse(err, "openai-responses", "openai"));
+      expect(result.error.message).toBe("bad request");
+      expect(result.error.type).toBe("api_error");
+    });
+
+    it("openai → openai-responses: converts error", () => {
+      const err = JSON.stringify({ error: { message: "timeout", type: "timeout" } });
+      const result = JSON.parse(coord.transformErrorResponse(err, "openai", "openai-responses"));
+      expect(result.error.message).toBe("timeout");
+      expect(result.error.type).toBe("invalid_request_error");
+    });
+
+    it("falls through to existing Chat ↔ Anthropic error conversion", () => {
+      const antError = JSON.stringify({ type: "error", error: { type: "err", message: "fail" } });
+      const result = JSON.parse(coord.transformErrorResponse(antError, "anthropic", "openai"));
+      expect(result.error.message).toBe("fail");
+    });
+
+    it("returns raw body on parse failure", () => {
+      const invalid = "not json at all";
+      expect(coord.transformErrorResponse(invalid, "openai", "anthropic")).toBe(invalid);
+    });
+  });
+
+  // ----------------------------------------------------------------
+  // createFormatTransform
+  // ----------------------------------------------------------------
+  describe("createFormatTransform", () => {
+    it("returns undefined for same apiType", () => {
+      expect(coord.createFormatTransform("openai", "openai", "gpt-4")).toBeUndefined();
+      expect(coord.createFormatTransform("anthropic", "anthropic", "claude-3")).toBeUndefined();
+      expect(coord.createFormatTransform("openai-responses", "openai-responses", "gpt-4o")).toBeUndefined();
+    });
+
+    it("returns ResponsesToAnthropicTransform for openai-responses client → anthropic provider", () => {
+      const t = coord.createFormatTransform("openai-responses", "anthropic", "gpt-4o");
+      expect(t).toBeInstanceOf(ResponsesToAnthropicTransform);
+    });
+
+    it("returns AnthropicToResponsesTransform for anthropic client → openai-responses provider", () => {
+      const t = coord.createFormatTransform("anthropic", "openai-responses", "claude-3");
+      expect(t).toBeInstanceOf(AnthropicToResponsesTransform);
+    });
+
+    it("returns OpenAIToAnthropicTransform for anthropic client → openai provider", () => {
+      const t = coord.createFormatTransform("anthropic", "openai", "claude-3");
+      expect(t).toBeInstanceOf(OpenAIToAnthropicTransform);
+    });
+
+    it("returns AnthropicToOpenAITransform for openai client → anthropic provider", () => {
+      const t = coord.createFormatTransform("openai", "anthropic", "gpt-4");
+      expect(t).toBeInstanceOf(AnthropicToOpenAITransform);
+    });
+
+    it("returns ResponsesToChatBridgeTransform for openai-responses client → openai provider", () => {
+      const t = coord.createFormatTransform("openai-responses", "openai", "gpt-4o");
+      expect(t).toBeInstanceOf(ResponsesToChatBridgeTransform);
+    });
+
+    it("returns ChatToResponsesBridgeTransform for openai client → openai-responses provider", () => {
+      const t = coord.createFormatTransform("openai", "openai-responses", "gpt-4o");
+      expect(t).toBeInstanceOf(ChatToResponsesBridgeTransform);
+    });
+  });
+
+  // ----------------------------------------------------------------
+  // getUpstreamPath (tested via transformRequest identity paths)
+  // ----------------------------------------------------------------
+  describe("getUpstreamPath", () => {
+    it("returns /v1/chat/completions for openai", () => {
+      const result = coord.transformRequest({ model: "gpt-4" }, "openai", "openai", "gpt-4");
+      expect(result.upstreamPath).toBe("/v1/chat/completions");
+    });
+
+    it("returns /v1/messages for anthropic", () => {
+      const result = coord.transformRequest({ model: "claude-3" }, "anthropic", "anthropic", "claude-3");
+      expect(result.upstreamPath).toBe("/v1/messages");
+    });
+
+    it("returns /v1/responses for openai-responses", () => {
+      const result = coord.transformRequest({ model: "gpt-4o" }, "openai-responses", "openai-responses", "gpt-4o");
+      expect(result.upstreamPath).toBe("/v1/responses");
+    });
+
+    it("returns /v1/chat/completions for unknown apiType", () => {
+      const result = coord.transformRequest({ model: "x" }, "unknown" as string, "unknown" as string, "x");
+      expect(result.upstreamPath).toBe("/v1/chat/completions");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Add full support for the OpenAI Responses API (`/v1/responses`) endpoint, enabling format conversion between Responses API, Chat Completions, and Anthropic Messages.

## Architecture

- **Tier-1 (near-lossless):** Responses ↔ Anthropic — structurally most similar formats
- **Bridge (lossy):** Responses ↔ Chat — Chat cannot represent reasoning/stateful conversations
- **Preserved:** Existing Anthropic ↔ Chat direct path stays one-hop

## Changes (51 files, +10,388 / -45 lines)

### New files
- `types-responses.ts` — Full Responses API type definitions
- `request-transform-responses.ts` — Responses ↔ Anthropic request transform
- `response-transform-responses.ts` — Responses ↔ Anthropic response transform
- `request-bridge-responses.ts` — Responses ↔ Chat bridge request transform
- `response-bridge-responses.ts` — Responses ↔ Chat bridge response transform
- `stream-ant2resp.ts` / `stream-resp2ant.ts` — Anthropic ↔ Responses SSE streaming
- `stream-bridge-chat2resp.ts` / `stream-bridge-resp2chat.ts` — Chat ↔ Responses SSE bridge
- `src/proxy/handler/responses.ts` — `/v1/responses` endpoint handler

### Modified files
- `transform-coordinator.ts` — Rewritten as 3×3 conversion matrix
- `stream-transform-base.ts` — Added `pushResponsesSSE()`
- 20+ files — api_type signature widened to `openai | openai-responses | anthropic`
- Monitor/metrics/patch systems — Extended for Responses format
- `src/index.ts` — Route registration
- `Providers.vue` — Frontend dropdown option

## Test Results
- **1,037 tests pass** (+210 new tests)
- **0 TypeScript compilation errors**
- 4 pre-existing storage test failures (timezone-related, unrelated)