### PR TITLE
fix: normalize patch names (hyphen→underscore) to fix developer_role mismatch

### DIFF
--- a/router/src/config/model-context.ts
+++ b/router/src/config/model-context.ts
@@ -99,6 +99,11 @@ export function lookupContextWindow(modelName: string): number {
   return MODEL_CONTEXT_WINDOWS[modelName] ?? DEFAULT_CONTEXT_WINDOW
 }
 
+/** 标准化 patch 名称：连字符 → 下划线 */
+function normalizePatchName(name: string): string {
+  return name.replace(/-/g, "_")
+}
+
 export function parseModels(raw: string): ModelEntry[] {
   if (!raw) return []
   try {
@@ -112,7 +117,7 @@ export function parseModels(raw: string): ModelEntry[] {
       if (!obj || !obj.name) return null
       return {
         name: obj.name,
-        patches: obj.patches ?? [],
+        patches: (obj.patches ?? []).map(normalizePatchName),
       }
     }).filter((e): e is ModelEntry => e !== null)
   } catch {

--- a/router/tests/model-context.test.ts
+++ b/router/tests/model-context.test.ts
@@ -22,7 +22,7 @@ describe('model-context', () => {
   it('parseModels handles object[] format with patches', () => {
     const result = parseModels('[{"name":"glm-5","patches":["thinking-param"]},{"name":"deepseek-chat"}]')
     expect(result).toEqual([
-      { name: 'glm-5', patches: ['thinking-param'] },
+      { name: 'glm-5', patches: ['thinking_param'] },
       { name: 'deepseek-chat', patches: [] },
     ])
   })
@@ -40,11 +40,11 @@ describe('model-context', () => {
   it('buildModelInfoList enriches entries with overrides, defaults, and patches', () => {
     const overrides = new Map([['glm-5', 999000]])
     const result = buildModelInfoList([
-      { name: 'glm-5', patches: ['thinking-param'] },
+      { name: 'glm-5', patches: ['thinking_param'] },
       { name: 'unknown', patches: [] },
     ], overrides)
     expect(result).toEqual([
-      { name: 'glm-5', context_window: 999000, patches: ['thinking-param'] },
+      { name: 'glm-5', context_window: 999000, patches: ['thinking_param'] },
       { name: 'unknown', context_window: 200000, patches: [] },
     ])
   })


### PR DESCRIPTION
## 问题

请求 `openai-responses` → `openai` (chat completions) 格式转换后，`developer` role 未被转换为 `system`，导致 DeepSeek 等不支持 `developer` role 的 provider 返回 400 错误：

```
messages[1].role: unknown variant `developer`, expected one of `system`, `user`, `assistant`, `tool`, `latest_reminder`
```

## 根因

DB 中 provider models 的 patches 配置使用连字符格式（如 `"developer-role"`），但代码中 `applyProviderPatches()` 用 `includes("developer_role")` 匹配（下划线格式）。

由于 DB 驱动模式中其他 patch（`non-ds-tools`）匹配成功导致 **提前 return**，回退自动检测逻辑也永远执行不到。

## 修复

在 `parseModels()` 中添加 `normalizePatchName()` 函数，将所有 patch 名中的连字符标准化为下划线，使匹配对用户输入格式容错。

## 改动

- `router/src/config/model-context.ts` — 添加 `normalizePatchName()`，在 `parseModels()` 中调用
- `router/tests/model-context.test.ts` — 同步更新测试期望值