### PR TITLE
fix: request queuing never executes + DB migration data corruption from 035

### DIFF
--- a/src/db/migrations/035_add_openai_responses_api_type.sql
+++ b/src/db/migrations/035_add_openai_responses_api_type.sql
@@ -33,7 +33,8 @@ CREATE TABLE providers_new (
   updated_at TEXT NOT NULL
 );
 
-INSERT INTO providers_new SELECT * FROM providers;
+INSERT INTO providers_new (id, name, api_type, base_url, api_key, api_key_preview, models, is_active, max_concurrency, queue_timeout_ms, max_queue_size, adaptive_enabled, adaptive_min, created_at, updated_at)
+SELECT id, name, api_type, base_url, api_key, api_key_preview, models, is_active, max_concurrency, queue_timeout_ms, max_queue_size, adaptive_enabled, adaptive_min, created_at, updated_at FROM providers;
 DROP TABLE providers;
 ALTER TABLE providers_new RENAME TO providers;
 

--- a/src/db/migrations/036_fix_035_data_corruption.sql
+++ b/src/db/migrations/036_fix_035_data_corruption.sql
@@ -1,0 +1,119 @@
+-- Fix data corruption caused by migration 035.
+-- Migration 035 used `INSERT INTO providers_new SELECT * FROM providers`
+-- which matches columns by position, not by name. The new table had a different
+-- column order than the old table (where columns were added sequentially via
+-- ALTER TABLE ADD COLUMN). This shifted every column from position 6 onward.
+--
+-- Old column order (via ALTER TABLE ADD COLUMN):
+--   id, name, api_type, base_url, api_key, is_active, created_at, updated_at,
+--   api_key_preview, models, max_concurrency, queue_timeout_ms, max_queue_size,
+--   adaptive_enabled, adaptive_min
+--
+-- New column order (035):
+--   id, name, api_type, base_url, api_key, api_key_preview, models, is_active,
+--   max_concurrency, queue_timeout_ms, max_queue_size, adaptive_enabled,
+--   adaptive_min, created_at, updated_at
+--
+-- Positional mapping of what actually went where:
+--   old(6) is_active            → new api_key_preview
+--   old(7) created_at           → new models
+--   old(8) updated_at           → new is_active
+--   old(9) api_key_preview      → new max_concurrency  ← visible bug
+--   old(10) models              → new queue_timeout_ms
+--   old(11) max_concurrency     → new max_queue_size
+--   old(12) queue_timeout_ms    → new adaptive_enabled
+--   old(13) max_queue_size      → new adaptive_min
+--   old(14) adaptive_enabled    → new created_at
+--   old(15) adaptive_min        → new updated_at
+--
+-- This migration reverses the shift with explicit column mapping.
+
+-- Step 1: Save referencing table data
+CREATE TABLE IF NOT EXISTS _tmp_m036_model_info AS SELECT * FROM provider_model_info;
+CREATE TABLE IF NOT EXISTS _tmp_m036_transform_rules AS SELECT * FROM provider_transform_rules;
+
+-- Step 2: Drop referencing tables
+DROP TABLE IF EXISTS provider_model_info;
+DROP TABLE IF EXISTS provider_transform_rules;
+
+-- Step 3: Recreate providers with corrected data
+-- Each column reads from the position where the OLD value actually ended up
+CREATE TABLE providers_fixed (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL UNIQUE,
+  api_type TEXT NOT NULL CHECK(api_type IN ('openai', 'openai-responses', 'anthropic')),
+  base_url TEXT NOT NULL,
+  api_key TEXT NOT NULL,
+  api_key_preview TEXT,
+  models TEXT NOT NULL DEFAULT '[]',
+  is_active INTEGER NOT NULL DEFAULT 1,
+  max_concurrency INTEGER NOT NULL DEFAULT 0,
+  queue_timeout_ms INTEGER NOT NULL DEFAULT 0,
+  max_queue_size INTEGER NOT NULL DEFAULT 100,
+  adaptive_enabled INTEGER NOT NULL DEFAULT 0,
+  adaptive_min INTEGER NOT NULL DEFAULT 1,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+INSERT INTO providers_fixed
+SELECT
+  id,                                     -- id (correct position)
+  name,                                   -- name (correct position)
+  api_type,                               -- api_type (correct position)
+  base_url,                               -- base_url (correct position)
+  api_key,                                -- api_key (correct position)
+  -- api_key_preview: old(9) api_key_preview ended up in max_concurrency
+  max_concurrency AS api_key_preview,
+  -- models: old(10) models ended up in queue_timeout_ms
+  queue_timeout_ms AS models,
+  -- is_active: old(6) is_active ended up in api_key_preview
+  CAST(api_key_preview AS INTEGER) AS is_active,
+  -- max_concurrency: old(11) max_concurrency ended up in max_queue_size
+  CAST(max_queue_size AS INTEGER) AS max_concurrency,
+  -- queue_timeout_ms: old(12) queue_timeout_ms ended up in adaptive_enabled
+  CAST(adaptive_enabled AS INTEGER) AS queue_timeout_ms,
+  -- max_queue_size: old(13) max_queue_size ended up in adaptive_min
+  CAST(adaptive_min AS INTEGER) AS max_queue_size,
+  -- adaptive_enabled: old(14) adaptive_enabled ended up in created_at
+  CAST(created_at AS INTEGER) AS adaptive_enabled,
+  -- adaptive_min: old(15) adaptive_min ended up in updated_at
+  CAST(updated_at AS INTEGER) AS adaptive_min,
+  -- created_at: old(7) created_at ended up in models
+  models AS created_at,
+  -- updated_at: old(8) updated_at ended up in is_active
+  is_active AS updated_at
+FROM providers;
+
+-- Step 4: Swap tables
+DROP TABLE providers;
+ALTER TABLE providers_fixed RENAME TO providers;
+
+-- Step 5: Recreate referencing tables
+CREATE TABLE provider_model_info (
+  provider_id TEXT NOT NULL,
+  model_name TEXT NOT NULL,
+  context_window INTEGER NOT NULL,
+  PRIMARY KEY (provider_id, model_name),
+  FOREIGN KEY (provider_id) REFERENCES providers(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS provider_transform_rules (
+  provider_id TEXT PRIMARY KEY REFERENCES providers(id) ON DELETE CASCADE,
+  inject_headers TEXT,
+  request_defaults TEXT,
+  drop_fields TEXT,
+  field_overrides TEXT,
+  plugin_name TEXT,
+  is_active INTEGER DEFAULT 1,
+  created_at TEXT DEFAULT (datetime('now')),
+  updated_at TEXT DEFAULT (datetime('now'))
+);
+
+-- Step 6: Restore referencing data
+INSERT INTO provider_model_info SELECT * FROM _tmp_m036_model_info;
+INSERT OR IGNORE INTO provider_transform_rules SELECT * FROM _tmp_m036_transform_rules;
+
+-- Step 7: Cleanup
+DROP TABLE _tmp_m036_model_info;
+DROP TABLE _tmp_m036_transform_rules;

--- a/src/db/migrations/036_fix_035_data_corruption.sql
+++ b/src/db/migrations/036_fix_035_data_corruption.sql
@@ -26,94 +26,29 @@
 --   old(14) adaptive_enabled    → new created_at
 --   old(15) adaptive_min        → new updated_at
 --
--- This migration reverses the shift with explicit column mapping.
+-- Guard: only fixes rows where max_concurrency contains text data
+-- (api_key_preview leaked into an INTEGER column). Providers created after
+-- 035 have correct INTEGER values and are not affected.
 
--- Step 1: Save referencing table data
-CREATE TABLE IF NOT EXISTS _tmp_m036_model_info AS SELECT * FROM provider_model_info;
-CREATE TABLE IF NOT EXISTS _tmp_m036_transform_rules AS SELECT * FROM provider_transform_rules;
+-- Step 1: Snapshot current data before fixing
+CREATE TABLE _m036_snapshot AS SELECT rowid, * FROM providers;
 
--- Step 2: Drop referencing tables
-DROP TABLE IF EXISTS provider_model_info;
-DROP TABLE IF EXISTS provider_transform_rules;
+-- Step 2: Only fix rows where max_concurrency is text (corrupted by api_key_preview).
+-- Each column reads from the snapshot position where the OLD value actually ended up.
+UPDATE providers SET
+  api_key_preview  = (SELECT max_concurrency   FROM _m036_snapshot s WHERE s.rowid = providers.rowid),
+  models           = (SELECT queue_timeout_ms  FROM _m036_snapshot s WHERE s.rowid = providers.rowid),
+  is_active        = (SELECT CAST(api_key_preview  AS INTEGER) FROM _m036_snapshot s WHERE s.rowid = providers.rowid),
+  max_concurrency  = (SELECT CAST(max_queue_size   AS INTEGER) FROM _m036_snapshot s WHERE s.rowid = providers.rowid),
+  queue_timeout_ms = (SELECT CAST(adaptive_enabled AS INTEGER) FROM _m036_snapshot s WHERE s.rowid = providers.rowid),
+  max_queue_size   = (SELECT CAST(adaptive_min     AS INTEGER) FROM _m036_snapshot s WHERE s.rowid = providers.rowid),
+  adaptive_enabled = (SELECT CAST(created_at      AS INTEGER) FROM _m036_snapshot s WHERE s.rowid = providers.rowid),
+  adaptive_min     = (SELECT CAST(updated_at      AS INTEGER) FROM _m036_snapshot s WHERE s.rowid = providers.rowid),
+  created_at       = (SELECT models    FROM _m036_snapshot s WHERE s.rowid = providers.rowid),
+  updated_at       = (SELECT is_active FROM _m036_snapshot s WHERE s.rowid = providers.rowid)
+WHERE typeof((
+  SELECT max_concurrency FROM _m036_snapshot s WHERE s.rowid = providers.rowid
+)) = 'text';
 
--- Step 3: Recreate providers with corrected data
--- Each column reads from the position where the OLD value actually ended up
-CREATE TABLE providers_fixed (
-  id TEXT PRIMARY KEY,
-  name TEXT NOT NULL UNIQUE,
-  api_type TEXT NOT NULL CHECK(api_type IN ('openai', 'openai-responses', 'anthropic')),
-  base_url TEXT NOT NULL,
-  api_key TEXT NOT NULL,
-  api_key_preview TEXT,
-  models TEXT NOT NULL DEFAULT '[]',
-  is_active INTEGER NOT NULL DEFAULT 1,
-  max_concurrency INTEGER NOT NULL DEFAULT 0,
-  queue_timeout_ms INTEGER NOT NULL DEFAULT 0,
-  max_queue_size INTEGER NOT NULL DEFAULT 100,
-  adaptive_enabled INTEGER NOT NULL DEFAULT 0,
-  adaptive_min INTEGER NOT NULL DEFAULT 1,
-  created_at TEXT NOT NULL,
-  updated_at TEXT NOT NULL
-);
-
-INSERT INTO providers_fixed
-SELECT
-  id,                                     -- id (correct position)
-  name,                                   -- name (correct position)
-  api_type,                               -- api_type (correct position)
-  base_url,                               -- base_url (correct position)
-  api_key,                                -- api_key (correct position)
-  -- api_key_preview: old(9) api_key_preview ended up in max_concurrency
-  max_concurrency AS api_key_preview,
-  -- models: old(10) models ended up in queue_timeout_ms
-  queue_timeout_ms AS models,
-  -- is_active: old(6) is_active ended up in api_key_preview
-  CAST(api_key_preview AS INTEGER) AS is_active,
-  -- max_concurrency: old(11) max_concurrency ended up in max_queue_size
-  CAST(max_queue_size AS INTEGER) AS max_concurrency,
-  -- queue_timeout_ms: old(12) queue_timeout_ms ended up in adaptive_enabled
-  CAST(adaptive_enabled AS INTEGER) AS queue_timeout_ms,
-  -- max_queue_size: old(13) max_queue_size ended up in adaptive_min
-  CAST(adaptive_min AS INTEGER) AS max_queue_size,
-  -- adaptive_enabled: old(14) adaptive_enabled ended up in created_at
-  CAST(created_at AS INTEGER) AS adaptive_enabled,
-  -- adaptive_min: old(15) adaptive_min ended up in updated_at
-  CAST(updated_at AS INTEGER) AS adaptive_min,
-  -- created_at: old(7) created_at ended up in models
-  models AS created_at,
-  -- updated_at: old(8) updated_at ended up in is_active
-  is_active AS updated_at
-FROM providers;
-
--- Step 4: Swap tables
-DROP TABLE providers;
-ALTER TABLE providers_fixed RENAME TO providers;
-
--- Step 5: Recreate referencing tables
-CREATE TABLE provider_model_info (
-  provider_id TEXT NOT NULL,
-  model_name TEXT NOT NULL,
-  context_window INTEGER NOT NULL,
-  PRIMARY KEY (provider_id, model_name),
-  FOREIGN KEY (provider_id) REFERENCES providers(id) ON DELETE CASCADE
-);
-
-CREATE TABLE IF NOT EXISTS provider_transform_rules (
-  provider_id TEXT PRIMARY KEY REFERENCES providers(id) ON DELETE CASCADE,
-  inject_headers TEXT,
-  request_defaults TEXT,
-  drop_fields TEXT,
-  field_overrides TEXT,
-  plugin_name TEXT,
-  is_active INTEGER DEFAULT 1,
-  created_at TEXT DEFAULT (datetime('now')),
-  updated_at TEXT DEFAULT (datetime('now'))
-);
-
--- Step 6: Restore referencing data
-INSERT INTO provider_model_info SELECT * FROM _tmp_m036_model_info;
-INSERT OR IGNORE INTO provider_transform_rules SELECT * FROM _tmp_m036_transform_rules;
-
--- Step 7: Cleanup
-DROP TABLE _tmp_m036_model_info;
-DROP TABLE _tmp_m036_transform_rules;
+-- Step 3: Cleanup
+DROP TABLE _m036_snapshot;

--- a/src/proxy/orchestration/semaphore.ts
+++ b/src/proxy/orchestration/semaphore.ts
@@ -65,6 +65,13 @@ export class ProviderSemaphoreManager {
 
     if (entry.current < 0) entry.current = 0;
 
+    // 当 maxConcurrency 降低时，将 current 限制在新的上限，
+    // 防止 current 停留在旧的高位，导致新请求始终进入队列、
+    // 且 release() 无法通过空队检查来递减 current（排队长驻）
+    if (entry.current > config.maxConcurrency) {
+      entry.current = config.maxConcurrency;
+    }
+
     while (
       entry.current < config.maxConcurrency &&
       entry.queue.length > 0

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -39,7 +39,7 @@ describe("initDatabase", () => {
       .prepare("SELECT name FROM migrations")
       .all() as { name: string }[];
 
-    expect(rows.length).toBe(37);
+    expect(rows.length).toBe(38);
     expect(rows[0].name).toBe("001_init.sql");
     expect(rows[1].name).toBe("002_add_request_response_body.sql");
     expect(rows[2].name).toBe("003_add_full_request_chain_log.sql");

--- a/tests/metrics.test.ts
+++ b/tests/metrics.test.ts
@@ -29,7 +29,7 @@ describe("request_metrics migration and insertMetrics", () => {
       .prepare("SELECT name FROM migrations")
       .all() as { name: string }[];
 
-    expect(rows).toHaveLength(37);
+    expect(rows).toHaveLength(38);
     expect(rows[5].name).toBe("006_create_request_metrics.sql");
     expect(rows[6].name).toBe("007_add_retry_fields.sql");
     expect(rows[7].name).toBe("008_create_router_keys.sql");


### PR DESCRIPTION
## 修复内容

### 1. 并发控制：请求进入队列后永不执行

**根因**：`ProviderSemaphoreManager.updateConfig()` 中当 `maxConcurrency` 被降低时（例如自适应控制器遇到 429 后从 10 降到 5），`entry.current` 未限制到新上限，永远停留在旧值。

**效果**：新请求始终进入队列，`release()` 维持 `current` 不降，队列永久排空不了。

**修复**：在 `updateConfig()` 中 cap `entry.current` 到 `config.maxConcurrency`。

### 2. DB 数据错乱：并发度展示显示 API Key

**根因**：迁移 035 的 `INSERT INTO providers_new SELECT * FROM providers` 按位置匹配列，但新旧表列顺序不同，导致第 6 列开始全部错位。`api_key_preview` 的值进入了 `max_concurrency` 字段。

**修复**：
- 035 迁移改用显式列名
- 新增 036 迁移修复已有数据

详见各 commit 正文。