### PR TITLE
fix: npm package 缺少 migrations SQL 文件

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
 
       - run: npm ci
       - run: cd core && npx tsc
-      - run: cd router && ../node_modules/.bin/tsc
+      - run: cd router && npm run build
       - run: npm run test -w core -w router
 
   docker:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -68,7 +68,7 @@ jobs:
         run: |
           npm ci
           cd core && npx tsc
-          cd ../router && ../node_modules/.bin/tsc
+          cd ../router && npm run build
           cd ../frontend && npm run build
 
       # ── 步骤 6: Publish @llm-router/core ─────────────

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
 
       - run: npm ci
       - run: cd core && npx tsc
-      - run: cd router && ../node_modules/.bin/tsc
+      - run: cd router && npm run build
       - run: cd frontend && npm run build
 
       # 复制运行时所需文件到打包目录

--- a/router/package.json
+++ b/router/package.json
@@ -26,7 +26,9 @@
     "start": "node dist/index.js",
     "test": "vitest run",
     "test:watch": "vitest",
-    "lint": "eslint . --max-warnings=0"
+    "lint": "eslint . --max-warnings=0",
+    "postbuild": "node -e \"require('fs').cpSync('src/db/migrations','dist/db/migrations',{recursive:true})\"",
+    "prepublishOnly": "npm run build:full"
   },
   "dependencies": {
     "@llm-router/core": "*",


### PR DESCRIPTION
## 问题

`npx llm-simple-router` 启动时报错：
```
Error: ENOENT: no such file or directory, scandir '.../llm-simple-router/dist/db/migrations'
```

原因是 `npm run build`（`tsc`）只编译 TypeScript，不会复制 `src/db/migrations/*.sql` 到 `dist/db/migrations/`，导致 npm 包缺少运行时必需的 migration 文件。

## 修复

| 文件 | 改动 |
|------|------|
| `router/package.json` | 添加 `postbuild`：tsc 后自动复制 migrations 到 dist |
| `router/package.json` | 添加 `prepublishOnly`：publish 前确保 `build:full`（含前端构建） |
| `.github/workflows/ci.yml` | router 构建改为 `npm run build` 以触发 postbuild |
| `.github/workflows/release.yml` | 同上 |
| `.github/workflows/publish.yml` | 同上 |

## 验证

- TypeScript 编译（core + router + pi-extension + frontend）：✅
- 942 个测试全部通过：✅
- `dist/db/migrations/` 包含 38 个 SQL 文件：✅