### PR TITLE
feat: version-based recommended config upgrade check

### DIFF
--- a/config/version.json
+++ b/config/version.json
@@ -1,0 +1,4 @@
+{
+  "providers": 1,
+  "retryRules": 1
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "llm-simple-router",
-  "version": "0.9.2",
+  "version": "0.9.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "llm-simple-router",
-      "version": "0.9.2",
+      "version": "0.9.4",
       "license": "MIT",
       "dependencies": {
         "@fastify/cookie": "^11.0.2",

--- a/src/admin/upgrade.ts
+++ b/src/admin/upgrade.ts
@@ -158,6 +158,9 @@ export const adminUpgradeRoutes: FastifyPluginCallback<UpgradeRoutesOptions> = (
       if (providersResult.status === 'rejected' && rulesResult.status === 'rejected') {
         throw new Error('同步失败: 无法获取 providers 和 retry-rules 配置')
       }
+      if (versionResult.status === 'rejected') {
+        process.stderr.write('[upgrade] warning: version.json sync failed, providers/rules synced without version\n')
+      }
       reloadConfig()
       if (checker) await checker.check(getConfigBaseUrl(source))
       return reply.send({ ok: true })

--- a/src/admin/upgrade.ts
+++ b/src/admin/upgrade.ts
@@ -141,15 +141,19 @@ export const adminUpgradeRoutes: FastifyPluginCallback<UpgradeRoutesOptions> = (
     const configDir = path.resolve(process.cwd(), 'config')
     try {
       fs.mkdirSync(configDir, { recursive: true })
-      const [providersResult, rulesResult] = await Promise.allSettled([
+      const [providersResult, rulesResult, versionResult] = await Promise.allSettled([
         fetchJson(`${base}/recommended-providers.json`),
         fetchJson(`${base}/recommended-retry-rules.json`),
+        fetchJson(`${base}/version.json`),
       ])
       if (providersResult.status === 'fulfilled') {
         fs.writeFileSync(path.join(configDir, 'recommended-providers.json'), JSON.stringify(providersResult.value, null, JSON_INDENT))
       }
       if (rulesResult.status === 'fulfilled') {
         fs.writeFileSync(path.join(configDir, 'recommended-retry-rules.json'), JSON.stringify(rulesResult.value, null, JSON_INDENT))
+      }
+      if (versionResult.status === 'fulfilled') {
+        fs.writeFileSync(path.join(configDir, 'version.json'), JSON.stringify(versionResult.value, null, JSON_INDENT))
       }
       if (providersResult.status === 'rejected' && rulesResult.status === 'rejected') {
         throw new Error('同步失败: 无法获取 providers 和 retry-rules 配置')

--- a/src/config/recommended.ts
+++ b/src/config/recommended.ts
@@ -25,6 +25,11 @@ export interface RecommendedRetryRule {
   providers?: string[]
 }
 
+export interface ConfigVersions {
+  providers: number
+  retryRules: number
+}
+
 let configDir = ''
 
 export function loadRecommendedConfig(dir?: string) {
@@ -42,6 +47,17 @@ export function getRecommendedRetryRules(): RecommendedRetryRule[] {
 // No-op: kept for backward compat (reload endpoint, upgrade flow)
 // Config is now always read from disk, no caching.
 export function reloadConfig() { /* no-op */ }
+
+/** 读取推荐配置的版本号（来自独立 version.json，历史版本代码不会读取此文件） */
+export function getConfigVersions(): ConfigVersions {
+  const filePath = path.join(configDir, 'version.json')
+  try {
+    if (!fs.existsSync(filePath)) return { providers: 0, retryRules: 0 }
+    return JSON.parse(fs.readFileSync(filePath, 'utf-8')) as ConfigVersions
+  } catch {
+    return { providers: 0, retryRules: 0 }
+  }
+}
 
 function loadJson<T>(filename: string): T {
   const filePath = path.join(configDir, filename)

--- a/src/upgrade/checker.ts
+++ b/src/upgrade/checker.ts
@@ -1,8 +1,8 @@
 import http from 'node:http'
 import https from 'node:https'
-import fs from 'node:fs'
 import path from 'node:path'
 import { getInstalledVersion } from './version.js'
+import { getConfigVersions } from '../config/recommended.js'
 
 export interface NpmStatus {
   hasUpdate: boolean
@@ -86,16 +86,6 @@ export function createUpgradeChecker(options?: CheckerOptions) {
   }
   let lastCheckedAt: string | null = null
 
-  function loadLocalJson(filename: string): unknown {
-    const filePath = path.join(configDir, filename)
-    try {
-      if (!fs.existsSync(filePath)) return null
-      return JSON.parse(fs.readFileSync(filePath, 'utf-8'))
-    } catch {
-      return null
-    }
-  }
-
   async function checkNpm(): Promise<void> {
     try {
       const data = await fetchJson(npmRegistryUrl) as { 'dist-tags'?: { latest?: string } }
@@ -113,20 +103,21 @@ export function createUpgradeChecker(options?: CheckerOptions) {
   async function checkConfig(sourceOverride?: string): Promise<void> {
     try {
       const base = sourceOverride ?? configBaseUrl
-      const [providersResult, rulesResult] = await Promise.allSettled([
-        fetchJson(`${base}/recommended-providers.json`),
-        fetchJson(`${base}/recommended-retry-rules.json`),
+      const [versionResult] = await Promise.allSettled([
+        fetchJson(`${base}/version.json`),
       ])
-      const remoteProviders = providersResult.status === 'fulfilled' ? providersResult.value : null
-      const remoteRules = rulesResult.status === 'fulfilled' ? rulesResult.value : null
-      if (!remoteProviders && !remoteRules) {
-        throw new Error('both providers and rules fetch failed')
-      }
-      const localProviders = loadLocalJson('recommended-providers.json')
-      const localRules = loadLocalJson('recommended-retry-rules.json')
 
-      const providersChanged = remoteProviders !== null && JSON.stringify(remoteProviders) !== JSON.stringify(localProviders)
-      const rulesChanged = remoteRules !== null && JSON.stringify(remoteRules) !== JSON.stringify(localRules)
+      // 远程无 version.json（老版本仓库）→ 视为无更新
+      if (versionResult.status !== 'fulfilled' || versionResult.value === null) {
+        configStatus = { hasUpdate: false, providerChanges: 0, retryRuleChanges: 0 }
+        return
+      }
+
+      const remote = versionResult.value as { providers?: number; retryRules?: number }
+      const local = getConfigVersions()
+
+      const providersChanged = (remote.providers ?? 0) > local.providers
+      const rulesChanged = (remote.retryRules ?? 0) > local.retryRules
 
       configStatus = {
         hasUpdate: providersChanged || rulesChanged,

--- a/src/upgrade/checker.ts
+++ b/src/upgrade/checker.ts
@@ -103,17 +103,13 @@ export function createUpgradeChecker(options?: CheckerOptions) {
   async function checkConfig(sourceOverride?: string): Promise<void> {
     try {
       const base = sourceOverride ?? configBaseUrl
-      const [versionResult] = await Promise.allSettled([
-        fetchJson(`${base}/version.json`),
-      ])
+      const remote = await fetchJson(`${base}/version.json`) as { providers?: number; retryRules?: number } | null
 
       // 远程无 version.json（老版本仓库）→ 视为无更新
-      if (versionResult.status !== 'fulfilled' || versionResult.value === null) {
+      if (remote === null) {
         configStatus = { hasUpdate: false, providerChanges: 0, retryRuleChanges: 0 }
         return
       }
-
-      const remote = versionResult.value as { providers?: number; retryRules?: number }
       const local = getConfigVersions()
 
       const providersChanged = (remote.providers ?? 0) > local.providers


### PR DESCRIPTION
## Summary

Replace `JSON.stringify` content comparison with version number comparison for recommended config update checking.

Uses a separate `version.json` file so existing JSON files (`recommended-providers.json`, `recommended-retry-rules.json`) remain as bare arrays — **fully backward compatible with older releases**.

## Changes

| File | Change |
|------|--------|
| `config/version.json` | New: `{"providers": 1, "retryRules": 1}` |
| `src/config/recommended.ts` | Add `ConfigVersions` interface + `getConfigVersions()` |
| `src/upgrade/checker.ts` | `checkConfig()` fetches remote `version.json`, compares version numbers; removes unused `loadLocalJson` |
| `src/admin/upgrade.ts` | `sync-config` endpoint also syncs `version.json` |

## Backward Compatibility

- **Old code ignores `version.json`** → no breakage
- **`recommended-providers.json` / `recommended-retry-rules.json` stay as bare arrays** → old code reads them unchanged
- **Remote repo without `version.json`** → treated as no update available (graceful fallback)

## How It Works

1. `checker.ts` fetches remote `version.json` and compares `{providers, retryRules}` version numbers against local
2. If remote version > local version → `hasUpdate: true`
3. When user clicks "sync config", `upgrade.ts` fetches all 3 files (providers, retry-rules, version.json) and writes them locally
4. Future config changes: just bump the version number in `version.json`

## Test Plan

- [x] TypeScript compilation passes (`npx tsc --noEmit`)
- [x] Server starts successfully
- [ ] Manual: deploy, trigger upgrade check, verify version comparison works
- [ ] Manual: sync config, verify `version.json` is written locally