### PR TITLE
fix: 快速配置页面三个交互问题修复

### DIFF
--- a/frontend/src/components/layout/Sidebar.vue
+++ b/frontend/src/components/layout/Sidebar.vue
@@ -230,6 +230,7 @@ import {
   ChevronDown,
   Globe,
   CalendarClock,
+  Wand2,
 } from 'lucide-vue-next'
 import { api, getApiMessage } from '@/api/client'
 import { Button } from '@/components/ui/button'
@@ -366,6 +367,7 @@ const navGroups = computed(() => {
         { path: '/router-keys', label: t('sidebar.nav.routerKeys'), icon: KeyRound },
         { path: '/retry-rules', label: t('sidebar.nav.retryRules'), icon: RefreshCcw },
         { path: '/schedules', label: t('sidebar.nav.schedules'), icon: CalendarClock },
+        { path: '/proxy-enhancement', label: t('sidebar.nav.proxyEnhancement'), icon: Wand2 },
       ],
     },
     {

--- a/frontend/src/components/quick-setup/types.ts
+++ b/frontend/src/components/quick-setup/types.ts
@@ -90,6 +90,7 @@ const CONTEXT_256K = 256_000
 const CONTEXT_200K = 200_000
 const CONTEXT_128K = 128_000
 const CONTEXT_32K = 32_000
+const CONTEXT_16K = 16_000
 const CONTEXT_8K = 8_000
 
 /** Default context window per model name pattern */
@@ -106,16 +107,28 @@ export function getDefaultContextWindow(modelName: string): number {
   // 256K context window models
   if (
     m.includes('kimi') ||         // Kimi K2/K2.5/K2.6/coding
-    m.includes('moonshotai')      // moonshotai/Kimi-K2 on SiliconFlow
+    m.includes('moonshotai') ||   // moonshotai/Kimi-K2 on SiliconFlow
+    m.includes('hunyuan-2.0') ||  // 混元 2.0 (instruct/thinking)
+    m.includes('hunyuan-a13b') || // 混元 A13B
+    m.includes('hunyuan-t1') ||   // 混元 T1
+    m.includes('step-3.5') ||     // 阶跃星辰 Step 3.5 Flash
+    m.includes('step-3') ||       // 阶跃星辰 Step 3
+    m.includes('qwen3.5-plus') || // Qwen 3.5 Plus
+    m.includes('qwen3-max') ||    // Qwen 3 Max
+    m.includes('doubao') ||       // 豆包 Seed 系列 (1.6+ 256K)
+    m.includes('ark-code') ||     // 火山引擎 Coding Plan
+    m.includes('tc-code')         // 腾讯云 Coding Plan
   ) return CONTEXT_256K
   // 200K context window models
   if (
     m.includes('glm-5') ||        // GLM-5.1, GLM-5, GLM-5-Turbo
-    m.includes('glm-4.7')         // GLM-4.7, GLM-4.7-Flash
+    m.includes('glm-4.7') ||      // GLM-4.7, GLM-4.7-Flash
+    m.includes('minimax')         // MiniMax M2 series (204,800 tokens)
   ) return CONTEXT_200K
   // Named context sizes
   if (m.includes('128k')) return CONTEXT_128K
   if (m.includes('32k')) return CONTEXT_32K
+  if (m.includes('16k')) return CONTEXT_16K
   if (m.includes('8k')) return CONTEXT_8K
   return CONTEXT_128K
 }

--- a/frontend/src/components/quick-setup/types.ts
+++ b/frontend/src/components/quick-setup/types.ts
@@ -86,6 +86,8 @@ export const CONTEXT_WINDOW_OPTIONS = [
 ]
 
 const CONTEXT_1M = 1_000_000
+const CONTEXT_256K = 256_000
+const CONTEXT_200K = 200_000
 const CONTEXT_128K = 128_000
 const CONTEXT_32K = 32_000
 const CONTEXT_8K = 8_000
@@ -101,6 +103,16 @@ export function getDefaultContextWindow(modelName: string): number {
     m.includes('reasoner') ||     // OpenAI reasoner
     m.includes('qwen3.6')         // Qwen 3.6 series
   ) return CONTEXT_1M
+  // 256K context window models
+  if (
+    m.includes('kimi') ||         // Kimi K2/K2.5/K2.6/coding
+    m.includes('moonshotai')      // moonshotai/Kimi-K2 on SiliconFlow
+  ) return CONTEXT_256K
+  // 200K context window models
+  if (
+    m.includes('glm-5') ||        // GLM-5.1, GLM-5, GLM-5-Turbo
+    m.includes('glm-4.7')         // GLM-4.7, GLM-4.7-Flash
+  ) return CONTEXT_200K
   // Named context sizes
   if (m.includes('128k')) return CONTEXT_128K
   if (m.includes('32k')) return CONTEXT_32K

--- a/frontend/src/components/shared/QuickSetupMappingList.vue
+++ b/frontend/src/components/shared/QuickSetupMappingList.vue
@@ -4,10 +4,11 @@ import { useI18n } from 'vue-i18n'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Switch } from '@/components/ui/switch'
-import { ArrowRight } from 'lucide-vue-next'
+import { Trash2 } from 'lucide-vue-next'
 import MappingEntryEditor from '@/components/mappings/MappingEntryEditor.vue'
+import CascadingModelSelect from '@/components/mappings/CascadingModelSelect.vue'
 import type { MappingTarget, MappingEntry } from '@/components/quick-setup/types'
-import type { ProviderGroup } from '@/components/mappings/cascading-types'
+import type { ProviderGroup, SelectedValue } from '@/components/mappings/cascading-types'
 
 const { t } = useI18n()
 
@@ -20,6 +21,7 @@ const emit = defineEmits<{
   'update:targets': [index: number, targets: MappingTarget[]]
   'toggle-active': [index: number]
   'add': [clientModel: string, targetModel: string]
+  'remove': [clientModel: string]
 }>()
 
 const expandedEntries = ref<Set<string>>(new Set())
@@ -32,19 +34,19 @@ function toggleExpand(clientModel: string) {
 }
 
 const newFrom = ref('')
-const newTo = ref('')
+const newToValue = ref<SelectedValue | undefined>()
 
 function canAdd(): boolean {
-  return newFrom.value.trim().length > 0 && newTo.value.trim().length > 0
+  return newFrom.value.trim().length > 0 && !!newToValue.value?.model
 }
 
 function addMapping() {
   const from = newFrom.value.trim()
-  const to = newTo.value.trim()
+  const to = newToValue.value
   if (from && to) {
-    emit('add', from, to)
+    emit('add', from, to.model)
     newFrom.value = ''
-    newTo.value = ''
+    newToValue.value = undefined
   }
 }
 
@@ -78,6 +80,14 @@ function handleKeydown(e: KeyboardEvent) {
 
         <!-- Actions -->
         <div class="flex items-center gap-1.5 shrink-0 pt-0.5">
+          <Button
+            variant="ghost"
+            size="icon-xs"
+            class="text-muted-foreground/40 hover:text-destructive"
+            @click.stop="emit('remove', entry.clientModel)"
+          >
+            <Trash2 class="size-3" />
+          </Button>
           <Switch
             :model-value="entry.active"
             @update:model-value="emit('toggle-active', idx)"
@@ -96,8 +106,15 @@ function handleKeydown(e: KeyboardEvent) {
     <!-- Add new mapping -->
     <div class="flex items-center gap-2 pt-2 border-t mt-2">
       <Input v-model="newFrom" :placeholder="t('providers.shared.clientModel')" class="h-8 flex-1 text-xs font-mono" @keydown="handleKeydown" />
-      <ArrowRight class="size-3 shrink-0 text-muted-foreground" />
-      <Input v-model="newTo" :placeholder="t('providers.shared.targetModel')" class="h-8 flex-1 text-xs font-mono" @keydown="handleKeydown" />
+      <div class="flex-1">
+        <CascadingModelSelect
+          :providers="providerGroups"
+          :model-value="newToValue"
+          compact
+          :placeholder="t('providers.shared.selectModel')"
+          @update:model-value="(v: SelectedValue) => newToValue = v"
+        />
+      </div>
       <Button size="sm" variant="outline" class="h-8 shrink-0" :disabled="!canAdd()" @click="addMapping">{{ t('providers.shared.add') }}</Button>
     </div>
   </div>

--- a/frontend/src/composables/useQuickSetup.ts
+++ b/frontend/src/composables/useQuickSetup.ts
@@ -13,6 +13,13 @@ import router from '@/router'
 
 export type ConcurrencyMode = 'auto' | 'manual' | 'none'
 
+const DEFAULT_CONCURRENCY = 10
+const DEFAULT_QUEUE_TIMEOUT_MS = 120_000
+const DEFAULT_QUEUE_SIZE = 100
+const DEFAULT_CONTEXT_WINDOW = 128_000
+const CONNECTION_TEST_DELAY_MS = 800
+const POST_SAVE_REDIRECT_MS = 1500
+
 /** Convert Chinese provider group name to valid backend name (a-zA-Z0-9_-) */
 const PROVIDER_NAME_MAP: Record<string, string> = {
   'DeepSeek': 'deepseek',
@@ -33,6 +40,167 @@ function toProviderName(group: string): string {
   return PROVIDER_NAME_MAP[group] ?? group.toLowerCase().replace(/[^a-z0-9]/gi, '-').replace(/-+/g, '-')
 }
 
+/** Compute default patches for a model based on its name and API format */
+function computeDefaultPatches(
+  modelName: string,
+  format: 'openai' | 'openai-responses' | 'anthropic',
+  isNonOpenaiEndpoint: boolean,
+): string[] {
+  const patches: string[] = []
+  const isDeepseek = modelName.toLowerCase().includes('deepseek')
+  if (isDeepseek) {
+    if (format === 'anthropic') {
+      patches.push('thinking-param', 'cache-control', 'thinking-blocks', 'orphan-tool-results')
+    } else {
+      patches.push('non-ds-tools', 'orphan-tool-results-oa')
+    }
+  }
+  if (format === 'openai' && isNonOpenaiEndpoint) {
+    patches.push('developer-role')
+  }
+  return patches
+}
+
+/** Parse transform rules from raw string inputs */
+function parseTransformRules(
+  headersInput: string,
+  dropFieldsInput: string,
+  requestDefaultsInput: string,
+  onError: (msg: string) => void,
+): NonNullable<QuickSetupPayload['transform_rules']> | undefined | false {
+  if (!headersInput && !dropFieldsInput && !requestDefaultsInput) return undefined
+  const result: NonNullable<QuickSetupPayload['transform_rules']> = {}
+  if (headersInput) {
+    try { result.inject_headers = JSON.parse(headersInput) } catch { onError('injectHeadersJsonError'); return false }
+  }
+  if (dropFieldsInput) {
+    result.drop_fields = dropFieldsInput.split(',').map(s => s.trim()).filter(Boolean)
+  }
+  if (requestDefaultsInput) {
+    try { result.request_defaults = JSON.parse(requestDefaultsInput) } catch { onError('requestDefaultsJsonError'); return false }
+  }
+  return Object.keys(result).length > 0 ? result : undefined
+}
+
+/** Toggle active state for existing mappings that changed */
+async function toggleChangedMappings(entries: MappingEntry[]): Promise<string[]> {
+  const errors: string[] = []
+  for (const entry of entries) {
+    if (entry.existing && entry.existingId && entry.originalActive !== undefined && entry.active !== entry.originalActive) {
+      try {
+        await api.toggleMappingGroup(entry.existingId)
+      } catch {
+        errors.push(entry.clientModel)
+      }
+    }
+  }
+  return errors
+}
+
+/** Build retry rules payload from selected rules */
+function buildRetryRulesPayload(
+  rules: RecommendedRetryRule[],
+  selectedRules: Set<string>,
+): QuickSetupPayload['retry_rules'] {
+  return rules
+    .filter(r => selectedRules.has(r.name) && !r.exists)
+    .map(r => ({
+      name: r.name,
+      status_code: r.status_code,
+      body_pattern: r.body_pattern,
+      retry_strategy: r.retry_strategy,
+      retry_delay_ms: r.retry_delay_ms,
+      max_retries: r.max_retries,
+      max_delay_ms: r.max_delay_ms,
+    }))
+}
+
+interface ProviderPayloadInput {
+  isCustom: boolean
+  selectedGroup: string
+  selectedPlan: string
+  apiType: 'openai' | 'openai-responses' | 'anthropic'
+  baseUrl: string
+  upstreamPath: string
+  apiKey: string
+  models: ModelConfig[]
+  concurrencyMode: ConcurrencyMode
+  maxConcurrency: number
+  queueTimeoutMs: number
+  maxQueueSize: number
+}
+
+function buildProviderPayload(input: ProviderPayloadInput): QuickSetupPayload['provider'] {
+  return {
+    name: input.isCustom
+      ? `custom-${Date.now()}`
+      : `${toProviderName(input.selectedGroup)}-${toProviderName(input.selectedPlan)}`,
+    api_type: input.apiType,
+    base_url: input.baseUrl,
+    upstream_path: input.upstreamPath || undefined,
+    api_key: input.apiKey,
+    models: input.models.map(m => ({
+      name: m.name,
+      context_window: m.contextWindow,
+      patches: m.patches.length > 0 ? m.patches : undefined,
+    })),
+    concurrency_mode: input.concurrencyMode,
+    max_concurrency: input.concurrencyMode !== 'none' ? input.maxConcurrency : undefined,
+    queue_timeout_ms: input.concurrencyMode !== 'none' ? input.queueTimeoutMs : undefined,
+    max_queue_size: input.concurrencyMode !== 'none' ? input.maxQueueSize : undefined,
+  }
+}
+
+/** Build mapping entries by merging existing DB mappings with client defaults */
+function buildMappingEntries(
+  clientType: ClientType,
+  enabledModels: ModelConfig[],
+  existingMappings: MappingGroup[],
+): MappingEntry[] {
+  let clientModelNames: string[]
+  if (clientType === 'pi') {
+    clientModelNames = enabledModels.map(m => m.name)
+  } else {
+    clientModelNames = DEFAULT_CLIENT_MAPPINGS[clientType] ?? enabledModels.map(m => m.name)
+  }
+
+  return clientModelNames.map((cmName) => {
+    const existingGroup = existingMappings.find(g => g.client_model === cmName)
+    if (existingGroup) {
+      let rule: Rule = {}
+      try { rule = JSON.parse(existingGroup.rule) } catch { rule = {} }
+      const targets = rule.targets ?? []
+      return {
+        clientModel: cmName,
+        targets: targets.length > 0
+          ? targets.map(t => ({
+            backend_model: t.backend_model,
+            provider_id: t.provider_id,
+            overflow_provider_id: t.overflow_provider_id,
+            overflow_model: t.overflow_model,
+          }))
+          : [{ backend_model: enabledModels[0]?.name ?? '', provider_id: '__new__' }],
+        existing: true,
+        existingId: existingGroup.id,
+        tag: 'existing' as const,
+        active: !!existingGroup.is_active,
+        originalActive: !!existingGroup.is_active,
+      }
+    }
+
+    const defaultTarget = enabledModels[clientModelNames.indexOf(cmName)]?.name
+      ?? enabledModels[enabledModels.length - 1]?.name
+      ?? ''
+    return {
+      clientModel: cmName,
+      targets: [{ backend_model: defaultTarget, provider_id: '__new__' }],
+      existing: false,
+      tag: (clientType === 'pi' ? 'auto' : 'def') as 'auto' | 'def',
+      active: true,
+    }
+  })
+}
+
 export function useQuickSetup() {
   const { t } = useI18n()
   // --- State ---
@@ -51,9 +219,9 @@ export function useQuickSetup() {
 
   // Concurrency state
   const concurrencyMode = ref<ConcurrencyMode>('auto')
-  const maxConcurrency = ref(10)
-  const queueTimeoutMs = ref(120000)
-  const maxQueueSize = ref(100)
+  const maxConcurrency = ref(DEFAULT_CONCURRENCY)
+  const queueTimeoutMs = ref(DEFAULT_QUEUE_TIMEOUT_MS)
+  const maxQueueSize = ref(DEFAULT_QUEUE_SIZE)
 
   // Transform rules state
   const transformInjectHeaders = ref('')
@@ -87,7 +255,7 @@ export function useQuickSetup() {
     if (!preset) return ''
     const defaultPath = preset.apiType === 'anthropic' ? '/v1/messages'
       : preset.apiType === 'openai-responses' ? '/v1/responses'
-      : '/v1/chat/completions'
+        : '/v1/chat/completions'
     if (preset.upstreamPath && preset.upstreamPath !== defaultPath) return preset.upstreamPath
     return ''
   })
@@ -128,7 +296,7 @@ export function useQuickSetup() {
       provider: { id: p.id, name: p.name },
       models: (p.models ?? []).map(m => ({
         name: m.name,
-        contextWindow: m.context_window ?? 128000,
+        contextWindow: m.context_window ?? DEFAULT_CONTEXT_WINDOW,
       })),
     }))
     // Only include new provider when there are enabled models configured
@@ -147,24 +315,8 @@ export function useQuickSetup() {
     })
   })
 
-  // --- Patch defaults ---
   function getDefaultPatches(modelName: string, format: 'openai' | 'openai-responses' | 'anthropic'): string[] {
-    const patches: string[] = []
-    const isDeepseek = modelName.toLowerCase().includes('deepseek')
-
-    if (isDeepseek) {
-      if (format === 'anthropic') {
-        patches.push('thinking-param', 'cache-control', 'thinking-blocks', 'orphan-tool-results')
-      } else {
-        patches.push('non-ds-tools', 'orphan-tool-results-oa')
-      }
-    }
-
-    if (format === 'openai' && isNonOpenaiEndpoint.value) {
-      patches.push('developer-role')
-    }
-
-    return patches
+    return computeDefaultPatches(modelName, format, isNonOpenaiEndpoint.value)
   }
 
   function initModels(preset: { models: string[]; apiType: 'openai' | 'openai-responses' | 'anthropic' }) {
@@ -177,7 +329,7 @@ export function useQuickSetup() {
   }
 
   // --- Custom model management ---
-  function addCustomModel(name: string, contextWindow = 128000) {
+  function addCustomModel(name: string, contextWindow = DEFAULT_CONTEXT_WINDOW) {
     modelConfigs.value.push({
       name,
       contextWindow,
@@ -186,60 +338,9 @@ export function useQuickSetup() {
     })
   }
 
-  // --- Mappings ---
   function updateMappings() {
     const enabledModels = modelConfigs.value.filter(m => m.enabled)
-
-    // Build new recommended mappings based on client type
-    let clientModelNames: string[]
-    if (clientType.value === 'pi') {
-      // Pi: client model names = provider model names
-      clientModelNames = enabledModels.map(m => m.name)
-    } else {
-      clientModelNames = DEFAULT_CLIENT_MAPPINGS[clientType.value] ?? enabledModels.map(m => m.name)
-    }
-
-    // For each client model name, check if it already has a mapping in DB
-    const entries: MappingEntry[] = clientModelNames.map((cmName) => {
-      // Look up existing mapping for this client model
-      const existingGroup = existingMappings.value.find(g => g.client_model === cmName)
-      if (existingGroup) {
-        let rule: Rule = {}
-        try { rule = JSON.parse(existingGroup.rule) } catch { /* ignore */ }
-        const targets = rule.targets ?? []
-        return {
-          clientModel: cmName,
-          targets: targets.length > 0
-            ? targets.map(t => ({
-                backend_model: t.backend_model,
-                provider_id: t.provider_id,
-                overflow_provider_id: t.overflow_provider_id,
-                overflow_model: t.overflow_model,
-              }))
-            : [{ backend_model: enabledModels[0]?.name ?? '', provider_id: '__new__' }],
-          existing: true,
-          existingId: existingGroup.id,
-          tag: 'existing' as const,
-          active: !!existingGroup.is_active,
-          originalActive: !!existingGroup.is_active,
-        }
-      }
-
-      // No existing mapping → create default
-      // Find best matching provider model by index
-      const defaultTarget = enabledModels[clientModelNames.indexOf(cmName)]?.name
-        ?? enabledModels[enabledModels.length - 1]?.name
-        ?? ''
-      return {
-        clientModel: cmName,
-        targets: [{ backend_model: defaultTarget, provider_id: '__new__' }],
-        existing: false,
-        tag: (clientType.value === 'pi' ? 'auto' : 'def') as 'auto' | 'def',
-        active: true,
-      }
-    })
-
-    mappingEntries.value = entries
+    mappingEntries.value = buildMappingEntries(clientType.value, enabledModels, existingMappings.value)
   }
 
   // --- Auto-select retry rules when provider changes ---
@@ -360,28 +461,11 @@ export function useQuickSetup() {
       return
     }
     connectionStatus.value = 'testing'
-    await new Promise(resolve => setTimeout(resolve, 800))
+    await new Promise(resolve => setTimeout(resolve, CONNECTION_TEST_DELAY_MS))
     connectionStatus.value = 'ok'
   }
 
   // --- Submit ---
-  function buildTransformRules(): NonNullable<QuickSetupPayload['transform_rules']> | undefined | false {
-    const headersStr = transformInjectHeaders.value.trim()
-    const dropStr = transformDropFields.value.trim()
-    const defaultsStr = transformRequestDefaults.value.trim()
-    if (!headersStr && !dropStr && !defaultsStr) return undefined
-    const result: NonNullable<QuickSetupPayload['transform_rules']> = {}
-    if (headersStr) {
-      try { result.inject_headers = JSON.parse(headersStr) } catch { toast.error(t('quickSetup.messages.injectHeadersJsonError')); return false }
-    }
-    if (dropStr) {
-      result.drop_fields = dropStr.split(',').map(s => s.trim()).filter(Boolean)
-    }
-    if (defaultsStr) {
-      try { result.request_defaults = JSON.parse(defaultsStr) } catch { toast.error(t('quickSetup.messages.requestDefaultsJsonError')); return false }
-    }
-    return Object.keys(result).length > 0 ? result : undefined
-  }
 
   async function submit() {
     if (!currentPreset.value) {
@@ -395,69 +479,40 @@ export function useQuickSetup() {
 
     saving.value = true
     try {
+      const transformRules = parseTransformRules(
+        transformInjectHeaders.value.trim(),
+        transformDropFields.value.trim(),
+        transformRequestDefaults.value.trim(),
+        (key) => toast.error(t(`quickSetup.messages.${key}`)),
+      )
+      if (transformRules === false) return
+
       const payload: QuickSetupPayload = {
-        provider: {
-          name: isCustomProvider.value
-            ? `custom-${Date.now()}`
-            : `${toProviderName(selectedGroup.value)}-${toProviderName(selectedPlan.value)}`,
-          api_type: apiType.value,
-          base_url: baseUrl.value,
-          upstream_path: upstreamPath.value || undefined,
-          api_key: apiKey.value.trim(),
-          models: modelConfigs.value.map(m => ({
-            name: m.name,
-            context_window: m.contextWindow,
-            patches: m.patches.length > 0 ? m.patches : undefined,
-          })),
-          concurrency_mode: concurrencyMode.value,
-          max_concurrency: concurrencyMode.value !== 'none' ? maxConcurrency.value : undefined,
-          queue_timeout_ms: concurrencyMode.value !== 'none' ? queueTimeoutMs.value : undefined,
-          max_queue_size: concurrencyMode.value !== 'none' ? maxQueueSize.value : undefined,
-        },
+        provider: buildProviderPayload({
+          isCustom: isCustomProvider.value, selectedGroup: selectedGroup.value, selectedPlan: selectedPlan.value,
+          apiType: apiType.value, baseUrl: baseUrl.value, upstreamPath: upstreamPath.value, apiKey: apiKey.value.trim(),
+          models: modelConfigs.value, concurrencyMode: concurrencyMode.value,
+          maxConcurrency: maxConcurrency.value, queueTimeoutMs: queueTimeoutMs.value, maxQueueSize: maxQueueSize.value,
+        }),
         mappings: mappingEntries.value
           .filter(m => m.targets[0]?.backend_model)
           .map(m => ({
             client_model: m.clientModel,
             backend_model: m.targets[0]?.backend_model ?? '',
           })),
-        retry_rules: recommendedRules.value
-          .filter(r => selectedRetryRules.value.has(r.name) && !r.exists)
-          .map(r => ({
-            name: r.name,
-            status_code: r.status_code,
-            body_pattern: r.body_pattern,
-            retry_strategy: r.retry_strategy,
-            retry_delay_ms: r.retry_delay_ms,
-            max_retries: r.max_retries,
-            max_delay_ms: r.max_delay_ms,
-          })),
-        transform_rules: (() => {
-          const rules = buildTransformRules()
-          if (rules === false) throw new Error('__transform_invalid__')
-          return rules
-        })(),
+        retry_rules: buildRetryRulesPayload(recommendedRules.value, selectedRetryRules.value),
+        transform_rules: transformRules,
       }
 
       await api.quickSetup(payload)
 
-      // Toggle active state for existing mappings that changed
-      const toggleErrors: string[] = []
-      for (const entry of mappingEntries.value) {
-        if (entry.existing && entry.existingId && entry.originalActive !== undefined && entry.active !== entry.originalActive) {
-          try {
-            await api.toggleMappingGroup(entry.existingId)
-          } catch {
-            toggleErrors.push(entry.clientModel)
-          }
-        }
-      }
-
+      const toggleErrors = await toggleChangedMappings(mappingEntries.value)
       if (toggleErrors.length > 0) {
         toast.success(t('quickSetup.messages.setupCompleteWithErrors', { count: toggleErrors.length }))
       } else {
         toast.success(t('quickSetup.messages.setupComplete'))
       }
-      await new Promise(r => setTimeout(r, 1500))
+      await new Promise(r => setTimeout(r, POST_SAVE_REDIRECT_MS))
       router.push('/')
     } catch (e: unknown) {
       toast.error(getApiMessage(e, t('quickSetup.messages.setupFailed')))
@@ -469,16 +524,16 @@ export function useQuickSetup() {
   // --- Init ---
   onMounted(async () => {
     try {
-      const [groups, rules, mappings, providers] = await Promise.all([
+      const [groupsResult, rulesResult, mappingsResult, providersResult] = await Promise.allSettled([
         api.recommended.getProviders(),
         api.recommended.getRetryRules(),
-        api.getMappingGroups().catch(() => [] as MappingGroup[]),
-        api.getProviders().catch(() => [] as ApiProvider[]),
+        api.getMappingGroups(),
+        api.getProviders(),
       ])
-      providerGroups.value = groups
-      allRecommendedRules.value = rules
-      existingMappings.value = mappings as MappingGroup[]
-      allProviders.value = providers as ApiProvider[]
+      if (groupsResult.status === 'fulfilled') providerGroups.value = groupsResult.value
+      if (rulesResult.status === 'fulfilled') allRecommendedRules.value = rulesResult.value
+      if (mappingsResult.status === 'fulfilled') existingMappings.value = mappingsResult.value as MappingGroup[]
+      if (providersResult.status === 'fulfilled') allProviders.value = providersResult.value as ApiProvider[]
 
       selectClient('claude-code')
     } catch (e: unknown) {

--- a/frontend/src/composables/useQuickSetup.ts
+++ b/frontend/src/composables/useQuickSetup.ts
@@ -252,31 +252,11 @@ export function useQuickSetup() {
   }
 
   // --- Client / Provider / Plan selection ---
+  // Client selection only changes client type and rebuilds mappings.
+  // It does NOT affect provider configuration (group, plan, apiType, models).
   function selectClient(type: ClientType) {
     clientType.value = type
-    const client = CLIENTS.find(c => c.id === type)
-    if (!client) return
-
-    selectedGroup.value = ''
-    selectedPlan.value = ''
-
-    for (const group of providerGroups.value) {
-      if (group.group === client.defaultProvider) {
-        selectedGroup.value = group.group
-        for (const preset of group.presets) {
-          if (preset.plan === client.defaultPlan) {
-            selectedPlan.value = preset.plan
-            apiType.value = preset.apiType as 'openai' | 'openai-responses' | 'anthropic'
-            initModels(preset)
-            break
-          }
-        }
-        break
-      }
-    }
-
     updateMappings()
-    autoSelectRetryRules()
   }
 
   function onProviderChange(group: string) {

--- a/frontend/src/views/Providers.vue
+++ b/frontend/src/views/Providers.vue
@@ -470,6 +470,7 @@ function getDefaultPatches(modelName: string, apiType: string): string[] {
 }
 
 function onConcurrencyModeChange(mode: ConcurrencyMode) {
+  concurrencyMode.value = mode
   if (mode === 'auto') {
     if (!form.value.max_concurrency || form.value.max_concurrency < 1) form.value.max_concurrency = DEFAULT_CONCURRENCY_AUTO
     form.value.adaptive_enabled = true

--- a/frontend/src/views/QuickSetup.vue
+++ b/frontend/src/views/QuickSetup.vue
@@ -335,7 +335,7 @@ const {
   allProviderGroups,
   transformInjectHeaders, transformDropFields, transformRequestDefaults,
   selectClient, onProviderChange, onPlanChange,
-  updateMappingTargets, toggleMappingActive, addMappingEntry,
+  updateMappingTargets, toggleMappingActive, addMappingEntry, removeMappingEntry,
   toggleRetryRule, onConcurrencyModeChange, testConnection, submit,
   addCustomModel,
 } = useQuickSetup()

--- a/frontend/src/views/QuickSetup.vue
+++ b/frontend/src/views/QuickSetup.vue
@@ -190,6 +190,7 @@
             @update:targets="updateMappingTargets"
             @toggle-active="toggleMappingActive"
             @add="addMappingEntry"
+            @remove="removeMappingEntry"
           />
         </CardContent>
       </Card>

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
     },
     "core": {
       "name": "@llm-router/core",
-      "version": "0.9.21",
+      "version": "0.9.22",
       "devDependencies": {
         "@types/node": "^24.12.2",
         "typescript": "^5.8.3",
@@ -948,6 +948,7 @@
       "resolved": "https://registry.npmmirror.com/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -3123,6 +3124,7 @@
       "resolved": "https://registry.npmmirror.com/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
       "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -3204,6 +3206,7 @@
       "resolved": "https://registry.npmmirror.com/@noble/ciphers/-/ciphers-1.3.0.tgz",
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -3675,8 +3678,7 @@
       "optional": true,
       "os": [
         "android"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
       "version": "4.60.2",
@@ -3690,8 +3692,7 @@
       "optional": true,
       "os": [
         "android"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.60.2",
@@ -3705,8 +3706,7 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
       "version": "4.60.2",
@@ -3720,8 +3720,7 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
       "version": "4.60.2",
@@ -3735,8 +3734,7 @@
       "optional": true,
       "os": [
         "freebsd"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
       "version": "4.60.2",
@@ -3750,8 +3748,7 @@
       "optional": true,
       "os": [
         "freebsd"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
       "version": "4.60.2",
@@ -3765,8 +3762,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
       "version": "4.60.2",
@@ -3780,8 +3776,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
       "version": "4.60.2",
@@ -3795,8 +3790,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
       "version": "4.60.2",
@@ -3810,8 +3804,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
       "version": "4.60.2",
@@ -3825,8 +3818,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
       "version": "4.60.2",
@@ -3840,8 +3832,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
       "version": "4.60.2",
@@ -3855,8 +3846,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
       "version": "4.60.2",
@@ -3870,8 +3860,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
       "version": "4.60.2",
@@ -3885,8 +3874,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
       "version": "4.60.2",
@@ -3900,8 +3888,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
       "version": "4.60.2",
@@ -3915,8 +3902,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.60.2",
@@ -3930,8 +3916,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
       "version": "4.60.2",
@@ -3945,8 +3930,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
       "version": "4.60.2",
@@ -3960,8 +3944,7 @@
       "optional": true,
       "os": [
         "openbsd"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
       "version": "4.60.2",
@@ -3975,8 +3958,7 @@
       "optional": true,
       "os": [
         "openharmony"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
       "version": "4.60.2",
@@ -3990,8 +3972,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
       "version": "4.60.2",
@@ -4005,8 +3986,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
       "version": "4.60.2",
@@ -4020,8 +4000,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.60.2",
@@ -4035,8 +4014,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@silvia-odwyer/photon-node": {
       "version": "0.3.4",
@@ -4994,6 +4972,7 @@
       "integrity": "sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.1",
         "@typescript-eslint/types": "8.59.1",
@@ -5623,6 +5602,7 @@
       "resolved": "https://registry.npmmirror.com/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6119,6 +6099,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -6327,6 +6308,7 @@
       "resolved": "https://registry.npmmirror.com/chart.js/-/chart.js-4.5.1.tgz",
       "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@kurkle/color": "^0.3.0"
       },
@@ -7314,6 +7296,7 @@
       "resolved": "https://registry.npmmirror.com/eslint/-/eslint-10.3.0.tgz",
       "integrity": "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -8687,6 +8670,7 @@
       "resolved": "https://registry.npmmirror.com/hono/-/hono-4.12.16.tgz",
       "integrity": "sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -9112,6 +9096,7 @@
       "resolved": "https://registry.npmmirror.com/jiti/-/jiti-2.6.1.tgz",
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -9409,6 +9394,7 @@
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "dev": true,
       "license": "MPL-2.0",
+      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.3"
       },
@@ -10820,6 +10806,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -12510,6 +12497,7 @@
       "resolved": "https://registry.npmmirror.com/stylus/-/stylus-0.57.0.tgz",
       "integrity": "sha512-yOI6G8WYfr0q8v8rRvE91wbxFU+rJPo760Va4MF6K0I6BZjO4r+xSynkvyPBP9tV1CIEUeRsiidjIs2rzb1CnQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "css": "^3.0.0",
         "debug": "^4.3.2",
@@ -12756,6 +12744,7 @@
       "resolved": "https://registry.npmmirror.com/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -13144,7 +13133,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13162,7 +13150,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13180,7 +13167,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13198,7 +13184,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13216,7 +13201,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13234,7 +13218,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13252,7 +13235,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13270,7 +13252,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13288,7 +13269,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13306,7 +13286,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13324,7 +13303,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13342,7 +13320,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13360,7 +13337,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13378,7 +13354,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13396,7 +13371,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13414,7 +13388,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13432,7 +13405,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13450,7 +13422,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13468,7 +13439,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13486,7 +13456,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13504,7 +13473,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13522,7 +13490,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13540,7 +13507,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13558,7 +13524,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13576,7 +13541,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13594,7 +13558,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13704,6 +13667,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -13901,6 +13865,7 @@
       "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -15162,6 +15127,7 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -15243,6 +15209,7 @@
       "resolved": "https://registry.npmmirror.com/vue/-/vue-3.5.33.tgz",
       "integrity": "sha512-1AgChhx5w3ALgT4oK3acm2Es/7jyZhWSVUfs3rOBlGQC0rjEDkS7G4lWlJJGGNQD+BV3reCwbQrOe1mPNwKHBQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.33",
         "@vue/compiler-sfc": "3.5.33",
@@ -15652,6 +15619,7 @@
       "integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
       "devOptional": true,
       "license": "ISC",
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -15801,6 +15769,7 @@
       "resolved": "https://registry.npmmirror.com/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
     "frontend"
   ],
   "scripts": {
-    "build": "npm run build -w core -w router",
+    "build": "npm run build -w core -w router -w frontend",
+    "build:core": "npm run build -w core",
+    "build:router": "npm run build -w core -w router",
+    "build:frontend": "npm run build -w frontend",
     "test": "npm run test -w core -w router",
     "dev": "npm run dev -w router"
   },

--- a/router/config/recommended-providers.json
+++ b/router/config/recommended-providers.json
@@ -96,6 +96,7 @@
         "models": [
           "glm-5.1",
           "glm-5",
+          "glm-5-turbo",
           "glm-4.7",
           "glm-4.5-air"
         ]


### PR DESCRIPTION
1. 客户端选择不再联动供应商配置 — selectClient() 只改 clientType 和映射，不重置 provider/plan/apiType/models
2. 映射条目添加删除按钮 — 每条映射右侧新增 Trash2 按钮，连接 removeMappingEntry
3. 目标模型改用 CascadingModelSelect 下拉选择 — 添加映射时从 Input 改为级联选择组件