### PR TITLE
fix: 自适应并发控制两个盲区修复 — 信号量超时不可见 + stream_error 误过滤

### DIFF
--- a/core/src/concurrency/adaptive-controller.ts
+++ b/core/src/concurrency/adaptive-controller.ts
@@ -61,9 +61,9 @@ export class AdaptiveController {
     const entry = this.entries.get(providerId);
     if (!entry) return;
     if (result.success) {
-      this.transitionSuccess(providerId, entry);
+      this.transitionSuccess(providerId, entry, result);
     } else {
-      this.transitionFailure(providerId, entry, result.statusCode);
+      this.transitionFailure(providerId, entry, result);
     }
   }
 
@@ -98,7 +98,7 @@ export class AdaptiveController {
     }
   }
 
-  private transitionSuccess(providerId: string, entry: AdaptiveEntry): void {
+  private transitionSuccess(providerId: string, entry: AdaptiveEntry, result: AdaptiveResult): void {
     const s = entry.state;
     s.consecutiveSuccesses++;
     s.consecutiveFailures = 0;
@@ -108,23 +108,29 @@ export class AdaptiveController {
       if (!s.probeActive) {
         s.probeActive = true;
         s.consecutiveSuccesses = 0;
-        this.logger?.debug?.({ providerId, currentLimit: s.currentLimit, action: "probe_open" }, "Adaptive: probe window opened");
+        const effective = Math.min(Math.max(s.currentLimit + 1, ADAPTIVE_MIN), entry.max);
+        this.logger?.info?.({ providerId, requestId: result.requestId, prevLimit: s.currentLimit, newLimit: s.currentLimit, effectiveLimit: effective, action: "probe_open" }, "Adaptive: probe window opened");
       } else {
+        const prevLimit = s.currentLimit;
         s.currentLimit = Math.min(s.currentLimit + 1, entry.max);
         s.consecutiveSuccesses = 0;
-        this.logger?.debug?.({ providerId, currentLimit: s.currentLimit, max: entry.max, action: "limit_increased" }, "Adaptive: limit increased by 1");
+        const effective = Math.min(Math.max(s.currentLimit + 1, ADAPTIVE_MIN), entry.max);
+        this.logger?.info?.({ providerId, requestId: result.requestId, prevLimit, newLimit: s.currentLimit, effectiveLimit: effective, max: entry.max, action: "limit_increased" }, "Adaptive: limit increased by 1");
       }
       this.syncToSemaphore(providerId);
     }
   }
 
-  private transitionFailure(providerId: string, entry: AdaptiveEntry, statusCode?: number): void {
-    // 只对明确的并发相关错误做退避：
-    // - 429: 限流
-    // - 5xx: 服务端错误（可能过载）
-    // - undefined: 网络异常
-    // 2xx（如 upstream 200 body 含 error）和 4xx（客户端错误）不是并发问题，不触发退避
-    if (statusCode !== undefined && statusCode !== RATE_LIMIT_STATUS && statusCode < 500) {
+  private transitionFailure(providerId: string, entry: AdaptiveEntry, result: AdaptiveResult): void {
+    const statusCode = result.statusCode;
+    // 过滤非并发相关的错误：
+    // - retryRuleMatched=true → resilience 层根据重试规则判断为可重试的失败，计入退避
+    // - 429: 限流，计入退避
+    // - 5xx: 服务端错误（可能过载），计入退避
+    // - undefined: 网络异常，计入退避
+    // - 2xx/4xx 且 retryRuleMatched!=true: 非并发问题（如 upstream 200 body error 但未命中重试规则），不触发退避
+    if (!result.retryRuleMatched && statusCode !== undefined && statusCode !== RATE_LIMIT_STATUS && statusCode < 500) {
+      this.logger?.debug?.({ providerId, statusCode, action: "failure_ignored" }, "Adaptive: non-concurrency failure ignored");
       return;
     }
 
@@ -139,14 +145,14 @@ export class AdaptiveController {
       s.cooldownUntil = Date.now() + COOLDOWN_MS;
       s.consecutiveFailures = 0;
       this.syncToSemaphore(providerId);
-      this.logger?.warn?.({ providerId, prevLimit, newLimit: s.currentLimit, cooldownMs: COOLDOWN_MS, action: "rate_limit_backoff" }, "Adaptive: 429 rate limit, halved concurrency and entered cooldown");
+      this.logger?.warn?.({ providerId, requestId: result.requestId, prevLimit, newLimit: s.currentLimit, cooldownMs: COOLDOWN_MS, statusCode, action: "rate_limit_backoff" }, "Adaptive: 429 rate limit, halved concurrency and entered cooldown");
     } else if (s.consecutiveFailures >= FAILURE_THRESHOLD) {
       const prevLimit = s.currentLimit;
       s.currentLimit = Math.max(s.currentLimit - DECREASE_STEP, ADAPTIVE_MIN);
       s.probeActive = false;
       s.consecutiveFailures = 0;
       this.syncToSemaphore(providerId);
-      this.logger?.warn?.({ providerId, prevLimit, newLimit: s.currentLimit, action: "failure_backoff" }, "Adaptive: sustained failures, decreased concurrency");
+      this.logger?.warn?.({ providerId, requestId: result.requestId, prevLimit, newLimit: s.currentLimit, statusCode, retryRuleMatched: result.retryRuleMatched ?? false, action: "failure_backoff" }, "Adaptive: sustained failures, decreased concurrency");
     }
   }
 

--- a/core/src/concurrency/types.ts
+++ b/core/src/concurrency/types.ts
@@ -18,6 +18,10 @@ export interface AdaptiveState {
 export interface AdaptiveResult {
   success: boolean;
   statusCode?: number;
+  /** 重试规则是否匹配（resilience 层判断为可重试的失败），为 true 时忽略 statusCode 过滤 */
+  retryRuleMatched?: boolean;
+  /** 触发此反馈的请求日志 ID，用于日志关联 */
+  requestId?: string;
 }
 
 /** Abstraction for semaphore operations (decouples AdaptiveController). */

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -1,6 +1,7 @@
 /** Generic logger interface for core package decoupling from pino/fastify. */
 export interface Logger {
   debug?(obj: Record<string, unknown>, msg: string): void;
+  info?(obj: Record<string, unknown>, msg: string): void;
   warn?(obj: Record<string, unknown>, msg: string): void;
   error?(obj: Record<string, unknown>, msg: string): void;
 }

--- a/router/src/proxy/orchestration/orchestrator.ts
+++ b/router/src/proxy/orchestration/orchestrator.ts
@@ -11,6 +11,7 @@ import type { TrackerScope } from "./scope.js";
 import { TrackerScope as TrackerScopeClass } from "./scope.js";
 import type { ActiveRequest } from "@llm-router/core/monitor";
 import type { SemaphoreManager } from "@llm-router/core/concurrency";
+import { SemaphoreTimeoutError, SemaphoreQueueFullError } from "@llm-router/core";
 import type { RequestTracker } from "@llm-router/core/monitor";
 import type { AdaptiveController } from "@llm-router/core/concurrency";
 
@@ -108,14 +109,20 @@ export class ProxyOrchestrator {
         })),
       );
       const { status, statusCode } = this.extractTrackStatus(result);
-      this.deps.adaptiveController?.onRequestComplete(providerId, { success: status === "completed", statusCode });
+      // 如果有重试尝试（非 throw 类型），说明 resilience 层的重试规则匹配了，
+      // 意味着这是一个"有意义的失败"——即使上游返回 200 body error 也应该计入退避
+      const retryRuleMatched = status === "failed" && result.attempts.length > 1;
+      this.deps.adaptiveController?.onRequestComplete(providerId, { success: status === "completed", statusCode, retryRuleMatched, requestId: config.trackerId });
       this.sendResponse(reply, result.result, ctx);
       return result;
     } catch (e) {
       if (e instanceof ProviderSwitchNeeded) {
         const lastResult = e.lastResult;
         const statusCode = lastResult && "statusCode" in lastResult ? lastResult.statusCode : undefined;
-        this.deps.adaptiveController?.onRequestComplete(providerId, { success: false, statusCode });
+        this.deps.adaptiveController?.onRequestComplete(providerId, { success: false, statusCode, retryRuleMatched: true, requestId: config.trackerId });
+      } else if (e instanceof SemaphoreTimeoutError || e instanceof SemaphoreQueueFullError) {
+        // 信号量超时或队列满：说明并发压力大，上报给自适应控制器
+        this.deps.adaptiveController?.onRequestComplete(providerId, { success: false, requestId: config.trackerId });
       }
       throw e;
     }

--- a/router/tests/adaptive-controller.test.ts
+++ b/router/tests/adaptive-controller.test.ts
@@ -162,13 +162,19 @@ describe("AdaptiveConcurrencyController", () => {
       sem.updateConfig.mockClear();
     });
 
-    it("ignores stream_error with upstream 200 (body error)", () => {
-      for (let i = 0; i < 5; i++) ctrl.onRequestComplete("p1", { success: false, statusCode: 200 });
+    it("ignores stream_error with upstream 200 when retryRuleMatched is false", () => {
+      for (let i = 0; i < 5; i++) ctrl.onRequestComplete("p1", { success: false, statusCode: 200, retryRuleMatched: false });
       expect(ctrl.getStatus("p1")!.currentLimit).toBe(6);
       expect(ctrl.getStatus("p1")!.consecutiveFailures).toBe(0);
     });
 
-    it("ignores 4xx client errors", () => {
+    it("counts stream_error with upstream 200 when retryRuleMatched is true", () => {
+      for (let i = 0; i < 3; i++) ctrl.onRequestComplete("p1", { success: false, statusCode: 200, retryRuleMatched: true });
+      expect(ctrl.getStatus("p1")!.currentLimit).toBe(4);
+      expect(ctrl.getStatus("p1")!.probeActive).toBe(false);
+    });
+
+    it("ignores 4xx client errors without retryRuleMatched", () => {
       ctrl.onRequestComplete("p1", { success: false, statusCode: 400 });
       ctrl.onRequestComplete("p1", { success: false, statusCode: 401 });
       ctrl.onRequestComplete("p1", { success: false, statusCode: 403 });
@@ -177,12 +183,25 @@ describe("AdaptiveConcurrencyController", () => {
       expect(ctrl.getStatus("p1")!.consecutiveFailures).toBe(0);
     });
 
-    it("does not reset success counter on 2xx/4xx failures", () => {
+    it("counts 4xx as failure when retryRuleMatched is true", () => {
+      for (let i = 0; i < 3; i++) ctrl.onRequestComplete("p1", { success: false, statusCode: 400, retryRuleMatched: true });
+      expect(ctrl.getStatus("p1")!.currentLimit).toBe(4);
+    });
+
+    it("does not reset success counter on 2xx/4xx failures without retryRuleMatched", () => {
       ctrl.onRequestComplete("p1", { success: true });
       ctrl.onRequestComplete("p1", { success: true });
-      ctrl.onRequestComplete("p1", { success: false, statusCode: 200 });
+      ctrl.onRequestComplete("p1", { success: false, statusCode: 200, retryRuleMatched: false });
       expect(ctrl.getStatus("p1")!.consecutiveSuccesses).toBe(2); // not reset
       expect(ctrl.getStatus("p1")!.consecutiveFailures).toBe(0); // not incremented
+    });
+
+    it("resets success counter on any failure with retryRuleMatched", () => {
+      ctrl.onRequestComplete("p1", { success: true });
+      ctrl.onRequestComplete("p1", { success: true });
+      ctrl.onRequestComplete("p1", { success: false, statusCode: 200, retryRuleMatched: true });
+      expect(ctrl.getStatus("p1")!.consecutiveSuccesses).toBe(0); // reset
+      expect(ctrl.getStatus("p1")!.consecutiveFailures).toBe(1);
     });
   });
 


### PR DESCRIPTION
## 问题

### 盲区 1: SemaphoreTimeoutError 对自适应完全不可见

当 provider 的并发槽位被长请求占满，新请求在信号量队列中等待 120 秒超时（504），这些错误走的是异常抛出路径（`SemaphoreTimeoutError`），不经过 `onRequestComplete`。自适应控制器不知道队列在堆积，无法主动降并发。

### 盲区 2: stream_error（上游 200 body error）被误过滤

zhipu 等 provider 经常返回 200 但 body 包含模型错误（`stream_error`）。Resilience 层的重试规则能正确识别并触发重试，但 `transitionFailure` 中 `statusCode < 500` 的过滤把这当成"非并发问题"直接忽略——即使已经触发了重试。

## 修复

### 1. AdaptiveResult 新增 `retryRuleMatched` 字段

由 orchestrator 根据 resilience 层是否执行了重试来设置。如果重试规则匹配并触发了重试（`attempts.length > 1`），则标记 `retryRuleMatched: true`。

### 2. transitionFailure 优先使用 retryRuleMatched

```diff
- if (statusCode !== 429 && statusCode < 500) return;
+ if (!retryRuleMatched && statusCode !== 429 && statusCode < 500) return;
```

只要 resilience 层判定这是"值得重试的失败"，就计入自适应退避，不管 statusCode 是多少。

### 3. orchestrator 补上信号量异常上报

`SemaphoreTimeoutError` 和 `SemaphoreQueueFullError` 现在也会调用 `onRequestComplete({ success: false })`，让自适应感知队列堆积。

### 4. 测试更新

新增 3 个测试用例覆盖 `retryRuleMatched` 场景。