### PR TITLE
feat: 工具错误日志记录 (Tool Error Logging)

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -316,6 +316,7 @@ export interface ProxyEnhancementConfig {
   tool_call_loop_enabled: boolean;
   stream_loop_enabled: boolean;
   tool_round_limit_enabled: boolean;
+  tool_error_logging_enabled: boolean;
 }
 
 export interface UpgradeStatus {

--- a/frontend/src/i18n/locales/en/proxyEnhancement.json
+++ b/frontend/src/i18n/locales/en/proxyEnhancement.json
@@ -18,6 +18,10 @@
       "description": "Detect content repetition loops in streaming output (N-gram pattern). Automatically interrupts the stream when the threshold is exceeded."
     }
   },
+  "toolErrorLogging": {
+    "title": "Tool Error Logging",
+    "description": "Record detailed information about Claude Code / pi tool call failures (including tool_use input, error content, provider, model). Used for analyzing patterns of model-generated incorrect tool_use parameters."
+  },
   "loadFailed": "Failed to load configuration",
   "saveFailed": "Failed to save"
 }

--- a/frontend/src/i18n/locales/zh-CN/proxyEnhancement.json
+++ b/frontend/src/i18n/locales/zh-CN/proxyEnhancement.json
@@ -18,6 +18,10 @@
       "description": "检测流式输出中内容重复循环（N-gram 模式），超过阈值时自动中断流。"
     }
   },
+  "toolErrorLogging": {
+    "title": "工具调用错误日志",
+    "description": "记录 Claude Code / pi 工具调用失败的详细信息（包含 tool_use 输入参数、错误内容、provider、模型），用于分析各模型产生错误 tool_use 参数的模式。"
+  },
   "loadFailed": "加载配置失败",
   "saveFailed": "保存失败"
 }

--- a/frontend/src/views/ProxyEnhancement.vue
+++ b/frontend/src/views/ProxyEnhancement.vue
@@ -62,6 +62,26 @@
       </CardContent>
     </Card>
 
+    <Card class="mt-4">
+      <CardHeader>
+        <CardTitle>{{ t('proxyEnhancement.toolErrorLogging.title') }}</CardTitle>
+        <CardDescription>
+          {{ t('proxyEnhancement.toolErrorLogging.description') }}
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div class="flex items-center gap-3">
+          <Switch
+            id="tool-error-logging-toggle"
+            v-model="toolErrorLoggingEnabled"
+          />
+          <Label for="tool-error-logging-toggle">
+            {{ toolErrorLoggingEnabled ? t('proxyEnhancement.status.enabled') : t('proxyEnhancement.status.disabled') }}
+          </Label>
+        </div>
+      </CardContent>
+    </Card>
+
     <div class="flex justify-end mt-4">
       <Button :disabled="saving" @click="handleSave">
         <span v-if="saving" class="flex items-center gap-1">
@@ -89,6 +109,7 @@ const { t } = useI18n()
 const toolRoundLimitEnabled = ref(true)
 const toolCallLoopEnabled = ref(false)
 const streamLoopEnabled = ref(false)
+const toolErrorLoggingEnabled = ref(false)
 const saving = ref(false)
 
 async function loadConfig() {
@@ -97,6 +118,7 @@ async function loadConfig() {
     toolRoundLimitEnabled.value = data.tool_round_limit_enabled
     toolCallLoopEnabled.value = data.tool_call_loop_enabled
     streamLoopEnabled.value = data.stream_loop_enabled
+    toolErrorLoggingEnabled.value = data.tool_error_logging_enabled
   } catch (e: unknown) {
     console.error('Failed to load proxy enhancement config:', e)
     toast.error(getApiMessage(e, t('proxyEnhancement.loadFailed')))
@@ -110,6 +132,7 @@ async function handleSave() {
       tool_call_loop_enabled: toolCallLoopEnabled.value,
       stream_loop_enabled: streamLoopEnabled.value,
       tool_round_limit_enabled: toolRoundLimitEnabled.value,
+      tool_error_logging_enabled: toolErrorLoggingEnabled.value,
     })
     toast.success(t('common.saveSuccess'))
   } catch (e: unknown) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
     },
     "core": {
       "name": "@llm-router/core",
-      "version": "0.9.22",
+      "version": "0.9.23",
       "devDependencies": {
         "@types/node": "^24.12.2",
         "typescript": "^5.8.3",
@@ -948,6 +948,7 @@
       "resolved": "https://registry.npmmirror.com/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -3123,6 +3124,7 @@
       "resolved": "https://registry.npmmirror.com/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
       "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -3204,6 +3206,7 @@
       "resolved": "https://registry.npmmirror.com/@noble/ciphers/-/ciphers-1.3.0.tgz",
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -3675,8 +3678,7 @@
       "optional": true,
       "os": [
         "android"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
       "version": "4.60.2",
@@ -3690,8 +3692,7 @@
       "optional": true,
       "os": [
         "android"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.60.2",
@@ -3705,8 +3706,7 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
       "version": "4.60.2",
@@ -3720,8 +3720,7 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
       "version": "4.60.2",
@@ -3735,8 +3734,7 @@
       "optional": true,
       "os": [
         "freebsd"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
       "version": "4.60.2",
@@ -3750,8 +3748,7 @@
       "optional": true,
       "os": [
         "freebsd"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
       "version": "4.60.2",
@@ -3765,8 +3762,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
       "version": "4.60.2",
@@ -3780,8 +3776,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
       "version": "4.60.2",
@@ -3795,8 +3790,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
       "version": "4.60.2",
@@ -3810,8 +3804,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
       "version": "4.60.2",
@@ -3825,8 +3818,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
       "version": "4.60.2",
@@ -3840,8 +3832,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
       "version": "4.60.2",
@@ -3855,8 +3846,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
       "version": "4.60.2",
@@ -3870,8 +3860,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
       "version": "4.60.2",
@@ -3885,8 +3874,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
       "version": "4.60.2",
@@ -3900,8 +3888,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
       "version": "4.60.2",
@@ -3915,8 +3902,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.60.2",
@@ -3930,8 +3916,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
       "version": "4.60.2",
@@ -3945,8 +3930,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
       "version": "4.60.2",
@@ -3960,8 +3944,7 @@
       "optional": true,
       "os": [
         "openbsd"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
       "version": "4.60.2",
@@ -3975,8 +3958,7 @@
       "optional": true,
       "os": [
         "openharmony"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
       "version": "4.60.2",
@@ -3990,8 +3972,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
       "version": "4.60.2",
@@ -4005,8 +3986,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
       "version": "4.60.2",
@@ -4020,8 +4000,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.60.2",
@@ -4035,8 +4014,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@silvia-odwyer/photon-node": {
       "version": "0.3.4",
@@ -4994,6 +4972,7 @@
       "integrity": "sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.1",
         "@typescript-eslint/types": "8.59.1",
@@ -5623,6 +5602,7 @@
       "resolved": "https://registry.npmmirror.com/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6119,6 +6099,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -6327,6 +6308,7 @@
       "resolved": "https://registry.npmmirror.com/chart.js/-/chart.js-4.5.1.tgz",
       "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@kurkle/color": "^0.3.0"
       },
@@ -7314,6 +7296,7 @@
       "resolved": "https://registry.npmmirror.com/eslint/-/eslint-10.3.0.tgz",
       "integrity": "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -8687,6 +8670,7 @@
       "resolved": "https://registry.npmmirror.com/hono/-/hono-4.12.16.tgz",
       "integrity": "sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -9112,6 +9096,7 @@
       "resolved": "https://registry.npmmirror.com/jiti/-/jiti-2.6.1.tgz",
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -9409,6 +9394,7 @@
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "dev": true,
       "license": "MPL-2.0",
+      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.3"
       },
@@ -10820,6 +10806,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -12510,6 +12497,7 @@
       "resolved": "https://registry.npmmirror.com/stylus/-/stylus-0.57.0.tgz",
       "integrity": "sha512-yOI6G8WYfr0q8v8rRvE91wbxFU+rJPo760Va4MF6K0I6BZjO4r+xSynkvyPBP9tV1CIEUeRsiidjIs2rzb1CnQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "css": "^3.0.0",
         "debug": "^4.3.2",
@@ -12756,6 +12744,7 @@
       "resolved": "https://registry.npmmirror.com/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -13144,7 +13133,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13162,7 +13150,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13180,7 +13167,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13198,7 +13184,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13216,7 +13201,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13234,7 +13218,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13252,7 +13235,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13270,7 +13252,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13288,7 +13269,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13306,7 +13286,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13324,7 +13303,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13342,7 +13320,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13360,7 +13337,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13378,7 +13354,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13396,7 +13371,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13414,7 +13388,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13432,7 +13405,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13450,7 +13422,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13468,7 +13439,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13486,7 +13456,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13504,7 +13473,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13522,7 +13490,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13540,7 +13507,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13558,7 +13524,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13576,7 +13541,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13594,7 +13558,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13704,6 +13667,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -13901,6 +13865,7 @@
       "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -15162,6 +15127,7 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -15243,6 +15209,7 @@
       "resolved": "https://registry.npmmirror.com/vue/-/vue-3.5.33.tgz",
       "integrity": "sha512-1AgChhx5w3ALgT4oK3acm2Es/7jyZhWSVUfs3rOBlGQC0rjEDkS7G4lWlJJGGNQD+BV3reCwbQrOe1mPNwKHBQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.33",
         "@vue/compiler-sfc": "3.5.33",
@@ -15652,6 +15619,7 @@
       "integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
       "devOptional": true,
       "license": "ISC",
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -15801,6 +15769,7 @@
       "resolved": "https://registry.npmmirror.com/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/router/src/admin/proxy-enhancement.ts
+++ b/router/src/admin/proxy-enhancement.ts
@@ -7,6 +7,7 @@ const UpdateProxyEnhancementSchema = Type.Object({
   tool_call_loop_enabled: Type.Boolean(),
   stream_loop_enabled: Type.Boolean(),
   tool_round_limit_enabled: Type.Boolean(),
+  tool_error_logging_enabled: Type.Boolean(),
 });
 
 
@@ -19,7 +20,7 @@ export const adminProxyEnhancementRoutes: FastifyPluginCallback<ProxyEnhancement
 
   app.get("/admin/api/proxy-enhancement", async (_request, reply) => {
     const raw = getSetting(db, "proxy_enhancement");
-    const defaults = { tool_call_loop_enabled: false, stream_loop_enabled: false, tool_round_limit_enabled: true };
+    const defaults = { tool_call_loop_enabled: false, stream_loop_enabled: false, tool_round_limit_enabled: true, tool_error_logging_enabled: false };
     let config = defaults;
     if (raw) {
       try {
@@ -28,6 +29,7 @@ export const adminProxyEnhancementRoutes: FastifyPluginCallback<ProxyEnhancement
           tool_call_loop_enabled: parsed.tool_call_loop_enabled ?? false,
           stream_loop_enabled: parsed.stream_loop_enabled ?? false,
           tool_round_limit_enabled: parsed.tool_round_limit_enabled ?? true,
+          tool_error_logging_enabled: parsed.tool_error_logging_enabled ?? false,
         };
       } catch { /* eslint-disable-line taste/no-silent-catch -- invalid JSON, return defaults */ }
     }
@@ -40,6 +42,7 @@ export const adminProxyEnhancementRoutes: FastifyPluginCallback<ProxyEnhancement
       tool_call_loop_enabled: body.tool_call_loop_enabled,
       stream_loop_enabled: body.stream_loop_enabled,
       tool_round_limit_enabled: body.tool_round_limit_enabled,
+      tool_error_logging_enabled: body.tool_error_logging_enabled,
     };
     setSetting(db, "proxy_enhancement", JSON.stringify(config));
     return reply.send({ success: true });

--- a/router/src/db/log-cleaner.ts
+++ b/router/src/db/log-cleaner.ts
@@ -1,6 +1,7 @@
 import Database from "better-sqlite3";
 import { deleteLogsBefore } from "./logs.js";
 import { getLogRetentionDays } from "./settings.js";
+import { deleteToolErrorLogsBefore } from "./tool-error-logs.js";
 
 const MS_PER_DAY = 86_400_000;
 const CLEANUP_INTERVAL_MS = 3_600_000; // 1 小时
@@ -14,7 +15,9 @@ export function runLogCleanup(db: Database.Database): number {
   const days = getLogRetentionDays(db);
   if (days <= 0) return 0;
   const cutoff = new Date(Date.now() - days * MS_PER_DAY).toISOString();
-  return deleteLogsBefore(db, cutoff);
+  const logDeleted = deleteLogsBefore(db, cutoff);
+  const toolErrorDeleted = deleteToolErrorLogsBefore(db, cutoff);
+  return logDeleted + toolErrorDeleted;
 }
 
 /** 启动定时清理，返回 handle 用于停止 */

--- a/router/src/db/migrations/041_create_tool_error_logs.sql
+++ b/router/src/db/migrations/041_create_tool_error_logs.sql
@@ -1,0 +1,28 @@
+CREATE TABLE IF NOT EXISTS tool_error_logs (
+  id TEXT PRIMARY KEY,
+  request_log_id TEXT REFERENCES request_logs(id) ON DELETE SET NULL,
+  provider_id TEXT NOT NULL,
+  backend_model TEXT NOT NULL,
+  client_agent_type TEXT NOT NULL DEFAULT 'unknown'
+    CHECK(client_agent_type IN ('claude-code', 'pi', 'unknown')),
+  tool_name TEXT NOT NULL,
+  tool_use_id TEXT,
+  tool_input TEXT,
+  error_content TEXT,
+  router_key_id TEXT,
+  session_id TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_tool_error_logs_time
+  ON tool_error_logs(created_at);
+CREATE INDEX IF NOT EXISTS idx_tool_error_logs_provider
+  ON tool_error_logs(provider_id, created_at);
+CREATE INDEX IF NOT EXISTS idx_tool_error_logs_model
+  ON tool_error_logs(backend_model, created_at);
+CREATE INDEX IF NOT EXISTS idx_tool_error_logs_tool
+  ON tool_error_logs(tool_name);
+CREATE INDEX IF NOT EXISTS idx_tool_error_logs_agent
+  ON tool_error_logs(client_agent_type);
+CREATE INDEX IF NOT EXISTS idx_tool_error_logs_session
+  ON tool_error_logs(session_id);

--- a/router/src/db/tool-error-logs.ts
+++ b/router/src/db/tool-error-logs.ts
@@ -1,0 +1,10 @@
+import Database from "better-sqlite3";
+
+/**
+ * 删除 created_at 早于 beforeDate 的 tool_error_logs 记录。
+ * 外键 ON DELETE SET NULL 确保 request_logs 被删后 tool_error_logs 仍保留。
+ */
+export function deleteToolErrorLogsBefore(db: Database.Database, beforeDate: string): number {
+  const changes = db.prepare("DELETE FROM tool_error_logs WHERE created_at < ?").run(beforeDate).changes;
+  return changes;
+}

--- a/router/src/proxy/handler/proxy-handler-utils.ts
+++ b/router/src/proxy/handler/proxy-handler-utils.ts
@@ -3,8 +3,102 @@ import type { ContentBlock } from "@llm-router/core/monitor";
 import type { ToolCallRecord } from "@llm-router/core/loop-prevention";
 import type { TransportResult } from "../types.js";
 import { parseToolArguments } from "../transform/sanitize.js";
+import type { RawHeaders } from "../types.js";
 
 const HASH_DIGEST_LENGTH = 16;
+
+// ---------- Tool Error Logging ----------
+
+export type ClientAgentType = "claude-code" | "pi" | "unknown";
+
+export interface FailedToolResult {
+  toolName: string;
+  toolUseId: string | undefined;
+  toolInput: string | undefined;
+  errorContent: string;
+}
+
+/**
+ * 根据请求头识别客户端类型。
+ * - Claude Code 独有 x-claude-code-session-id 头
+ * - pi 的 User-Agent 包含 "pi-coding-agent"
+ */
+export function detectClientAgentType(headers: RawHeaders): ClientAgentType {
+  if (headers["x-claude-code-session-id"]) return "claude-code";
+  const ua = String(headers["user-agent"] ?? "").toLowerCase();
+  if (ua.includes("pi-coding-agent")) return "pi";
+  return "unknown";
+}
+
+/**
+ * 从请求体 messages 中提取本条请求新产生的失败 tool_result 块。
+ *
+ * 只扫描最后一条 role = "user" 且有 tool_result 的消息，
+ * 避免重复记录前轮请求已记录的 tool 失败。
+ *
+ * 通过向前扫描 assistant 消息中的 tool_use 块
+ * 关联对应的 tool_name 和 tool_input。
+ */
+export function extractFailedToolResults(
+  body: Record<string, unknown>,
+): FailedToolResult[] {
+  const messages = body.messages as Array<{
+    role?: string;
+    content?: unknown;
+  }> | undefined;
+  if (!messages || messages.length === 0) return [];
+
+  // 第一步：向后往前找最后一个包含 tool_result 的 user 消息
+  let lastUserIndex = -1;
+  const resultBlocks: Array<{ tool_use_id?: string; content: unknown; is_error?: boolean }> = [];
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msg = messages[i];
+    if (msg.role !== "user") continue;
+    const content = msg.content;
+    if (!Array.isArray(content)) continue;
+    for (const block of content) {
+      if (block.type === "tool_result") {
+        resultBlocks.push(block);
+        lastUserIndex = i;
+      }
+    }
+    if (resultBlocks.length > 0) break;
+  }
+  if (lastUserIndex < 0) return [];
+
+  // 第二步：在整个 messages 中建立 tool_use_id → { name, input } 映射
+  const toolUseMap = new Map<string, { name: string; input: string }>();
+  for (let i = 0; i < lastUserIndex; i++) {
+    const msg = messages[i];
+    if (msg.role !== "assistant") continue;
+    const content = Array.isArray(msg.content) ? msg.content : [];
+    for (const block of content) {
+      if (block.type === "tool_use" && block.id) {
+        const inputText = block.input ? JSON.stringify(block.input) : "";
+        toolUseMap.set(block.id, { name: block.name ?? "unknown", input: inputText });
+      }
+    }
+  }
+
+  // 第三步：提取 is_error === true 的 tool_result
+  const failures: FailedToolResult[] = [];
+  for (const block of resultBlocks) {
+    if (block.is_error !== true) continue;
+    const toolUse = block.tool_use_id && typeof block.tool_use_id === "string"
+      ? toolUseMap.get(block.tool_use_id)
+      : undefined;
+    const errorContent = typeof block.content === "string"
+      ? block.content
+      : JSON.stringify(block.content ?? "");
+    failures.push({
+      toolName: toolUse?.name ?? "unknown",
+      toolUseId: block.tool_use_id,
+      toolInput: toolUse?.input,
+      errorContent,
+    });
+  }
+  return failures;
+}
 
 /** 从 TransportResult 中提取最终 HTTP status code */
 export function getTransportStatusCode(result: TransportResult): number | null {

--- a/router/src/proxy/handler/proxy-handler.ts
+++ b/router/src/proxy/handler/proxy-handler.ts
@@ -30,7 +30,8 @@ import { applyProviderPatches } from "../patch/index.js";
 import { PipelineSnapshot, type StageRecord } from "../pipeline-snapshot.js";
 import { applyToolRoundLimit } from "../patch/tool-round-limiter.js";
 import { loadEnhancementConfig } from "../routing/enhancement-config.js";
-import { getTransportStatusCode, serializeBlocksForStorage, extractLastToolUse } from "./proxy-handler-utils.js";
+import { getTransportStatusCode, serializeBlocksForStorage, extractLastToolUse, extractFailedToolResults, detectClientAgentType } from "./proxy-handler-utils.js";
+import { logToolErrors } from "../tool-error-logger.js";
 
 const HTTP_ERROR_THRESHOLD = 400;
 const MAX_LOG_FIELD_LENGTH = 80;
@@ -212,8 +213,10 @@ async function executeFailoverLoop(ctx: FailoverContext): Promise<FastifyReply> 
   const config = getConfig();
   const excludeTargets: Target[] = [];
   let rootLogId: string | null = null;
+  let toolErrorsLogged = false;
   // TransformCoordinator 无状态，只需创建一次
   const coordinator = new TransformCoordinator();
+  const enhancementConfig = loadEnhancementConfig(deps.db);
   while (true) {
     const startTime = Date.now();
     const logId = randomUUID();
@@ -271,6 +274,25 @@ async function executeFailoverLoop(ctx: FailoverContext): Promise<FastifyReply> 
       return rejectAndReply(reply, rCtx, errors.providerUnavailable(),
         `Provider '${resolved.provider_id}' unavailable`, resolved.provider_id);
     }
+
+    // 工具错误日志记录 — 首次迭代时执行，记录本轮请求中的 is_error tool_result
+    if (enhancementConfig.tool_error_logging_enabled && !toolErrorsLogged) {
+      toolErrorsLogged = true;
+      const failures = extractFailedToolResults(pipelineBody);
+      if (failures.length > 0) {
+        request.log.info({ failures: failures.length, sessionId }, "Tool error results detected");
+        logToolErrors(failures, {
+          db: deps.db,
+          providerId: resolved.provider_id,
+          backendModel: resolved.backend_model ?? effectiveModel,
+          clientAgentType: detectClientAgentType(cliHdrs),
+          requestLogId: logId,
+          routerKeyId,
+          sessionId,
+        });
+      }
+    }
+
     // --- 溢出重定向：上下文超出时切换到更大模型（必须在 transform 之前，确保使用正确的 api_type） ---
     const overflowResult = applyOverflowRedirect(resolved, deps.db, currentBody);
     if (overflowResult) {

--- a/router/src/proxy/routing/enhancement-config.ts
+++ b/router/src/proxy/routing/enhancement-config.ts
@@ -5,12 +5,14 @@ export interface EnhancementConfig {
   tool_call_loop_enabled: boolean;
   stream_loop_enabled: boolean;
   tool_round_limit_enabled: boolean;
+  tool_error_logging_enabled: boolean;
 }
 
 const DEFAULT_CONFIG: EnhancementConfig = {
   tool_call_loop_enabled: false,
   stream_loop_enabled: false,
   tool_round_limit_enabled: true,
+  tool_error_logging_enabled: false,
 };
 
 /** 集中加载 proxy_enhancement 配置，避免多处重复 getSetting + JSON.parse */
@@ -23,6 +25,7 @@ export function loadEnhancementConfig(db: Database.Database): EnhancementConfig 
       tool_call_loop_enabled: parsed.tool_call_loop_enabled ?? false,
       stream_loop_enabled: parsed.stream_loop_enabled ?? false,
       tool_round_limit_enabled: parsed.tool_round_limit_enabled ?? true,
+      tool_error_logging_enabled: parsed.tool_error_logging_enabled ?? false,
     };
   } catch {
     return { ...DEFAULT_CONFIG };

--- a/router/src/proxy/tool-error-logger.ts
+++ b/router/src/proxy/tool-error-logger.ts
@@ -1,0 +1,53 @@
+import { randomUUID } from "crypto";
+import type Database from "better-sqlite3";
+import type { FailedToolResult, ClientAgentType } from "./handler/proxy-handler-utils.js";
+
+export interface ToolErrorLogContext {
+  db: Database.Database;
+  providerId: string;
+  backendModel: string;
+  clientAgentType: ClientAgentType;
+  requestLogId: string;
+  routerKeyId: string | null;
+  sessionId: string | undefined;
+}
+
+/**
+ * 将失败的 tool_result 批量写入 tool_error_logs 表。
+ * 每条失败记录独立一行。
+ */
+export function logToolErrors(failures: FailedToolResult[], ctx: ToolErrorLogContext): void {
+  if (failures.length === 0) return;
+
+  const stmt = ctx.db.prepare(`
+    INSERT INTO tool_error_logs
+      (id, request_log_id, provider_id, backend_model, client_agent_type,
+       tool_name, tool_use_id, tool_input, error_content,
+       router_key_id, session_id, created_at)
+    VALUES
+      (@id, @request_log_id, @provider_id, @backend_model, @client_agent_type,
+       @tool_name, @tool_use_id, @tool_input, @error_content,
+       @router_key_id, @session_id, @created_at)
+  `);
+
+  const now = new Date().toISOString();
+  const insertMany = ctx.db.transaction(() => {
+    for (const f of failures) {
+      stmt.run({
+        id: randomUUID(),
+        request_log_id: ctx.requestLogId,
+        provider_id: ctx.providerId,
+        backend_model: ctx.backendModel,
+        client_agent_type: ctx.clientAgentType,
+        tool_name: f.toolName,
+        tool_use_id: f.toolUseId ?? null,
+        tool_input: f.toolInput ?? null,
+        error_content: f.errorContent,
+        router_key_id: ctx.routerKeyId,
+        session_id: ctx.sessionId ?? null,
+        created_at: now,
+      });
+    }
+  });
+  insertMany();
+}

--- a/router/tests/db.test.ts
+++ b/router/tests/db.test.ts
@@ -39,7 +39,7 @@ describe("initDatabase", () => {
       .prepare("SELECT name FROM migrations")
       .all() as { name: string }[];
 
-    expect(rows.length).toBe(40);
+    expect(rows.length).toBe(41);
     expect(rows[0].name).toBe("001_init.sql");
     expect(rows[1].name).toBe("002_add_request_response_body.sql");
     expect(rows[2].name).toBe("003_add_full_request_chain_log.sql");

--- a/router/tests/metrics.test.ts
+++ b/router/tests/metrics.test.ts
@@ -29,7 +29,7 @@ describe("request_metrics migration and insertMetrics", () => {
       .prepare("SELECT name FROM migrations")
       .all() as { name: string }[];
 
-    expect(rows).toHaveLength(40);
+    expect(rows).toHaveLength(41);
     expect(rows[5].name).toBe("006_create_request_metrics.sql");
     expect(rows[6].name).toBe("007_add_retry_fields.sql");
     expect(rows[7].name).toBe("008_create_router_keys.sql");


### PR DESCRIPTION
新增 tool_error_logs 表，记录 Claude Code / pi 工具调用失败信息：

- 扫描请求体最后一条 user 消息的 tool_result（is_error===true）
- 关联 assistant 消息的 tool_use 获取 tool_name 和 input
- 记录 provider、model、client_agent_type（claude-code / pi / unknown）
- 跟随系统 log_retention_days 自动清理
- 实验性功能，默认关闭，通过 proxy-enhancement 页面开关控制