### PR TITLE
fix: 修复推荐供应商配置 + 添加 upstream_path 自定义路径 + 统一快速配置样式

### DIFF
--- a/docs/provider/doc_url.json
+++ b/docs/provider/doc_url.json
@@ -7,9 +7,9 @@
     "urls": {
       "overview": "https://api-docs.deepseek.com/",
       "models": "https://api-docs.deepseek.com/quick_start/pricing",
-      "api_reference": "https://api-docs.deepseek.com/api/create-chat-completion",
+      "api_reference": "https://api-docs.deepseek.com/guides/anthropic_api",
       "pricing": "https://api-docs.deepseek.com/quick_start/pricing",
-      "integration": null,
+      "integration": "https://api-docs.deepseek.com/guides/coding_agents",
       "changelog": null
     },
     "pages": [],
@@ -51,7 +51,7 @@
     "group": "科大讯飞",
     "plan": "API",
     "apiType": "openai",
-    "baseUrl": "https://spark-api-open.xf-yun.com/v1",
+    "baseUrl": "https://spark-api-open.xf-yun.com",
     "urls": {
       "overview": "https://www.xfyun.cn/doc/spark/%E6%8E%A5%E5%8F%A3%E8%AF%B4%E6%98%8E.html",
       "models": "https://www.xfyun.cn/doc/spark/%E6%8E%A5%E5%8F%A3%E8%AF%B4%E6%98%8E.html",
@@ -67,7 +67,7 @@
     "group": "硅基流动",
     "plan": "API",
     "apiType": "openai",
-    "baseUrl": "https://api.siliconflow.cn/v1",
+    "baseUrl": "https://api.siliconflow.cn",
     "urls": {
       "overview": "https://docs.siliconflow.cn/",
       "models": "https://docs.siliconflow.cn/api-reference/models",
@@ -101,9 +101,9 @@
     "apiType": "anthropic",
     "baseUrl": "https://open.bigmodel.cn/api/anthropic",
     "urls": {
-      "overview": "https://open.bigmodel.cn/dev/api/anthropic",
+      "overview": "https://docs.bigmodel.cn/cn/guide/develop/claude",
       "models": "https://open.bigmodel.cn/dev/api/anthropic",
-      "api_reference": "https://open.bigmodel.cn/dev/api/anthropic",
+      "api_reference": "https://docs.bigmodel.cn/cn/guide/develop/claude",
       "pricing": "https://open.bigmodel.cn/pricing",
       "integration": null,
       "changelog": null
@@ -117,10 +117,10 @@
     "apiType": "openai",
     "baseUrl": "https://api.moonshot.cn",
     "urls": {
-      "overview": "https://platform.moonshot.cn/docs",
-      "models": "https://platform.moonshot.cn/docs/models",
-      "api_reference": "https://platform.moonshot.cn/docs/api/chat",
-      "pricing": "https://platform.moonshot.cn/docs/pricing/chat",
+      "overview": "https://platform.moonshot.ai/docs",
+      "models": "https://platform.moonshot.ai/docs/models",
+      "api_reference": "https://platform.moonshot.ai/docs/api/chat",
+      "pricing": "https://platform.moonshot.ai/docs/pricing/chat",
       "integration": null,
       "changelog": null
     },
@@ -133,10 +133,10 @@
     "apiType": "anthropic",
     "baseUrl": "https://api.kimi.com/coding",
     "urls": {
-      "overview": "https://platform.moonshot.cn/docs/coding",
-      "models": "https://platform.moonshot.cn/docs/coding",
-      "api_reference": "https://platform.moonshot.cn/docs/coding",
-      "pricing": "https://platform.moonshot.cn/docs/pricing/chat",
+      "overview": "https://platform.moonshot.ai/docs/coding",
+      "models": "https://platform.moonshot.ai/docs/coding",
+      "api_reference": "https://platform.moonshot.ai/docs/coding",
+      "pricing": "https://platform.moonshot.ai/docs/pricing/chat",
       "integration": null,
       "changelog": null
     },
@@ -151,7 +151,7 @@
     "urls": {
       "overview": "https://platform.minimaxi.com/docs/guides/models-intro",
       "models": "https://platform.minimaxi.com/docs/guides/models-intro",
-      "api_reference": "https://platform.minimaxi.com/docs/api-reference/api-overview",
+      "api_reference": "https://platform.minimaxi.com/docs/api-reference/text-openai-api",
       "pricing": "https://platform.minimaxi.com/docs/pricing/overview",
       "integration": null,
       "changelog": null
@@ -165,17 +165,34 @@
     "apiType": "anthropic",
     "baseUrl": "https://api.minimaxi.com/anthropic",
     "urls": {
-      "overview": "https://platform.minimaxi.com/docs/guides/models-intro",
+      "overview": "https://platform.minimaxi.com/docs/token-plan/intro",
       "models": null,
-      "api_reference": "https://platform.minimaxi.com/docs/api-reference/api-overview",
+      "api_reference": "https://platform.minimaxi.com/docs/api-reference/text-anthropic-api",
       "pricing": "https://platform.minimaxi.com/docs/pricing/overview",
       "integration": null,
       "changelog": null
     },
     "pages": [
-      { "id": "token-plan-intro", "url": "https://platform.minimaxi.com/docs/token-plan/intro", "purpose": "plan-overview" },
-      { "id": "token-plan-claude-code", "url": "https://platform.minimaxi.com/docs/token-plan/claude-code", "purpose": "integration" },
-      { "id": "token-plan-quickstart", "url": "https://platform.minimaxi.com/docs/token-plan/quickstart", "purpose": "models-list" }
+      {
+        "id": "token-plan-intro",
+        "url": "https://platform.minimaxi.com/docs/token-plan/intro",
+        "purpose": "plan-overview"
+      },
+      {
+        "id": "token-plan-claude-code",
+        "url": "https://platform.minimaxi.com/docs/token-plan/claude-code",
+        "purpose": "integration"
+      },
+      {
+        "id": "token-plan-quickstart",
+        "url": "https://platform.minimaxi.com/docs/token-plan/quickstart",
+        "purpose": "models-list"
+      },
+      {
+        "id": "coding-tools",
+        "url": "https://platform.minimaxi.com/docs/guides/text-ai-coding-tools",
+        "purpose": "integration"
+      }
     ],
     "note": "Token Plan (Anthropic 格式)；按 Token 计费；highspeed 版本模型需从 quickstart 页获取"
   },
@@ -199,11 +216,11 @@
     "group": "火山引擎",
     "plan": "Coding Plan",
     "apiType": "anthropic",
-    "baseUrl": "https://ark.cn-beijing.volces.com/api/compatible",
+    "baseUrl": "https://ark.cn-beijing.volces.com/api/coding",
     "urls": {
-      "overview": "https://www.volcengine.com/docs/82379/1399568",
+      "overview": "https://www.volcengine.com/article/37255",
       "models": "https://www.volcengine.com/docs/82379/1399568",
-      "api_reference": "https://www.volcengine.com/docs/82379/1399568",
+      "api_reference": "https://www.volcengine.com/article/37363",
       "pricing": "https://www.volcengine.com/docs/82379/1399568",
       "integration": null,
       "changelog": null
@@ -219,7 +236,7 @@
     "urls": {
       "overview": "https://help.aliyun.com/zh/model-studio/",
       "models": "https://help.aliyun.com/zh/model-studio/models",
-      "api_reference": "https://help.aliyun.com/zh/model-studio/developer-reference/use-qwen-by-calling-api",
+      "api_reference": "https://help.aliyun.com/zh/model-studio/compatibility-of-openai-with-dashscope",
       "pricing": "https://help.aliyun.com/zh/model-studio/models",
       "integration": null,
       "changelog": null
@@ -233,9 +250,9 @@
     "apiType": "anthropic",
     "baseUrl": "https://coding.dashscope.aliyuncs.com/apps/anthropic",
     "urls": {
-      "overview": "https://help.aliyun.com/zh/model-studio/coding-plan",
-      "models": "https://help.aliyun.com/zh/model-studio/coding-plan",
-      "api_reference": "https://help.aliyun.com/zh/model-studio/coding-plan",
+      "overview": "https://help.aliyun.com/zh/model-studio/other-tools-coding-plan",
+      "models": "https://help.aliyun.com/zh/model-studio/other-tools-coding-plan",
+      "api_reference": "https://help.aliyun.com/zh/model-studio/other-tools-coding-plan",
       "pricing": "https://help.aliyun.com/zh/model-studio/coding-plan",
       "integration": null,
       "changelog": null
@@ -251,7 +268,7 @@
     "urls": {
       "overview": "https://cloud.tencent.com/document/product/1729",
       "models": "https://cloud.tencent.com/document/product/1729",
-      "api_reference": "https://cloud.tencent.com/document/product/1729",
+      "api_reference": "https://cloud.tencent.com/document/product/1729/111007",
       "pricing": "https://cloud.tencent.com/document/product/1729/111033",
       "integration": null,
       "changelog": null
@@ -265,9 +282,9 @@
     "apiType": "anthropic",
     "baseUrl": "https://api.lkeap.cloud.tencent.com/coding/anthropic",
     "urls": {
-      "overview": "https://cloud.tencent.com/document/product/1772/128947",
+      "overview": "https://cloud.tencent.com/document/product/1823/130092",
       "models": "https://cloud.tencent.com/document/product/1772/128947",
-      "api_reference": "https://cloud.tencent.com/document/product/1772/128947",
+      "api_reference": "https://cloud.tencent.com/document/product/1772/130011",
       "pricing": "https://cloud.tencent.com/document/product/1772/128947",
       "integration": null,
       "changelog": null
@@ -283,7 +300,7 @@
     "urls": {
       "overview": "https://platform.stepfun.com/docs/zh/guides/models",
       "models": "https://platform.stepfun.com/docs/zh/guides/models",
-      "api_reference": "https://platform.stepfun.com/docs/zh/api/chat-completion",
+      "api_reference": "https://platform.stepfun.com/docs/zh/guides/developer/openai",
       "pricing": "https://platform.stepfun.com/docs/zh/guides/models",
       "integration": null,
       "changelog": null
@@ -297,14 +314,46 @@
     "apiType": "anthropic",
     "baseUrl": "https://api.stepfun.com/step_plan",
     "urls": {
-      "overview": "https://platform.stepfun.com/docs/zh/guides/models",
-      "models": "https://platform.stepfun.com/docs/zh/guides/models",
-      "api_reference": "https://platform.stepfun.com/docs/zh/guides/models",
-      "pricing": "https://platform.stepfun.com/docs/zh/guides/models",
-      "integration": null,
+      "overview": "https://platform.stepfun.com/docs/zh/step-plan/overview",
+      "models": "https://platform.stepfun.com/docs/zh/step-plan/overview",
+      "api_reference": "https://platform.stepfun.com/docs/zh/step-plan/integrations/reasoning-api",
+      "pricing": "https://platform.stepfun.com/step-plan",
+      "integration": "https://platform.stepfun.com/docs/zh/step-plan/integrations/reasoning-api",
       "changelog": null
     },
     "pages": [],
     "note": "Step Plan (Anthropic 格式)；面向编码场景"
+  },
+  "opencode-go-openai": {
+    "group": "OpenCode",
+    "plan": "Go OpenAI",
+    "apiType": "openai",
+    "baseUrl": "https://opencode.ai/zen/go/v1/chat/completions",
+    "urls": {
+      "overview": "https://opencode.ai/docs/zh-cn/go/",
+      "models": "https://opencode.ai/docs/zh-cn/go/",
+      "api_reference": "https://opencode.ai/docs/providers/",
+      "pricing": "https://opencode.ai/go",
+      "integration": null,
+      "changelog": null
+    },
+    "pages": [],
+    "note": "OpenCode Go OpenAI 兼容端点; base_url 末尾不含 /v1/chat/completions 因为路由需要完整路径"
+  },
+  "opencode-go-anthropic": {
+    "group": "OpenCode",
+    "plan": "Go Anthropic",
+    "apiType": "anthropic",
+    "baseUrl": "https://opencode.ai/zen/go/v1/messages",
+    "urls": {
+      "overview": "https://opencode.ai/docs/zh-cn/go/",
+      "models": "https://opencode.ai/docs/zh-cn/go/",
+      "api_reference": "https://opencode.ai/docs/providers/",
+      "pricing": "https://opencode.ai/go",
+      "integration": null,
+      "changelog": null
+    },
+    "pages": [],
+    "note": "OpenCode Go Anthropic 兼容端点; base_url 末尾不含 /v1/messages 因为路由需要完整路径"
   }
 }

--- a/docs/provider/doc_url.json
+++ b/docs/provider/doc_url.json
@@ -109,7 +109,8 @@
       "changelog": null
     },
     "pages": [],
-    "note": "Coding Plan (Anthropic 格式)；面向编码场景"
+    "note": "Coding Plan (Anthropic 格式)；面向编码场景",
+    "models": "https://docs.bigmodel.cn/cn/guide/develop/claude"
   },
   "kimi": {
     "group": "KIMI",
@@ -338,7 +339,7 @@
       "changelog": null
     },
     "pages": [],
-    "note": "OpenCode Go OpenAI 兼容端点; base_url 末尾不含 /v1/chat/completions 因为路由需要完整路径"
+    "note": "OpenCode Go OpenAI 兼容端点; baseUrl 已包含完整路径，buildUpstreamUrl 会自动检测后缀匹配不做二次追加"
   },
   "opencode-go-anthropic": {
     "group": "OpenCode",
@@ -354,6 +355,6 @@
       "changelog": null
     },
     "pages": [],
-    "note": "OpenCode Go Anthropic 兼容端点; base_url 末尾不含 /v1/messages 因为路由需要完整路径"
+    "note": "OpenCode Go Anthropic 兼容端点; baseUrl 已包含完整路径，buildUpstreamUrl 会自动检测后缀匹配不做二次追加"
   }
 }

--- a/docs/superpowers/plans/2026-05-03-upstream-path-config.md
+++ b/docs/superpowers/plans/2026-05-03-upstream-path-config.md
@@ -1,0 +1,711 @@
+# Upstream Path 配置 + 推荐供应商修复 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 为 provider 增加 `upstream_path` 可配置字段，解决百度千帆等非标准路径供应商的 URL 拼接问题；同时修复所有推荐供应商的 baseUrl 错误和 OpenCode Go 模型缺失。
+
+**Architecture:** 在 provider DB 表增加 `upstream_path` 可选字段（默认 NULL），路由器 proxy 时优先使用此字段替代硬编码的 `/v1/chat/completions` 或 `/v1/messages`。前端 QuickSetup 页面在 Base URL 旁增加可编辑的 Upstream Path 输入框，选择推荐预设时自动填充默认值。百度千帆等非标准供应商设置非默认的 `upstream_path`。
+
+**Tech Stack:** SQLite migration, Fastify/TypeBox, Vue 3 + shadcn-vue
+
+---
+
+## File Structure
+
+| Operation | File | Responsibility |
+|-----------|------|----------------|
+| Create | `router/src/db/migrations/038_add_upstream_path.sql` | DB migration: 添加 `upstream_path` 列 |
+| Modify | `router/src/db/providers.ts` | Provider interface + CRUD 支持 `upstream_path` |
+| Modify | `router/src/proxy/handler/proxy-handler.ts` | proxy 时使用 `provider.upstream_path` |
+| Modify | `router/src/proxy/proxy-core.ts` | `buildUpstreamUrl` 支持自定义 upstreamPath |
+| Modify | `router/src/proxy/transform/transform-coordinator.ts` | `getUpstreamPath` 支持外部覆盖 |
+| Modify | `router/src/admin/providers.ts` | provider CRUD API schema 支持 `upstream_path` |
+| Modify | `router/src/admin/quick-setup.ts` | quick-setup API schema 支持 `upstream_path` |
+| Modify | `router/config/recommended-providers.json` | 修复 baseUrl + 添加 upstreamPath + 更新模型 |
+| Modify | `router/src/config/recommended.ts` | ProviderPreset 接口添加 `upstreamPath` |
+| Modify | `frontend/src/types/mapping.ts` | Provider 类型添加 `upstream_path` |
+| Modify | `frontend/src/api/client.ts` | 前端 API 类型添加 `upstream_path` |
+| Modify | `frontend/src/composables/useQuickSetup.ts` | composable 支持 upstreamPath |
+| Modify | `frontend/src/views/QuickSetup.vue` | UI: 添加 Upstream Path 输入框 |
+| Modify | `frontend/src/views/Providers.vue` | Provider 编辑表单支持 upstream_path |
+| Modify | `docs/provider/doc_url.json` | 同步文档 URL |
+
+---
+
+### Task 1: DB Migration — 添加 `upstream_path` 列
+
+**Files:**
+- Create: `router/src/db/migrations/038_add_upstream_path.sql`
+
+- [ ] **Step 1: 创建 migration SQL**
+
+```sql
+-- Add upstream_path column to providers table.
+-- When NULL, the router uses the default path based on api_type:
+--   openai / openai-responses → /v1/chat/completions or /v1/responses
+--   anthropic → /v1/messages
+-- When set, this value overrides the default upstream path.
+
+ALTER TABLE providers ADD COLUMN upstream_path TEXT DEFAULT NULL;
+```
+
+- [ ] **Step 2: 验证 migration 被自动加载**
+
+Run: `cd router && grep -n "migrations" src/db/index.ts | head -5`
+
+确认 migration runner 会自动扫描 `migrations/` 目录按编号执行。
+
+---
+
+### Task 2: 后端 Provider 类型 + CRUD 支持 `upstream_path`
+
+**Files:**
+- Modify: `router/src/db/providers.ts`
+
+- [ ] **Step 1: Provider interface 添加 `upstream_path`**
+
+在 `Provider` interface 的 `base_url` 之后添加:
+
+```typescript
+export interface Provider {
+  id: string;
+  name: string;
+  api_type: "openai" | "openai-responses" | "anthropic";
+  base_url: string;
+  upstream_path: string | null;  // ← 新增
+  api_key: string;
+  // ... 其余不变
+}
+```
+
+- [ ] **Step 2: `PROVIDER_FIELDS` 添加 `"upstream_path"`**
+
+```typescript
+const PROVIDER_FIELDS = new Set([
+  "name", "api_type", "base_url", "upstream_path", "api_key", "api_key_preview", "models", "is_active", "max_concurrency", "queue_timeout_ms", "max_queue_size", "adaptive_enabled",
+]);
+```
+
+- [ ] **Step 3: `createProvider` 函数签名和 SQL 添加 `upstream_path`**
+
+`createProvider` 参数对象添加:
+```typescript
+upstream_path?: string | null;
+```
+
+INSERT SQL 改为:
+```sql
+INSERT INTO providers (id, name, api_type, base_url, upstream_path, api_key, api_key_preview, models, is_active, max_concurrency, queue_timeout_ms, max_queue_size, adaptive_enabled, created_at, updated_at)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+```
+
+对应的 `.run()` 参数在 `base_url` 之后添加 `provider.upstream_path ?? null`。
+
+- [ ] **Step 4: `updateProvider` 的 `Partial<Pick<Provider, ...>>` 联合类型添加 `"upstream_path"`**
+
+```typescript
+export function updateProvider(
+  db: Database.Database,
+  id: string,
+  fields: Partial<Pick<Provider, "name" | "api_type" | "base_url" | "upstream_path" | "api_key" | "api_key_preview" | "models" | "is_active" | "max_concurrency" | "queue_timeout_ms" | "max_queue_size" | "adaptive_enabled">>,
+): void {
+```
+
+- [ ] **Step 5: 验证编译**
+
+Run: `cd router && npx tsc --noEmit 2>&1 | grep "providers.ts" | head -5`
+
+---
+
+### Task 3: 后端 API Schema — providers 路由支持 `upstream_path`
+
+**Files:**
+- Modify: `router/src/admin/providers.ts`
+
+- [ ] **Step 1: Create schema 添加 `upstream_path` 可选字段**
+
+找到 `base_url: Type.String({ minLength: 1 })` 行，在其后添加:
+
+```typescript
+upstream_path: Type.Optional(Type.String({ minLength: 1 })),
+```
+
+- [ ] **Step 2: Update schema 添加 `upstream_path` 可选字段**
+
+找到 Update schema 中的 `base_url: Type.Optional(...)` 行，在其后添加:
+
+```typescript
+upstream_path: Type.Optional(Type.String({ minLength: 1 })),
+```
+
+- [ ] **Step 3: Create handler 传递 `upstream_path`**
+
+找到 `createProvider(db, {` 调用，在 `base_url: body.base_url,` 之后添加:
+
+```typescript
+upstream_path: body.upstream_path ?? null,
+```
+
+- [ ] **Step 4: Update handler 传递 `upstream_path`**
+
+找到 `if (body.base_url !== undefined) fields.base_url = body.base_url;` 行，在其后添加:
+
+```typescript
+if (body.upstream_path !== undefined) fields.upstream_path = body.upstream_path || null;
+```
+
+- [ ] **Step 5: 验证编译**
+
+Run: `cd router && npx tsc --noEmit 2>&1 | grep "providers.ts" | head -5`
+
+---
+
+### Task 4: 后端 API Schema — quick-setup 路由支持 `upstream_path`
+
+**Files:**
+- Modify: `router/src/admin/quick-setup.ts`
+
+- [ ] **Step 1: QuickSetupProviderSchema 添加 `upstream_path`**
+
+在 `base_url: Type.String({ minLength: 1 })` 之后添加:
+
+```typescript
+upstream_path: Type.Optional(Type.String({ minLength: 1 })),
+```
+
+- [ ] **Step 2: createProvider 调用传递 `upstream_path`**
+
+找到 `createProvider(db, {` 调用中的 `base_url: body.provider.base_url,` 行，在其后添加:
+
+```typescript
+upstream_path: body.provider.upstream_path ?? null,
+```
+
+- [ ] **Step 3: 验证编译**
+
+Run: `cd router && npx tsc --noEmit 2>&1 | grep "quick-setup" | head -5`
+
+---
+
+### Task 5: 推荐配置接口 — ProviderPreset 添加 `upstreamPath`
+
+**Files:**
+- Modify: `router/src/config/recommended.ts`
+
+- [ ] **Step 1: ProviderPreset interface 添加 `upstreamPath` 可选字段**
+
+```typescript
+export interface ProviderPreset {
+  plan: string
+  presetName: string
+  apiType: 'openai' | 'openai-responses' | 'anthropic'
+  baseUrl: string
+  upstreamPath?: string  // ← 新增，覆盖默认的 upstream path
+  models: string[]
+}
+```
+
+---
+
+### Task 6: 路由器 Proxy — 使用 `provider.upstream_path` 覆盖默认路径
+
+**Files:**
+- Modify: `router/src/proxy/proxy-core.ts`
+- Modify: `router/src/proxy/handler/proxy-handler.ts`
+
+- [ ] **Step 1: proxy-handler.ts — 在 `effectiveUpstreamPath` 计算之后注入自定义路径**
+
+找到以下代码段（约 line 300-307）:
+
+```typescript
+let effectiveUpstreamPath = upstreamPath;
+
+if (needsTransform) {
+  const transformed = coordinator.transformRequest(currentBody, apiType, provider.api_type, resolved.backend_model);
+  // 用转换后的结果替换 currentBody
+  currentBody = transformed.body as Record<string, unknown>;
+  effectiveUpstreamPath = transformed.upstreamPath;
+  effectiveApiType = provider.api_type;
+}
+```
+
+在 `if (needsTransform)` 块之后（约 line 308），添加自定义 upstream_path 覆盖逻辑:
+
+```typescript
+// Provider 自定义 upstream_path 覆盖默认路径（例如百度千帆 /chat/completions）
+if (provider.upstream_path) {
+  effectiveUpstreamPath = provider.upstream_path;
+}
+```
+
+- [ ] **Step 2: 验证编译**
+
+Run: `cd router && npx tsc --noEmit 2>&1 | grep "proxy-handler" | head -5`
+
+---
+
+### Task 7: 修复推荐配置 JSON — baseUrl + upstreamPath + 模型
+
+**Files:**
+- Modify: `router/config/recommended-providers.json`
+
+这是数据修复任务，需要修改以下供应商的配置：
+
+- [ ] **Step 1: 硅基流动 — 去掉 baseUrl 的 `/v1`**
+
+```
+baseUrl: "https://api.siliconflow.cn/v1" → "https://api.siliconflow.cn"
+```
+
+- [ ] **Step 2: 科大讯飞 — 去掉 baseUrl 的 `/v1`**
+
+```
+baseUrl: "https://spark-api-open.xf-yun.com/v1" → "https://spark-api-open.xf-yun.com"
+```
+
+- [ ] **Step 3: 阶跃星辰 API — 去掉 baseUrl 的 `/v1`**
+
+```
+baseUrl: "https://api.stepfun.com/v1" → "https://api.stepfun.com"
+```
+
+- [ ] **Step 4: 百度千帆 — 保持 baseUrl，添加 `upstreamPath: "/chat/completions"`**
+
+```
+baseUrl 保持 "https://qianfan.baidubce.com/v2"
+添加 upstreamPath: "/chat/completions"
+```
+
+因为路由器默认拼接 `/v1/chat/completions`，百度千帆的正确路径是 `/v2/chat/completions`。
+设置 `baseUrl = "https://qianfan.baidubce.com/v2"` + `upstreamPath = "/chat/completions"` → 最终 URL = `https://qianfan.baidubce.com/v2/chat/completions`。
+
+- [ ] **Step 5: OpenCode Go — 更新模型列表 + 修正 baseUrl**
+
+当前 baseUrl `https://opencode.ai/zen/go/v1/chat/completions` 虽然能工作（buildUpstreamUrl 去重），但不符合常规做法。改为标准形式：
+
+Go OpenAI preset:
+```json
+{
+  "plan": "Go OpenAI",
+  "presetName": "opencode-go-openai",
+  "apiType": "openai",
+  "baseUrl": "https://opencode.ai/zen/go/v1/chat/completions",
+  "models": [
+    "glm-5.1", "glm-5",
+    "kimi-k2.5", "kimi-k2.6",
+    "deepseek-v4-pro", "deepseek-v4-flash",
+    "mimo-v2-pro", "mimo-v2-omni", "mimo-v2.5-pro", "mimo-v2.5",
+    "qwen3.6-plus", "qwen3.5-plus"
+  ]
+}
+```
+
+Go Anthropic preset:
+```json
+{
+  "plan": "Go Anthropic",
+  "presetName": "opencode-go-anthropic",
+  "apiType": "anthropic",
+  "baseUrl": "https://opencode.ai/zen/go/v1/messages",
+  "models": [
+    "minimax-m2.7", "minimax-m2.5"
+  ]
+}
+```
+
+- [ ] **Step 6: 用 python 脚本一次性执行所有 JSON 修改**
+
+```python
+import json
+
+with open('router/config/recommended-providers.json') as f:
+    data = json.load(f)
+
+for g in data:
+    # 硅基流动: 去掉 /v1
+    if g['group'] == '硅基流动':
+        for p in g['presets']:
+            if p['baseUrl'] == 'https://api.siliconflow.cn/v1':
+                p['baseUrl'] = 'https://api.siliconflow.cn'
+
+    # 科大讯飞: 去掉 /v1
+    if g['group'] == '科大讯飞':
+        for p in g['presets']:
+            if p['baseUrl'] == 'https://spark-api-open.xf-yun.com/v1':
+                p['baseUrl'] = 'https://spark-api-open.xf-yun.com'
+
+    # 阶跃星辰 API: 去掉 /v1
+    if g['group'] == '阶跃星辰':
+        for p in g['presets']:
+            if p['apiType'] == 'openai' and p['baseUrl'] == 'https://api.stepfun.com/v1':
+                p['baseUrl'] = 'https://api.stepfun.com'
+
+    # 百度千帆: 添加 upstreamPath
+    if g['group'] == '百度千帆':
+        for p in g['presets']:
+            p['upstreamPath'] = '/chat/completions'
+
+    # OpenCode: 更新模型
+    if g['group'] == 'OpenCode':
+        for p in g['presets']:
+            if p['presetName'] == 'opencode-go-openai':
+                p['models'] = [
+                    'glm-5.1', 'glm-5',
+                    'kimi-k2.5', 'kimi-k2.6',
+                    'deepseek-v4-pro', 'deepseek-v4-flash',
+                    'mimo-v2-pro', 'mimo-v2-omni', 'mimo-v2.5-pro', 'mimo-v2.5',
+                    'qwen3.6-plus', 'qwen3.5-plus',
+                ]
+            elif p['presetName'] == 'opencode-go-anthropic':
+                p['models'] = ['minimax-m2.7', 'minimax-m2.5']
+
+with open('router/config/recommended-providers.json', 'w') as f:
+    json.dump(data, f, indent=2, ensure_ascii=False)
+    f.write('\n')
+```
+
+- [ ] **Step 7: 验证 JSON 语法正确**
+
+Run: `python3 -c "import json; json.load(open('router/config/recommended-providers.json'))"` 
+
+---
+
+### Task 8: 前端类型 — 添加 `upstream_path` 支持
+
+**Files:**
+- Modify: `frontend/src/types/mapping.ts`
+- Modify: `frontend/src/api/client.ts`
+
+- [ ] **Step 1: `mapping.ts` — Provider interface 添加 `upstream_path`**
+
+```typescript
+export interface Provider {
+  id: string
+  name: string
+  api_type: string
+  base_url: string
+  upstream_path: string | null  // ← 新增
+  api_key: string
+  // ... 其余不变
+}
+```
+
+- [ ] **Step 2: `client.ts` — ProviderPreset 添加 `upstreamPath`**
+
+```typescript
+export interface ProviderPreset {
+  plan: string;
+  presetName: string;
+  apiType: "openai" | "openai-responses" | "anthropic";
+  baseUrl: string;
+  upstreamPath?: string;  // ← 新增
+  models: string[];
+}
+```
+
+- [ ] **Step 3: `client.ts` — QuickSetupPayload.provider 添加 `upstream_path`**
+
+在 `base_url: string` 之后添加:
+
+```typescript
+upstream_path?: string  // ← 新增
+```
+
+- [ ] **Step 4: `client.ts` — ProviderPayload 添加 `upstream_path`**
+
+在 `base_url: string` 之后添加:
+
+```typescript
+upstream_path?: string  // ← 新增
+```
+
+---
+
+### Task 9: 前端 Composable — `useQuickSetup.ts` 支持 upstreamPath
+
+**Files:**
+- Modify: `frontend/src/composables/useQuickSetup.ts`
+
+- [ ] **Step 1: 添加 `upstreamPath` 状态**
+
+在 `const customBaseUrl = ref('')` 之后添加:
+
+```typescript
+const customUpstreamPath = ref('')
+```
+
+- [ ] **Step 2: 添加 `upstreamPath` computed**
+
+在 `const baseUrl = computed(...)` 之后添加:
+
+```typescript
+const upstreamPath = computed(() => {
+  if (isCustomProvider.value) return customUpstreamPath.value
+  const preset = currentPreset.value
+  if (!preset) return ''
+  // 默认路径由 apiType 决定，只有非默认值才需要返回
+  const defaultPath = preset.apiType === 'anthropic' ? '/v1/messages'
+    : preset.apiType === 'openai-responses' ? '/v1/responses'
+    : '/v1/chat/completions'
+  if (preset.upstreamPath && preset.upstreamPath !== defaultPath) return preset.upstreamPath
+  return ''
+})
+```
+
+- [ ] **Step 3: `submit()` 中 payload 添加 `upstream_path`**
+
+在 `base_url: baseUrl.value,` 之后添加:
+
+```typescript
+upstream_path: upstreamPath.value || undefined,
+```
+
+- [ ] **Step 4: `onProviderChange` 中重置 `customUpstreamPath`**
+
+在 `customBaseUrl.value = ''` 之后添加:
+
+```typescript
+customUpstreamPath.value = ''
+```
+
+- [ ] **Step 5: return 中导出 `upstreamPath` 和 `customUpstreamPath`**
+
+在 return 对象中添加:
+
+```typescript
+upstreamPath, customUpstreamPath,
+```
+
+---
+
+### Task 10: 前端 UI — QuickSetup 页面添加 Upstream Path 输入框
+
+**Files:**
+- Modify: `frontend/src/views/QuickSetup.vue`
+
+- [ ] **Step 1: 在解构导入中添加 `upstreamPath, customUpstreamPath`**
+
+找到:
+```
+baseUrl, availablePlans, isNonOpenaiEndpoint,
+```
+在其后添加:
+```
+upstreamPath, customUpstreamPath,
+```
+
+- [ ] **Step 2: 在 Preset 模式的 Base URL 之后添加 Upstream Path 输入框**
+
+找到（约 line 97）:
+```html
+<Input :model-value="baseUrl" readonly class="font-mono md:text-xs h-7" />
+```
+
+在其 `</div>` 关闭标签之后（Base URL 的 `w-72` div 之后），添加:
+
+```html
+<!-- 非默认 upstream path（如百度千帆） -->
+<div v-if="upstreamPath" class="w-48 space-y-1">
+  <Label class="text-xs text-muted-foreground">Upstream Path</Label>
+  <Input :model-value="upstreamPath" readonly class="font-mono md:text-xs h-7" />
+</div>
+```
+
+- [ ] **Step 3: 在 Custom 模式的 Base URL 之后添加 Upstream Path 输入框**
+
+找到 customBaseUrl 的 Input 行，在其后（同一个 template #else 分支内），添加:
+
+```html
+<div class="w-48 space-y-1">
+  <Label class="text-xs text-muted-foreground">Upstream Path</Label>
+  <Input v-model="customUpstreamPath" placeholder="/v1/chat/completions" class="font-mono md:text-xs h-7" />
+</div>
+```
+
+---
+
+### Task 11: 前端 UI — Providers 页面支持 `upstream_path`
+
+**Files:**
+- Modify: `frontend/src/views/Providers.vue`
+
+- [ ] **Step 1: 表格列显示 `upstream_path`（可选，在 base_url 旁）**
+
+找到 `{{ p.base_url }}` 的 TableCell，在其后添加:
+
+```html
+<TableCell class="text-muted-foreground text-xs">{{ p.upstream_path || (p.api_type === 'anthropic' ? '/v1/messages' : '/v1/chat/completions') }}</TableCell>
+```
+
+同时更新 TableHead 部分，在 Base URL 表头之后添加:
+```html
+<TableHead class="text-xs">Path</TableHead>
+```
+
+- [ ] **Step 2: 编辑表单添加 `upstream_path` 字段**
+
+找到 `base_url` 的 Input 行（约 line 144），在其表单项之后添加:
+
+```html
+<div>
+  <Label class="text-xs">Upstream Path</Label>
+  <Input v-model="form.upstream_path" placeholder="默认: /v1/chat/completions 或 /v1/messages" class="mt-1 font-mono text-xs" />
+  <p class="text-xs text-muted-foreground mt-0.5">留空使用 API 类型默认路径</p>
+</div>
+```
+
+- [ ] **Step 3: `DEFAULT_FORM` 添加 `upstream_path`**
+
+找到 `DEFAULT_FORM` 定义，在 `base_url: ''` 之后添加:
+
+```typescript
+upstream_path: '' as string,
+```
+
+- [ ] **Step 4: `openEdit` 函数中从 provider 填充 `upstream_path`**
+
+找到 `form.value = { name: p.name,` 那个赋值块，在 `base_url: p.base_url,` 之后添加:
+
+```typescript
+upstream_path: p.upstream_path || '',
+```
+
+- [ ] **Step 5: `ProviderFormPayload` 类型和提交逻辑添加 `upstream_path`**
+
+找到 `type ProviderFormPayload = Pick<...>` 那行，在 `'base_url'` 之后添加 `'upstream_path'`:
+
+```typescript
+type ProviderFormPayload = Pick<ProviderPayload, 'name' | 'api_type' | 'base_url' | 'upstream_path' | 'models' | 'is_active' | ...>
+```
+
+在提交时 `base_url: form.value.base_url,` 之后添加:
+
+```typescript
+upstream_path: form.value.upstream_path || null,
+```
+
+---
+
+### Task 12: 更新 `doc_url.json` 同步 baseUrl 变更
+
+**Files:**
+- Modify: `docs/provider/doc_url.json`
+
+- [ ] **Step 1: 用 python 脚本同步 baseUrl 到 doc_url.json**
+
+```python
+import json
+
+with open('router/config/recommended-providers.json') as f:
+    providers = json.load(f)
+
+with open('docs/provider/doc_url.json') as f:
+    docs = json.load(f)
+
+# 同步 baseUrl 变更
+baseUrl_map = {}
+for g in providers:
+    for p in g['presets']:
+        if 'presetName' in p:
+            baseUrl_map[p['presetName']] = p['baseUrl']
+
+mapping = {
+    'siliconflow': 'siliconflow',
+    'iflytek-spark': 'iflytek-spark',
+    'stepfun': 'stepfun',
+    'qianfan': 'qianfan',
+    'opencode-go-openai': 'opencode-go-openai',
+    'opencode-go-anthropic': 'opencode-go-anthropic',
+}
+
+for doc_key, preset_name in mapping.items():
+    if doc_key in docs and preset_name in baseUrl_map:
+        docs[doc_key]['baseUrl'] = baseUrl_map[preset_name]
+        print(f"Updated {doc_key}: {baseUrl_map[preset_name]}")
+
+with open('docs/provider/doc_url.json', 'w') as f:
+    json.dump(docs, f, indent=2, ensure_ascii=False)
+    f.write('\n')
+```
+
+---
+
+### Task 13: 验证 + 构建 + 提交
+
+**Files:** 无新增
+
+- [ ] **Step 1: 编译 core 包**
+
+Run: `cd core && npm run build`
+
+- [ ] **Step 2: 编译 router 后端**
+
+Run: `cd router && npx tsc --noEmit`
+
+- [ ] **Step 3: 编译前端**
+
+Run: `cd frontend && npx vue-tsc --noEmit 2>&1 | tail -20`
+
+- [ ] **Step 4: 用 curl 验证百度千帆修复后的 URL 拼接**
+
+```bash
+# 模拟 buildUpstreamUrl("https://qianfan.baidubce.com/v2", "/chat/completions")
+# = "https://qianfan.baidubce.com/v2/chat/completions"
+curl -s -o /dev/null -w '%{http_code}' -X POST -H "Content-Type: application/json" \
+  -d '{"model":"test","messages":[{"role":"user","content":"hi"}]}' \
+  "https://qianfan.baidubce.com/v2/chat/completions"
+# Expected: 401
+```
+
+- [ ] **Step 5: 用 curl 验证其他修复的 baseUrl**
+
+```bash
+# 硅基流动: buildUpstreamUrl("https://api.siliconflow.cn", "/v1/chat/completions")
+# = "https://api.siliconflow.cn/v1/chat/completions"
+curl -s -o /dev/null -w '%{http_code}' -X POST -H "Content-Type: application/json" \
+  -d '{"model":"test"}' "https://api.siliconflow.cn/v1/chat/completions"
+# Expected: 401
+
+# 阶跃星辰: buildUpstreamUrl("https://api.stepfun.com", "/v1/chat/completions")
+# = "https://api.stepfun.com/v1/chat/completions"
+curl -s -o /dev/null -w '%{http_code}' -X POST -H "Content-Type: application/json" \
+  -d '{"model":"test"}' "https://api.stepfun.com/v1/chat/completions"
+# Expected: 401
+```
+
+- [ ] **Step 6: 提交所有修改**
+
+```bash
+git add router/src/db/migrations/038_add_upstream_path.sql \
+       router/src/db/providers.ts \
+       router/src/admin/providers.ts \
+       router/src/admin/quick-setup.ts \
+       router/src/config/recommended.ts \
+       router/src/proxy/handler/proxy-handler.ts \
+       router/config/recommended-providers.json \
+       frontend/src/types/mapping.ts \
+       frontend/src/api/client.ts \
+       frontend/src/composables/useQuickSetup.ts \
+       frontend/src/views/QuickSetup.vue \
+       frontend/src/views/Providers.vue \
+       docs/provider/doc_url.json
+
+# 使用 zcommit skill 提交
+```
+
+建议分为两个 commit:
+1. `feat: 为 provider 添加 upstream_path 自定义上游路径配置` (Task 1-6, 8-11)
+2. `fix: 修复推荐供应商 baseUrl 错误和模型缺失` (Task 7, 12)
+
+---
+
+## Self-Review Checklist
+
+- [x] **Spec coverage:** 每个需求都有对应 Task
+  - upstream_path 配置: Task 1-6, 8-11
+  - baseUrl 修复 (硅基流动/科大讯飞/阶跃星辰): Task 7
+  - 百度千帆特殊路径: Task 1-6 (upstream_path) + Task 7 (配置)
+  - OpenCode Go 模型更新: Task 7
+  - 前端 UI: Task 10-11
+- [x] **Placeholder scan:** 所有步骤都有完整代码，无 TBD/TODO
+- [x] **Type consistency:** `upstream_path` (snake_case, DB/API) / `upstreamPath` (camelCase, JSON/config/frontend) 命名一致

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -102,6 +102,7 @@ export interface ProviderPreset {
   presetName: string;
   apiType: "openai" | "openai-responses" | "anthropic";
   baseUrl: string;
+  upstreamPath?: string;
   models: string[];
 }
 
@@ -126,6 +127,7 @@ export interface ProviderPayload {
   name: string;
   api_type: string;
   base_url: string;
+  upstream_path?: string;
   api_key?: string;
   models?: Array<string | { name: string; context_window?: number; patches?: string[] }>;
   is_active: number;
@@ -174,6 +176,7 @@ export interface QuickSetupPayload {
     name: string
     api_type: string
     base_url: string
+    upstream_path?: string
     api_key: string
     models: Array<{ name: string; context_window?: number; patches?: string[] }>
     concurrency_mode?: 'auto' | 'manual' | 'none'

--- a/frontend/src/components/shared/ConcurrencyControl.vue
+++ b/frontend/src/components/shared/ConcurrencyControl.vue
@@ -32,14 +32,14 @@ const emit = defineEmits<{
 </script>
 
 <template>
-  <div :class="compact ? 'space-y-2' : 'flex items-end gap-3 flex-wrap'">
+  <div :class="compact ? 'space-y-2' : 'flex items-end gap-2 flex-wrap'">
     <div :class="compact ? '' : 'w-36'" class="space-y-1">
       <Label class="text-xs text-muted-foreground">{{ t('providers.concurrency.mode') }}</Label>
       <Select
         :model-value="mode"
         @update:model-value="(v: unknown) => emit('update:mode', v as ConcurrencyMode)"
       >
-        <SelectTrigger>
+        <SelectTrigger class="w-full text-xs data-[size=default]:h-7">
           <SelectValue />
         </SelectTrigger>
         <SelectContent>
@@ -55,6 +55,7 @@ const emit = defineEmits<{
         <Input
           :model-value="maxConcurrency"
           type="number" min="1" max="100"
+          class="text-xs md:text-xs md:text-xs h-7"
           @update:model-value="emit('update:maxConcurrency', Number($event))"
         />
       </div>
@@ -64,6 +65,7 @@ const emit = defineEmits<{
           :model-value="queueTimeoutMs"
           type="number" min="0"
           :placeholder="t('providers.shared.queueTimeoutPlaceholder')"
+          class="text-xs md:text-xs md:text-xs h-7"
           @update:model-value="emit('update:queueTimeoutMs', Number($event))"
         />
       </div>
@@ -72,6 +74,7 @@ const emit = defineEmits<{
         <Input
           :model-value="maxQueueSize"
           type="number" min="1" max="1000"
+          class="text-xs md:text-xs md:text-xs h-7"
           @update:model-value="emit('update:maxQueueSize', Number($event))"
         />
       </div>

--- a/frontend/src/components/shared/TransformRulesForm.vue
+++ b/frontend/src/components/shared/TransformRulesForm.vue
@@ -26,7 +26,7 @@ const { t } = useI18n()
       <Input
         :model-value="injectHeaders"
         placeholder='{"x-custom": "value"}'
-        class="mt-0.5 text-xs font-mono"
+        class="mt-0.5 md:text-xs font-mono"
         @update:model-value="emit('update:injectHeaders', $event as string)"
       />
     </div>
@@ -35,7 +35,7 @@ const { t } = useI18n()
       <Input
         :model-value="dropFields"
         placeholder="logprobs, frequency_penalty"
-        class="mt-0.5 text-xs font-mono"
+        class="mt-0.5 md:text-xs font-mono"
         @update:model-value="emit('update:dropFields', $event as string)"
       />
     </div>
@@ -44,7 +44,7 @@ const { t } = useI18n()
       <Input
         :model-value="requestDefaults"
         placeholder='{"max_tokens": 4096}'
-        class="mt-0.5 text-xs font-mono"
+        class="mt-0.5 md:text-xs font-mono"
         @update:model-value="emit('update:requestDefaults', $event as string)"
       />
     </div>

--- a/frontend/src/composables/useQuickSetup.ts
+++ b/frontend/src/composables/useQuickSetup.ts
@@ -25,7 +25,7 @@ const PROVIDER_NAME_MAP: Record<string, string> = {
   '火山引擎': 'volcengine',
   '阿里云': 'aliyun',
   '腾讯云': 'tencent',
-  'OpenCode Go': 'opencode-go',
+  'OpenCode': 'opencode',
   '阶跃星辰': 'stepfun',
 }
 
@@ -79,7 +79,18 @@ export function useQuickSetup() {
   })
 
   const customBaseUrl = ref('')
+  const customUpstreamPath = ref('')
   const baseUrl = computed(() => isCustomProvider.value ? customBaseUrl.value : (currentPreset.value?.baseUrl ?? ''))
+  const upstreamPath = computed(() => {
+    if (isCustomProvider.value) return customUpstreamPath.value
+    const preset = currentPreset.value
+    if (!preset) return ''
+    const defaultPath = preset.apiType === 'anthropic' ? '/v1/messages'
+      : preset.apiType === 'openai-responses' ? '/v1/responses'
+      : '/v1/chat/completions'
+    if (preset.upstreamPath && preset.upstreamPath !== defaultPath) return preset.upstreamPath
+    return ''
+  })
 
   const availablePlans = computed(() => {
     const group = providerGroups.value.find(g => g.group === selectedGroup.value)
@@ -276,6 +287,7 @@ export function useQuickSetup() {
     if (group === '__custom__') {
       apiType.value = 'openai'
       customBaseUrl.value = ''
+      customUpstreamPath.value = ''
       modelConfigs.value = []
     } else {
       const groupData = providerGroups.value.find(g => g.group === group)
@@ -410,6 +422,7 @@ export function useQuickSetup() {
             : `${toProviderName(selectedGroup.value)}-${toProviderName(selectedPlan.value)}`,
           api_type: apiType.value,
           base_url: baseUrl.value,
+          upstream_path: upstreamPath.value || undefined,
           api_key: apiKey.value.trim(),
           models: modelConfigs.value.map(m => ({
             name: m.name,
@@ -498,7 +511,7 @@ export function useQuickSetup() {
     apiType, apiKey, modelConfigs, mappingEntries,
     allRecommendedRules, recommendedRules,
     selectedRetryRules, saving, connectionStatus,
-    currentClient, currentPreset, baseUrl, customBaseUrl, isCustomProvider,
+    currentClient, currentPreset, baseUrl, customBaseUrl, upstreamPath, customUpstreamPath, isCustomProvider,
     availablePlans, isNonOpenaiEndpoint,
     concurrencyMode, maxConcurrency, queueTimeoutMs, maxQueueSize,
     transformInjectHeaders, transformDropFields, transformRequestDefaults,

--- a/frontend/src/types/mapping.ts
+++ b/frontend/src/types/mapping.ts
@@ -32,6 +32,7 @@ export interface Provider {
   name: string
   api_type: string
   base_url: string
+  upstream_path: string | null
   api_key: string
   models: ModelInfo[]
   is_active: number

--- a/frontend/src/views/Providers.vue
+++ b/frontend/src/views/Providers.vue
@@ -21,6 +21,7 @@
             <TableHead class="text-muted-foreground">{{ t('providers.tableHeaders.name') }}</TableHead>
             <TableHead class="text-muted-foreground">{{ t('providers.tableHeaders.type') }}</TableHead>
             <TableHead class="text-muted-foreground">{{ t('providers.tableHeaders.baseUrl') }}</TableHead>
+            <TableHead class="text-xs">Path</TableHead>
             <TableHead class="text-muted-foreground">{{ t('providers.tableHeaders.apiKey') }}</TableHead>
             <TableHead class="text-muted-foreground">{{ t('providers.tableHeaders.models') }}</TableHead>
             <TableHead class="text-muted-foreground">{{ t('providers.tableHeaders.concurrency') }}</TableHead>
@@ -35,6 +36,7 @@
               <Badge variant="secondary">{{ API_TYPE_LABELS[p.api_type] ?? p.api_type }}</Badge>
             </TableCell>
             <TableCell class="text-muted-foreground">{{ p.base_url }}</TableCell>
+            <TableCell class="text-muted-foreground text-xs">{{ p.upstream_path || (p.api_type === 'anthropic' ? '/v1/messages' : '/v1/chat/completions') }}</TableCell>
             <TableCell>
               <div class="flex items-center gap-1">
                 <span class="font-mono text-xs text-muted-foreground">{{ maskKey(p.api_key) }}</span>
@@ -79,7 +81,7 @@
             </TableCell>
           </TableRow>
           <TableRow v-if="providers.length === 0">
-            <TableCell colspan="8" class="text-center text-muted-foreground py-8">{{ t('providers.noProviders') }}</TableCell>
+            <TableCell colspan="9" class="text-center text-muted-foreground py-8">{{ t('providers.noProviders') }}</TableCell>
           </TableRow>
         </TableBody>
       </Table>
@@ -149,6 +151,12 @@
               <Input v-model="form.api_key" type="text" :required="!editingId" :placeholder="editingId ? t('providers.fields.apiKeyPlaceholder') : ''" class="mt-1" @input="delete errors.api_key" />
               <p v-if="errors.api_key" class="text-xs text-destructive mt-0.5">{{ errors.api_key }}</p>
             </div>
+          </div>
+          <!-- Upstream Path -->
+          <div>
+            <Label class="text-xs">Upstream Path</Label>
+            <Input v-model="form.upstream_path" placeholder="默认: /v1/chat/completions 或 /v1/messages" class="mt-1 font-mono text-xs" />
+            <p class="text-xs text-muted-foreground mt-0.5">留空使用 API 类型默认路径</p>
           </div>
 
           <!-- 可用模型 -->
@@ -296,7 +304,7 @@ const CONTEXT_WINDOW_OPTIONS = [
   { label: '1M', value: '1000000' },
 ] as const
 const API_TYPE_LABELS: Record<string, string> = { openai: 'OpenAI Chat Completions', 'openai-responses': 'OpenAI Responses', anthropic: 'Anthropic Messages' }
-const DEFAULT_FORM = { name: '', api_type: 'anthropic', base_url: '', api_key: '', models: [] as ModelInfo[], is_active: true, max_concurrency: DEFAULT_CONCURRENCY_AUTO, queue_timeout_ms: DEFAULT_QUEUE_TIMEOUT_MS, max_queue_size: DEFAULT_QUEUE_SIZE, adaptive_enabled: true }
+const DEFAULT_FORM = { name: '', api_type: 'anthropic', base_url: '', upstream_path: '' as string, api_key: '', models: [] as ModelInfo[], is_active: true, max_concurrency: DEFAULT_CONCURRENCY_AUTO, queue_timeout_ms: DEFAULT_QUEUE_TIMEOUT_MS, max_queue_size: DEFAULT_QUEUE_SIZE, adaptive_enabled: true }
 const modelInput = ref('')
 const modelContextWindow = ref(DEFAULT_CONTEXT_WINDOW)
 const contextWindowSelect = computed({
@@ -472,7 +480,7 @@ function openEdit(p: Provider) {
   } else {
     concurrencyMode.value = 'manual'
   }
-  form.value = { name: p.name, api_type: p.api_type, base_url: p.base_url, api_key: '', models: (p.models || []).map(m => ({ name: m.name, context_window: m.context_window ?? DEFAULT_CONTEXT_WINDOW, patches: m.patches ?? [] })), is_active: !!p.is_active, max_concurrency: concurrencyMode.value === 'none' ? DEFAULT_CONCURRENCY_AUTO : mc, queue_timeout_ms: p.queue_timeout_ms ?? DEFAULT_QUEUE_TIMEOUT_MS, max_queue_size: p.max_queue_size ?? DEFAULT_QUEUE_SIZE, adaptive_enabled: concurrencyMode.value === 'auto' }
+  form.value = { name: p.name, api_type: p.api_type, base_url: p.base_url, upstream_path: p.upstream_path || '', api_key: '', models: (p.models || []).map(m => ({ name: m.name, context_window: m.context_window ?? DEFAULT_CONTEXT_WINDOW, patches: m.patches ?? [] })), is_active: !!p.is_active, max_concurrency: concurrencyMode.value === 'none' ? DEFAULT_CONCURRENCY_AUTO : mc, queue_timeout_ms: p.queue_timeout_ms ?? DEFAULT_QUEUE_TIMEOUT_MS, max_queue_size: p.max_queue_size ?? DEFAULT_QUEUE_SIZE, adaptive_enabled: concurrencyMode.value === 'auto' }
   modelInput.value = ''
   modelContextWindow.value = DEFAULT_CONTEXT_WINDOW
   presetGroup.value = ''
@@ -482,13 +490,14 @@ function openEdit(p: Provider) {
   loadTransformRules(p.id)
 }
 
-type ProviderFormPayload = Pick<ProviderPayload, 'name' | 'api_type' | 'base_url' | 'models' | 'is_active' | 'max_concurrency' | 'queue_timeout_ms' | 'max_queue_size' | 'adaptive_enabled'> & { api_key?: string }
+type ProviderFormPayload = Pick<ProviderPayload, 'name' | 'api_type' | 'base_url' | 'upstream_path' | 'models' | 'is_active' | 'max_concurrency' | 'queue_timeout_ms' | 'max_queue_size' | 'adaptive_enabled'> & { api_key?: string }
 
 function buildPayload(): ProviderFormPayload {
   const payload: ProviderFormPayload = {
     name: form.value.name,
     api_type: form.value.api_type,
     base_url: form.value.base_url,
+    upstream_path: form.value.upstream_path || null,
     models: form.value.models.map(m => ({ name: m.name, context_window: m.context_window ?? undefined, patches: m.patches ?? undefined })),
     is_active: form.value.is_active ? 1 : 0,
     max_concurrency: concurrencyMode.value === 'none' ? 0 : form.value.max_concurrency,

--- a/frontend/src/views/QuickSetup.vue
+++ b/frontend/src/views/QuickSetup.vue
@@ -45,7 +45,7 @@
           <div class="w-40 space-y-1">
             <Label class="text-xs text-muted-foreground">{{ t('quickSetup.provider.label') }}</Label>
             <Select :model-value="selectedGroup" @update:model-value="(v: unknown) => onProviderChange(v as string)">
-              <SelectTrigger class="w-full"><SelectValue :placeholder="t('quickSetup.provider.select')" /></SelectTrigger>
+              <SelectTrigger class="w-full text-xs data-[size=default]:h-7"><SelectValue :placeholder="t('quickSetup.provider.select')" /></SelectTrigger>
               <SelectContent>
                 <SelectItem value="__custom__">{{ t('quickSetup.provider.custom') }}</SelectItem>
                 <SelectItem v-for="g in providerGroups" :key="g.group" :value="g.group">{{ g.group }}</SelectItem>
@@ -57,7 +57,7 @@
             <div class="w-48 space-y-1">
               <Label class="text-xs text-muted-foreground">{{ t('quickSetup.provider.format') }}</Label>
               <Select v-model="apiType">
-                <SelectTrigger class="w-full"><SelectValue /></SelectTrigger>
+                <SelectTrigger class="w-full text-xs data-[size=default]:h-7"><SelectValue /></SelectTrigger>
                 <SelectContent>
                   <SelectItem value="anthropic">Anthropic Messages</SelectItem>
                   <SelectItem value="openai">OpenAI Chat Completions</SelectItem>
@@ -67,7 +67,11 @@
             </div>
             <div class="w-80 space-y-1">
               <Label class="text-xs text-muted-foreground">Base URL</Label>
-              <Input v-model="customBaseUrl" placeholder="https://api.example.com/v1" class="font-mono text-xs" />
+              <Input v-model="customBaseUrl" placeholder="https://api.example.com/v1" class="font-mono md:text-xs h-7" />
+            </div>
+            <div class="w-48 space-y-1">
+              <Label class="text-xs text-muted-foreground">Upstream Path</Label>
+              <Input v-model="customUpstreamPath" placeholder="/v1/chat/completions" class="font-mono md:text-xs h-7" />
             </div>
           </template>
           <!-- Preset mode: show plan + readonly base url -->
@@ -75,7 +79,7 @@
             <div class="w-28 space-y-1">
               <Label class="text-xs text-muted-foreground">{{ t('quickSetup.provider.plan') }}</Label>
               <Select :model-value="selectedPlan" @update:model-value="(v: unknown) => onPlanChange(v as string)">
-                <SelectTrigger class="w-full"><SelectValue :placeholder="t('quickSetup.provider.select')" /></SelectTrigger>
+                <SelectTrigger class="w-full text-xs data-[size=default]:h-7"><SelectValue :placeholder="t('quickSetup.provider.select')" /></SelectTrigger>
                 <SelectContent>
                   <SelectItem v-for="p in availablePlans" :key="p.plan" :value="p.plan">{{ p.plan }}</SelectItem>
                 </SelectContent>
@@ -84,7 +88,7 @@
             <div class="w-48 space-y-1">
               <Label class="text-xs text-muted-foreground">{{ t('quickSetup.provider.format') }}</Label>
               <Select v-model="apiType">
-                <SelectTrigger class="w-full"><SelectValue /></SelectTrigger>
+                <SelectTrigger class="w-full text-xs data-[size=default]:h-7"><SelectValue /></SelectTrigger>
                 <SelectContent>
                   <SelectItem value="anthropic">Anthropic Messages</SelectItem>
                   <SelectItem value="openai">OpenAI Chat Completions</SelectItem>
@@ -94,12 +98,17 @@
             </div>
             <div class="w-72 space-y-1">
               <Label class="text-xs text-muted-foreground">Base URL</Label>
-              <Input :model-value="baseUrl" readonly class="font-mono text-xs" />
+              <Input :model-value="baseUrl" readonly class="font-mono md:text-xs h-7" />
+            </div>
+            <!-- 非默认 upstream path（如百度千帆） -->
+            <div v-if="upstreamPath" class="w-48 space-y-1">
+              <Label class="text-xs text-muted-foreground">Upstream Path</Label>
+              <Input :model-value="upstreamPath" readonly class="font-mono md:text-xs h-7" />
             </div>
           </template>
           <div class="w-64 space-y-1">
             <Label class="text-xs text-muted-foreground">{{ t('quickSetup.provider.apiKey') }}</Label>
-            <Input v-model="apiKey" type="password" :placeholder="t('quickSetup.provider.apiKeyPlaceholder')" />
+            <Input v-model="apiKey" type="password" :placeholder="t('quickSetup.provider.apiKeyPlaceholder')" class="md:text-xs h-7" />
           </div>
           <div class="shrink-0 space-y-1">
             <Label class="text-xs text-muted-foreground invisible">{{ t('quickSetup.provider.connect') }}</Label>
@@ -140,7 +149,7 @@
           </div>
           <!-- Custom mode: add model input -->
           <div v-if="isCustomProvider" class="flex gap-2 mt-2">
-            <Input v-model="customModelInput" :placeholder="t('quickSetup.model.namePlaceholder')" @keydown.enter.prevent="handleAddCustomModel" class="flex-1" />
+            <Input v-model="customModelInput" :placeholder="t('quickSetup.model.namePlaceholder')" @keydown.enter.prevent="handleAddCustomModel" class="flex-1 md:text-xs h-7" />
             <Button type="button" variant="outline" size="sm" @click="handleAddCustomModel" :disabled="!customModelInput.trim()">{{ t('common.add') }}</Button>
           </div>
         </div>
@@ -323,7 +332,7 @@ const {
   allRecommendedRules, recommendedRules,
   selectedRetryRules, saving, connectionStatus,
   baseUrl, availablePlans, isNonOpenaiEndpoint,
-  isCustomProvider, customBaseUrl,
+  isCustomProvider, customBaseUrl, upstreamPath, customUpstreamPath,
   concurrencyMode, maxConcurrency, queueTimeoutMs, maxQueueSize,
   allProviderGroups,
   transformInjectHeaders, transformDropFields, transformRequestDefaults,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1396,31 +1396,6 @@
         "@noble/ciphers": "^1.0.0"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmmirror.com/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmmirror.com/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmmirror.com/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -7557,50 +7532,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/esbuild": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmmirror.com/esbuild/-/esbuild-0.28.0.tgz",
-      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.28.0",
-        "@esbuild/android-arm": "0.28.0",
-        "@esbuild/android-arm64": "0.28.0",
-        "@esbuild/android-x64": "0.28.0",
-        "@esbuild/darwin-arm64": "0.28.0",
-        "@esbuild/darwin-x64": "0.28.0",
-        "@esbuild/freebsd-arm64": "0.28.0",
-        "@esbuild/freebsd-x64": "0.28.0",
-        "@esbuild/linux-arm": "0.28.0",
-        "@esbuild/linux-arm64": "0.28.0",
-        "@esbuild/linux-ia32": "0.28.0",
-        "@esbuild/linux-loong64": "0.28.0",
-        "@esbuild/linux-mips64el": "0.28.0",
-        "@esbuild/linux-ppc64": "0.28.0",
-        "@esbuild/linux-riscv64": "0.28.0",
-        "@esbuild/linux-s390x": "0.28.0",
-        "@esbuild/linux-x64": "0.28.0",
-        "@esbuild/netbsd-arm64": "0.28.0",
-        "@esbuild/netbsd-x64": "0.28.0",
-        "@esbuild/openbsd-arm64": "0.28.0",
-        "@esbuild/openbsd-x64": "0.28.0",
-        "@esbuild/openharmony-arm64": "0.28.0",
-        "@esbuild/sunos-x64": "0.28.0",
-        "@esbuild/win32-arm64": "0.28.0",
-        "@esbuild/win32-ia32": "0.28.0",
-        "@esbuild/win32-x64": "0.28.0"
       }
     },
     "node_modules/escalade": {
@@ -16050,7 +15981,7 @@
     },
     "router": {
       "name": "llm-simple-router",
-      "version": "0.9.6",
+      "version": "0.9.7",
       "license": "MIT",
       "dependencies": {
         "@fastify/cookie": "^11.0.2",

--- a/router/config/recommended-providers.json
+++ b/router/config/recommended-providers.json
@@ -41,7 +41,8 @@
           "ernie-x1-32k-preview",
           "deepseek-v3",
           "deepseek-r1"
-        ]
+        ],
+        "upstreamPath": "/chat/completions"
       }
     ]
   },
@@ -52,7 +53,7 @@
         "plan": "API",
         "presetName": "iflytek-spark",
         "apiType": "openai",
-        "baseUrl": "https://spark-api-open.xf-yun.com/v1",
+        "baseUrl": "https://spark-api-open.xf-yun.com",
         "models": [
           "4.0Ultra",
           "generalv3.5",
@@ -71,7 +72,7 @@
         "plan": "API",
         "presetName": "siliconflow",
         "apiType": "openai",
-        "baseUrl": "https://api.siliconflow.cn/v1",
+        "baseUrl": "https://api.siliconflow.cn",
         "models": [
           "deepseek-ai/DeepSeek-V3.2-Exp",
           "deepseek-ai/DeepSeek-R1",
@@ -178,7 +179,7 @@
         "plan": "Coding Plan",
         "presetName": "volcengine-coding-plan",
         "apiType": "anthropic",
-        "baseUrl": "https://ark.cn-beijing.volces.com/api/compatible",
+        "baseUrl": "https://ark.cn-beijing.volces.com/api/coding",
         "models": [
           "ark-code-latest",
           "doubao-seed-2.0-code",
@@ -267,16 +268,34 @@
     ]
   },
   {
-    "group": "OpenCode Go",
+    "group": "OpenCode",
     "presets": [
       {
-        "plan": "Go",
+        "plan": "Go OpenAI",
+        "presetName": "opencode-go-openai",
+        "apiType": "openai",
+        "baseUrl": "https://opencode.ai/zen/go/v1/chat/completions",
+        "models": [
+          "glm-5.1",
+          "glm-5",
+          "kimi-k2.5",
+          "kimi-k2.6",
+          "deepseek-v4-pro",
+          "deepseek-v4-flash",
+          "mimo-v2-pro",
+          "mimo-v2-omni",
+          "mimo-v2.5-pro",
+          "mimo-v2.5",
+          "qwen3.6-plus",
+          "qwen3.5-plus"
+        ]
+      },
+      {
+        "plan": "Go Anthropic",
         "presetName": "opencode-go-anthropic",
         "apiType": "anthropic",
         "baseUrl": "https://opencode.ai/zen/go/v1/messages",
         "models": [
-          "deepseek-v4-pro",
-          "deepseek-v4-flash",
           "minimax-m2.7",
           "minimax-m2.5"
         ]

--- a/router/package.json
+++ b/router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "llm-simple-router",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "LLM API proxy router with OpenAI/Anthropic support, model mapping, retry strategies, and admin dashboard",
   "license": "MIT",
   "author": "ZZzzswszzZZ",

--- a/router/src/admin/providers.ts
+++ b/router/src/admin/providers.ts
@@ -101,6 +101,7 @@ const CreateProviderSchema = Type.Object({
   name: Type.String({ minLength: 1 }),
   api_type: Type.Union([Type.Literal("openai"), Type.Literal("anthropic")]),
   base_url: Type.String({ minLength: 1 }),
+  upstream_path: Type.Optional(Type.String({ minLength: 1 })),
   api_key: Type.String({ minLength: 1 }),
   models: Type.Optional(Type.Array(Type.Union([
     Type.String(),
@@ -117,6 +118,7 @@ const UpdateProviderSchema = Type.Object({
   name: Type.Optional(Type.String({ minLength: 1 })),
   api_type: Type.Optional(Type.Union([Type.Literal("openai"), Type.Literal("anthropic")])),
   base_url: Type.Optional(Type.String({ minLength: 1 })),
+  upstream_path: Type.Optional(Type.String({ minLength: 1 })),
   api_key: Type.Optional(Type.String({ minLength: 1 })),
   models: Type.Optional(Type.Array(Type.Union([
     Type.String(),
@@ -182,6 +184,7 @@ export const adminProviderRoutes: FastifyPluginCallback<ProviderRoutesOptions> =
       name: body.name,
       api_type: body.api_type,
       base_url: body.base_url,
+      upstream_path: body.upstream_path ?? null,
       api_key: encryptedKey,
       api_key_preview: body.api_key.length > API_KEY_PREVIEW_MIN_LENGTH ? `${body.api_key.slice(0, API_KEY_PREVIEW_PREFIX_LEN)}...${body.api_key.slice(-API_KEY_PREVIEW_PREFIX_LEN)}` : "****",
       models: JSON.stringify(normalizedModels),
@@ -227,10 +230,11 @@ export const adminProviderRoutes: FastifyPluginCallback<ProviderRoutesOptions> =
     if (body.name !== undefined && !PROVIDER_NAME_RE.test(body.name)) {
       return reply.code(HTTP_BAD_REQUEST).send(apiError(API_CODE.VALIDATION_FAILED, "Provider 名称仅允许英文大小写字母、数字、横线和下划线"));
     }
-    const fields: Partial<Pick<Provider, 'name' | 'api_type' | 'base_url' | 'api_key' | 'api_key_preview' | 'models' | 'is_active' | 'max_concurrency' | 'queue_timeout_ms' | 'max_queue_size' | 'adaptive_enabled'>> = {};
+    const fields: Partial<Pick<Provider, 'name' | 'api_type' | 'base_url' | 'upstream_path' | 'api_key' | 'api_key_preview' | 'models' | 'is_active' | 'max_concurrency' | 'queue_timeout_ms' | 'max_queue_size' | 'adaptive_enabled'>> = {};
     if (body.name !== undefined) fields.name = body.name;
     if (body.api_type !== undefined) fields.api_type = body.api_type;
     if (body.base_url !== undefined) fields.base_url = body.base_url;
+    if (body.upstream_path !== undefined) fields.upstream_path = body.upstream_path || null;
     if (body.is_active !== undefined) fields.is_active = body.is_active;
     if (body.models !== undefined) {
       const { entries, overrides } = extractModelOverrides(body.models as ModelInput[]);

--- a/router/src/admin/quick-setup.ts
+++ b/router/src/admin/quick-setup.ts
@@ -22,6 +22,7 @@ const QuickSetupProviderSchema = Type.Object({
   name: Type.String({ minLength: 1 }),
   api_type: Type.Union([Type.Literal("openai"), Type.Literal("openai-responses"), Type.Literal("anthropic")]),
   base_url: Type.String({ minLength: 1 }),
+  upstream_path: Type.Optional(Type.String({ minLength: 1 })),
   api_key: Type.String({ minLength: 1 }),
   models: Type.Array(Type.Object({
     name: Type.String(),
@@ -115,6 +116,7 @@ export const adminQuickSetupRoutes: FastifyPluginCallback<QuickSetupRoutesOption
         name: body.provider.name,
         api_type: body.provider.api_type,
         base_url: body.provider.base_url,
+        upstream_path: body.provider.upstream_path ?? null,
         api_key: encryptedKey,
         api_key_preview: body.provider.api_key.length > API_KEY_PREVIEW_MIN_LENGTH
           ? `${body.provider.api_key.slice(0, API_KEY_PREVIEW_PREFIX_LEN)}...${body.provider.api_key.slice(-API_KEY_PREVIEW_PREFIX_LEN)}`

--- a/router/src/admin/upgrade.ts
+++ b/router/src/admin/upgrade.ts
@@ -10,8 +10,8 @@ import path from 'node:path'
 import { HTTP_BAD_REQUEST, HTTP_INTERNAL_ERROR } from '../core/constants.js'
 import { API_CODE, apiError } from './api-response.js'
 
-const GITHUB_CONFIG_BASE = 'https://raw.githubusercontent.com/zhushanwen321/llm-simple-router/main/config'
-const GITEE_CONFIG_BASE = 'https://gitee.com/zzzzswszzzz/llm-simple-router/raw/main/config'
+const GITHUB_CONFIG_BASE = 'https://raw.githubusercontent.com/zhushanwen321/llm-simple-router/main/router/config'
+const GITEE_CONFIG_BASE = 'https://gitee.com/zzzzswszzzz/llm-simple-router/raw/main/router/config'
 const CHECK_INTERVAL_MS = 60 * 60 * 1000 // eslint-disable-line no-magic-numbers
 const JSON_INDENT = 2
 

--- a/router/src/config/recommended.ts
+++ b/router/src/config/recommended.ts
@@ -6,6 +6,7 @@ export interface ProviderPreset {
   presetName: string
   apiType: 'openai' | 'openai-responses' | 'anthropic'
   baseUrl: string
+  upstreamPath?: string
   models: string[]
 }
 

--- a/router/src/db/migrations/038_add_upstream_path.sql
+++ b/router/src/db/migrations/038_add_upstream_path.sql
@@ -1,0 +1,7 @@
+-- Add upstream_path column to providers table.
+-- When NULL, the router uses the default path based on api_type:
+--   openai / openai-responses → /v1/chat/completions or /v1/responses
+--   anthropic → /v1/messages
+-- When set, this value overrides the default upstream path.
+
+ALTER TABLE providers ADD COLUMN upstream_path TEXT DEFAULT NULL;

--- a/router/src/db/providers.ts
+++ b/router/src/db/providers.ts
@@ -7,6 +7,7 @@ export interface Provider {
   name: string;
   api_type: "openai" | "openai-responses" | "anthropic";
   base_url: string;
+  upstream_path: string | null;
   api_key: string;
   api_key_preview?: string;
   models: string; // JSON 数组文本
@@ -26,7 +27,7 @@ export const PROVIDER_CONCURRENCY_DEFAULTS = {
 } as const;
 
 const PROVIDER_FIELDS = new Set([
-  "name", "api_type", "base_url", "api_key", "api_key_preview", "models", "is_active", "max_concurrency", "queue_timeout_ms", "max_queue_size", "adaptive_enabled",
+  "name", "api_type", "base_url", "upstream_path", "api_key", "api_key_preview", "models", "is_active", "max_concurrency", "queue_timeout_ms", "max_queue_size", "adaptive_enabled",
 ]);
 
 export function getActiveProviders(
@@ -52,6 +53,7 @@ export function createProvider(
     name: string;
     api_type: "openai" | "openai-responses" | "anthropic";
     base_url: string;
+    upstream_path?: string | null;
     api_key: string;
     api_key_preview?: string;
     models?: string;
@@ -65,10 +67,11 @@ export function createProvider(
   const id = randomUUID();
   const now = new Date().toISOString();
   db.prepare(
-    `INSERT INTO providers (id, name, api_type, base_url, api_key, api_key_preview, models, is_active, max_concurrency, queue_timeout_ms, max_queue_size, adaptive_enabled, created_at, updated_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    `INSERT INTO providers (id, name, api_type, base_url, upstream_path, api_key, api_key_preview, models, is_active, max_concurrency, queue_timeout_ms, max_queue_size, adaptive_enabled, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
     id, provider.name, provider.api_type, provider.base_url,
+    provider.upstream_path ?? null,
     provider.api_key, provider.api_key_preview ?? null,
     provider.models ?? "[]",
     provider.is_active ?? 1,
@@ -84,7 +87,7 @@ export function createProvider(
 export function updateProvider(
   db: Database.Database,
   id: string,
-  fields: Partial<Pick<Provider, "name" | "api_type" | "base_url" | "api_key" | "api_key_preview" | "models" | "is_active" | "max_concurrency" | "queue_timeout_ms" | "max_queue_size" | "adaptive_enabled">>,
+  fields: Partial<Pick<Provider, "name" | "api_type" | "base_url" | "upstream_path" | "api_key" | "api_key_preview" | "models" | "is_active" | "max_concurrency" | "queue_timeout_ms" | "max_queue_size" | "adaptive_enabled">>,
 ): void {
   buildUpdateQuery(db, "providers", id, fields, PROVIDER_FIELDS, { updatedAt: true });
 }

--- a/router/src/proxy/handler/proxy-handler.ts
+++ b/router/src/proxy/handler/proxy-handler.ts
@@ -307,6 +307,11 @@ async function executeFailoverLoop(ctx: FailoverContext): Promise<FastifyReply> 
       effectiveApiType = provider.api_type;
     }
 
+    // Provider 自定义 upstream_path 覆盖默认路径（例如百度千帆 /chat/completions）
+    if (provider.upstream_path) {
+      effectiveUpstreamPath = provider.upstream_path;
+    }
+
     // routing — 创建新对象而非 in-place mutation
     currentBody = { ...currentBody, model: resolved.backend_model };
     iterationSnapshot.add({ stage: "routing", client_model: effectiveModel, backend_model: resolved.backend_model, provider_id: resolved.provider_id, strategy: resolveResult.targetCount > 1 ? "failover" : "scheduled" });

--- a/router/src/upgrade/checker.ts
+++ b/router/src/upgrade/checker.ts
@@ -29,7 +29,7 @@ export interface CheckerOptions {
 }
 
 const DEFAULT_NPM_REGISTRY = 'https://registry.npmjs.org/llm-simple-router'
-const DEFAULT_GITHUB_CONFIG_BASE = 'https://raw.githubusercontent.com/zhushanwen321/llm-simple-router/main/config'
+const DEFAULT_GITHUB_CONFIG_BASE = 'https://raw.githubusercontent.com/zhushanwen321/llm-simple-router/main/router/config'
 const CHECK_TIMEOUT_MS = 5000
 const HTTP_STATUS_REDIRECT_LOWER = 300
 const HTTP_STATUS_REDIRECT_UPPER = 400

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,189 @@
+#!/bin/bash
+# release.sh — 合并 PR 分支到 main，升级版本，打 tag，推送，创建 GitHub Release
+#
+# 用法:
+#   ./scripts/release.sh [patch|minor|major]
+#   ./scripts/release.sh              # 默认 patch
+#   ./scripts/release.sh minor        # 升级中间位
+#
+# 前提:
+#   - 在 feature worktree 目录中执行（如 fix/quick-setup-providers/）
+#   - gh CLI 已安装并登录
+#   - 所有变更已 commit 并 push
+#
+# 流程:
+#   1. 自动检测当前分支和对应的 PR
+#   2. 在 main worktree 中 merge --no-ff
+#   3. 升级 router/package.json 版本号
+#   4. git tag + push
+#   5. 创建 GitHub Release（触发 CI npm publish）
+
+set -euo pipefail
+
+# ── 参数 ──────────────────────────────────────────────
+VERSION_TYPE="${1:-patch}"
+if [[ ! "$VERSION_TYPE" =~ ^(patch|minor|major)$ ]]; then
+  echo "Error: 版本类型必须是 patch|minor|major，收到: $VERSION_TYPE"
+  exit 1
+fi
+
+# ── 前置检查 ──────────────────────────────────────────
+command -v gh >/dev/null 2>&1 || { echo "Error: gh CLI 未安装"; exit 1; }
+gh auth status >/dev/null 2>&1 || { echo "Error: gh CLI 未登录"; exit 1; }
+
+# ── 定位 workspace ───────────────────────────────────
+# 当前 worktree 目录（feature 分支）
+WORKTREE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORKSPACE_ROOT="$(cd "$WORKTREE_DIR/.." && pwd)"
+BARE_DIR="$WORKSPACE_ROOT/.bare"
+
+if [[ ! -d "$BARE_DIR" ]]; then
+  echo "Error: 找不到 .bare/ 目录，请在 worktree 中运行此脚本"
+  exit 1
+fi
+
+# ── 当前分支信息 ─────────────────────────────────────
+cd "$WORKTREE_DIR"
+CURRENT_BRANCH=$(git branch --show-current)
+if [[ "$CURRENT_BRANCH" == "main" || -z "$CURRENT_BRANCH" ]]; then
+  echo "Error: 请在 feature 分支的 worktree 中运行此脚本，而不是 main"
+  exit 1
+fi
+
+# 检查未提交变更
+if ! git diff --quiet HEAD 2>/dev/null || ! git diff --cached --quiet 2>/dev/null; then
+  echo "Warning: 有未提交的变更，请先 commit"
+  git status --short
+  exit 1
+fi
+
+echo "当前分支: $CURRENT_BRANCH"
+echo "Workspace: $WORKSPACE_ROOT"
+echo "版本升级: $VERSION_TYPE"
+echo ""
+
+# ── 查找 PR ──────────────────────────────────────────
+PR_NUMBER=$(gh pr list --head "$CURRENT_BRANCH" --json number -q '.[0].number' 2>/dev/null || echo "")
+if [[ -z "$PR_NUMBER" ]]; then
+  echo "Error: 找不到分支 $CURRENT_BRANCH 对应的 PR"
+  echo "请先创建 PR: bash ~/.claude/skills/pr-worktree/pr-worktree.sh"
+  exit 1
+fi
+
+PR_TITLE=$(gh pr view "$PR_NUMBER" --json title -q '.title')
+echo "PR: #$PR_NUMBER — $PR_TITLE"
+echo ""
+
+# ── 定位 main worktree ────────────────────────────────
+MAIN_WORKTREE=""
+for wt_dir in "$WORKSPACE_ROOT"/*/; do
+  wt_name=$(basename "$wt_dir")
+  [[ "$wt_name" == "node_modules" ]] && continue
+  [[ -f "$wt_dir/.git" ]] || continue
+  wt_branch=$(git -C "$wt_dir" branch --show-current 2>/dev/null || echo "")
+  if [[ "$wt_branch" == "main" ]]; then
+    MAIN_WORKTREE="$wt_dir"
+    break
+  fi
+done
+
+if [[ -z "$MAIN_WORKTREE" ]]; then
+  echo "Error: 找不到 main 分支的 worktree"
+  exit 1
+fi
+
+echo "Main worktree: $MAIN_WORKTREE"
+echo ""
+
+# ── 步骤 1: Merge --no-ff ─────────────────────────────
+echo "=== 步骤 1/5: Merge --no-ff PR #$PR_NUMBER ==="
+
+cd "$MAIN_WORKTREE"
+git fetch origin "$CURRENT_BRANCH"
+git merge --no-ff "origin/$CURRENT_BRANCH" -m "Merge branch '$CURRENT_BRANCH' (PR #$PR_NUMBER): $PR_TITLE"
+
+echo "✅ 合并完成"
+echo ""
+
+# ── 步骤 2: 升级版本号 ────────────────────────────────
+echo "=== 步骤 2/5: 升级版本号 ==="
+
+PKG_FILE="$MAIN_WORKTREE/router/package.json"
+if [[ ! -f "$PKG_FILE" ]]; then
+  echo "Error: 找不到 $PKG_FILE"
+  exit 1
+fi
+
+OLD_VERSION=$(node -p "require('$PKG_FILE').version")
+
+# 检查最新 commit 是否已包含版本升级（幂等）
+LATEST_COMMIT_MSG=$(git log -1 --format=%s)
+if echo "$LATEST_COMMIT_MSG" | grep -qi "bump version"; then
+  echo "跳过：最新 commit 已包含版本升级"
+  NEW_VERSION="$OLD_VERSION"
+else
+  # 使用 npm version 升级（不自动 commit）
+  cd "$MAIN_WORKTREE/router"
+  npm version "$VERSION_TYPE" --no-git-tag-version --allow-same-version
+  cd "$MAIN_WORKTREE"
+  NEW_VERSION=$(node -p "require('$PKG_FILE').version")
+  echo "版本升级: $OLD_VERSION → $NEW_VERSION"
+fi
+echo ""
+
+# ── 步骤 3: 提交版本变更 + 打 tag ──────────────────────
+echo "=== 步骤 3/5: 提交 + 打 tag ==="
+
+TAG="v$NEW_VERSION"
+
+# 检查是否有变更需要提交
+if git diff --quiet HEAD 2>/dev/null; then
+  echo "无版本变更需要提交"
+else
+  git add router/package.json router/package-lock.json
+  git commit -m "chore: bump version to $NEW_VERSION"
+fi
+
+# 检查 tag 是否已存在
+if git tag -l "$TAG" | grep -q .; then
+  echo "Warning: Tag $TAG 已存在，跳过"
+else
+  git tag "$TAG"
+  echo "Tag: $TAG"
+fi
+echo ""
+
+# ── 步骤 4: Push ─────────────────────────────────────
+echo "=== 步骤 4/5: Push ==="
+git push origin main --tags
+echo "✅ 推送完成"
+echo ""
+
+# ── 步骤 5: 创建 GitHub Release ────────────────────────
+echo "=== 步骤 5/5: 创建 GitHub Release ==="
+
+# 检查 release 是否已存在
+EXISTING_RELEASE=$(gh release view "$TAG" 2>/dev/null && echo "exists" || echo "")
+if [[ "$EXISTING_RELEASE" == "exists" ]]; then
+  echo "Warning: Release $TAG 已存在，跳过"
+else
+  # 从 PR 获取 body 作为 release notes
+  PR_BODY=$(gh pr view "$PR_NUMBER" --json body -q '.body // ""' | head -100)
+  RELEASE_NOTES="## $TAG
+
+${PR_BODY:-$PR_TITLE}"
+
+  gh release create "$TAG" \
+    --title "$TAG" \
+    --target main \
+    --notes "$RELEASE_NOTES"
+  echo "✅ Release 创建成功"
+fi
+
+echo ""
+echo "============================================"
+echo "Release 完成!"
+echo "  PR: #$PR_NUMBER"
+echo "  版本: $TAG"
+echo "  Release: https://github.com/$(gh repo view --json nameWithOwner -q '.nameWithOwner')/releases/tag/$TAG"
+echo "============================================"


### PR DESCRIPTION
## 修复内容

### 1. Bug 修复：推荐配置同步 URL
- checker.ts / upgrade.ts 中 main/config → main/router/config（monorepo 重构后未更新）

### 2. Bug 修复：供应商 baseUrl 拼接错误
通过 POST 请求验证全部 20 个预设端点，确认以下问题：
- **硅基流动/科大讯飞/阶跃星辰**：baseUrl 包含 /v1，拼接后变成 /v1/v1/chat/completions → 404
- **百度千帆**：baseUrl /v2 + 默认 /v1/chat/completions → /v2/v1/chat/completions → 404
- **火山引擎 Coding Plan**：路径 api/compatible → api/coding

### 3. 新功能：upstream_path 自定义上游路径
- DB migration 添加 upstream_path 列（默认 NULL）
- 路由器 proxy 时优先使用 provider.upstream_path 覆盖默认路径
- 前端 QuickSetup 页面添加 Upstream Path 显示/编辑
- Providers 页面表格新增 Path 列 + 编辑表单支持

### 4. 数据修复：推荐供应商配置
- 修复 3 个供应商 baseUrl
- 百度千帆添加 upstreamPath: /chat/completions
- OpenCode Go 拆分为 Go OpenAI（12 模型）+ Go Anthropic（2 模型）
- 更新 14 个供应商的官方文档 URL

### 5. 样式修复：统一快速配置卡片
- SelectTrigger: data-[size=default]:h-7 text-xs（避免 size=sm 的 rounded-md 不匹配）
- Input: md:text-xs h-7（覆盖 md:text-sm 响应式变体）
- ConcurrencyControl: gap-3→gap-2, SelectTrigger 添加 w-full