### PR TITLE
feat: per-provider network proxy support (SOCKS5/HTTP)

### DIFF
--- a/.superpowers/2026-05-06-network-proxy/spec.md
+++ b/.superpowers/2026-05-06-network-proxy/spec.md
@@ -1,0 +1,198 @@
+# Per-Provider Network Proxy Support
+
+GitHub Issue: zhushanwen321/llm-simple-router#66
+
+## Background
+
+Users in restricted network environments need SOCKS5 or HTTP proxy to access external model providers (e.g., Anthropic). Currently they must use system-level proxies or network tools. This feature adds per-provider proxy configuration to the router itself.
+
+## Design Decisions
+
+| Decision | Choice | Reason |
+|----------|--------|--------|
+| Configuration granularity | Per-provider | Same proxy config may not apply to all providers; simple key-value on each provider |
+| Credential storage | AES-256-GCM encrypted (same as API Key) | Passwords are sensitive |
+| Routing strategy impact | Fully transparent | Proxy is a transport concern; retry/failover logic unchanged |
+| Implementation pattern | ProxyAgentFactory singleton with agent cache | Connection reuse; clean separation; matches SemaphoreManager pattern |
+
+## 1. Database Schema
+
+Migration `041_add_provider_proxy.sql`:
+
+```sql
+ALTER TABLE providers ADD COLUMN proxy_type TEXT DEFAULT NULL;  -- NULL | 'http' | 'socks5'
+ALTER TABLE providers ADD COLUMN proxy_url TEXT DEFAULT NULL;    -- e.g. 'socks5://127.0.0.1:1080'
+ALTER TABLE providers ADD COLUMN proxy_username TEXT DEFAULT NULL;  -- AES encrypted
+ALTER TABLE providers ADD COLUMN proxy_password TEXT DEFAULT NULL;  -- AES encrypted
+```
+
+- `proxy_type = NULL` means no proxy (default).
+- `proxy_username` and `proxy_password` are AES-256-GCM encrypted using existing `encrypt()`/`decrypt()`.
+- `proxy_url` is stored in plaintext (not sensitive, needed for admin display).
+
+## 2. ProxyAgentFactory Module
+
+New file: `router/src/proxy/transport/proxy-agent.ts`
+
+### Data Structure
+
+```ts
+agentCache: Map<string, { agent: http.Agent; proxyUrl: string }>
+```
+
+### API
+
+| Method | Signature | Behavior |
+|--------|-----------|----------|
+| `getAgent` | `(provider: { id, proxy_type, proxy_url, proxy_username, proxy_password }) => http.Agent \| undefined` | Cache hit → return existing agent. Cache miss → create new agent, cache, return. `proxy_type` falsy → return `undefined`. |
+| `invalidate` | `(providerId: string) => void` | Destroy old agent (`agent.destroy()`), remove from cache. |
+
+### Agent Creation
+
+- `proxy_type === "http"` → `new HttpProxyAgent(proxyUrl, { auth })`
+- `proxy_type === "socks5"` → `new SocksProxyAgent(proxyUrl, { auth })`
+- When `proxy_username`/`proxy_password` are non-empty, pass auth credentials.
+
+### npm Dependencies
+
+- `socks-proxy-agent` — SOCKS5 proxy support
+- `https-proxy-agent` — HTTP CONNECT proxy support
+
+### Lifecycle
+
+- Exported as singleton via `ServiceContainer` lazy-load pattern.
+- `invalidate()` called on provider update, delete, or disable.
+
+## 3. Transport Layer Changes
+
+### `router/src/proxy/transport/http.ts`
+
+`createUpstreamRequest` gains an optional `agent` parameter:
+
+```ts
+createUpstreamRequest(url: URL, options: UpstreamRequestOptions, agent?: http.Agent): http.ClientRequest
+```
+
+When `agent` is provided, it is passed as `options.agent` to `http.request()` / `https.request()`.
+
+`callNonStream` and `callGet` gain an optional `agent` parameter, forwarded to `createUpstreamRequest`.
+
+### `router/src/proxy/transport/stream.ts`
+
+`callStream` gains an optional `agent` parameter, forwarded to `createUpstreamRequest`.
+
+### `router/src/proxy/transport/transport-fn.ts`
+
+`buildTransportFn` calls `proxyAgentFactory.getAgent(provider)` and passes the result to `callStream` / `callNonStream`.
+
+### Call Chain
+
+```
+transport-fn.ts
+  proxyAgentFactory.getAgent(provider) → agent | undefined
+  → callStream(..., agent) / callNonStream(..., agent)
+    → createUpstreamRequest(url, options, agent)
+      → agent ? http.request({...options, agent}) : http.request(options)
+```
+
+`UpstreamRequestOptions` type is **not** modified — `agent` is a separate parameter, keeping `buildRequestOptions` unchanged.
+
+## 4. DB Layer + Admin API
+
+### `router/src/db/providers.ts`
+
+- `Provider` interface: add `proxy_type`, `proxy_url`, `proxy_username`, `proxy_password`.
+- `PROVIDER_FIELDS` whitelist: add all 4 fields.
+- `createProvider`: encrypt `proxy_username` and `proxy_password` before insert.
+- `updateProvider`: type already accepts partial fields; encryption handled in admin layer.
+
+### `router/src/admin/providers.ts`
+
+**TypeBox Schema** (`CreateProviderSchema` / `UpdateProviderSchema`):
+
+```ts
+proxy_type: Type.Optional(Type.Union([Type.Literal("http"), Type.Literal("socks5")])),
+proxy_url: Type.Optional(Type.String({ minLength: 1 })),
+proxy_username: Type.Optional(Type.String()),
+proxy_password: Type.Optional(Type.String()),
+```
+
+**Validation**: when `proxy_type` is non-null, `proxy_url` is required (400 if missing).
+
+**GET `/admin/api/providers`**: decrypt `proxy_username` / `proxy_password` before returning.
+
+**POST `/admin/api/providers`**:
+- Encrypt `proxy_username` / `proxy_password` before `createProvider()`.
+- When `proxy_type` is null/empty, clear all proxy fields (prevent stale data).
+
+**PUT `/admin/api/providers/:id`**:
+- Encrypt proxy credentials if provided.
+- When `proxy_type` is set to null, clear all proxy fields.
+- After successful update, call `proxyAgentFactory.invalidate(id)`.
+
+**DELETE `/admin/api/providers/:id`**:
+- Call `proxyAgentFactory.invalidate(id)` to clean up cached agent.
+
+## 5. Frontend
+
+### `frontend/src/views/Providers.vue`
+
+New collapsible section in the Provider edit dialog, placed after "Upstream Path" and before "Available Models":
+
+```
+┌─────────────────────────────────────┐
+│ Proxy Configuration              ▼  │  ← Collapsible
+│                                     │
+│ Proxy Type  [No Proxy ▼]            │  ← Select: No Proxy / HTTP / SOCKS5
+│ Proxy URL   [socks5://127.0.0.1:1080] │  ← Input, shown when type selected
+│ Username    [optional]              │  ← Input, shown when type selected
+│ Password    [optional]              │  ← Input type=password, shown when type selected
+└─────────────────────────────────────┘
+```
+
+**Behavior**:
+- "No Proxy" selected → hide URL/username/password fields, submit clears proxy fields.
+- HTTP/SOCKS5 selected → show URL (required), username/password (optional).
+- Proxy URL placeholder changes based on type: HTTP → `http://127.0.0.1:7890`, SOCKS5 → `socks5://127.0.0.1:1080`.
+
+### Provider List Table
+
+Add a proxy indicator icon (lucide `Shield` or `Globe`) next to the Base URL column cell. Hover tooltip shows proxy type. No extra column needed.
+
+### Type Changes
+
+- `frontend/src/api/client.ts` → `ProviderPayload` adds optional proxy fields.
+- `frontend/src/types/mapping.ts` → `Provider` type adds proxy fields.
+
+## 6. Error Handling + Testing
+
+### Error Handling
+
+- Proxy connection errors (`ECONNREFUSED`, `ETIMEDOUT`, auth failure) flow through existing `TransportResult.kind === "throw"` path.
+- Resilience layer is fully transparent to proxy vs direct errors.
+- Admin API validates: `proxy_type` non-null requires `proxy_url` (returns 400).
+
+### Testing
+
+| Type | Coverage |
+|------|----------|
+| Unit | `ProxyAgentFactory`: create/cache/invalidate; returns `undefined` when `proxy_type` is null |
+| Unit | Admin API: proxy field encrypt/decrypt; 400 when `proxy_type` set without `proxy_url` |
+| Integration | Mock SOCKS5/HTTP proxy server → Provider with proxy config → Request routed through proxy to mock backend |
+
+No changes to existing tests — proxy is optional, behavior unchanged when not configured.
+
+## Files Changed (Summary)
+
+| File | Change |
+|------|--------|
+| `router/src/db/migrations/041_add_provider_proxy.sql` | **NEW** — 4 columns on providers |
+| `router/src/proxy/transport/proxy-agent.ts` | **NEW** — ProxyAgentFactory singleton |
+| `router/src/proxy/transport/http.ts` | `createUpstreamRequest` + `callNonStream` + `callGet` gain optional `agent` param |
+| `router/src/proxy/transport/stream.ts` | `callStream` gains optional `agent` param |
+| `router/src/proxy/transport/transport-fn.ts` | Get agent from factory, pass to transport functions |
+| `router/src/db/providers.ts` | Interface + CRUD + whitelist add proxy fields |
+| `router/src/admin/providers.ts` | Schema + encrypt/decrypt + invalidate cache |
+| `frontend/src/views/Providers.vue` | Proxy config section in dialog |
+| `frontend/src/api/client.ts` | `ProviderPayload` add proxy fields |
+| `frontend/src/types/mapping.ts` | `Provider` add proxy fields |

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -134,6 +134,10 @@ export interface ProviderPayload {
   queue_timeout_ms?: number;
   max_queue_size?: number;
   adaptive_enabled?: number;
+  proxy_type?: string | null;
+  proxy_url?: string | null;
+  proxy_username?: string | null;
+  proxy_password?: string | null;
 }
 
 interface MappingPayload {

--- a/frontend/src/components/shared/ProxyConfigForm.vue
+++ b/frontend/src/components/shared/ProxyConfigForm.vue
@@ -1,0 +1,59 @@
+<!-- eslint-disable vue/multi-word-component-names -->
+<template>
+  <div class="border rounded-md p-3 space-y-3">
+    <div class="text-xs font-medium text-muted-foreground">{{ t('providers.fields.proxyTitle') }}</div>
+    <div class="grid grid-cols-2 gap-3">
+      <div>
+        <Label class="text-xs text-muted-foreground">{{ t('providers.fields.proxyType') }}</Label>
+        <Select :model-value="proxyType" class="mt-1" @update:model-value="onTypeChange">
+          <SelectTrigger><SelectValue /></SelectTrigger>
+          <SelectContent>
+            <SelectItem value="">{{ t('providers.fields.proxyNoProxy') }}</SelectItem>
+            <SelectItem value="http">{{ t('providers.fields.proxyHttp') }}</SelectItem>
+            <SelectItem value="socks5">{{ t('providers.fields.proxySocks5') }}</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+      <div v-if="proxyType">
+        <Label class="text-xs text-muted-foreground">{{ t('providers.fields.proxyUrl') }}</Label>
+        <Input :model-value="proxyUrl" type="text" class="mt-1 font-mono text-xs" :placeholder="proxyType === 'socks5' ? t('providers.fields.proxyUrlPlaceholderSocks5') : t('providers.fields.proxyUrlPlaceholderHttp')" @update:model-value="emit('update:proxyUrl', $event)" />
+      </div>
+    </div>
+    <div v-if="proxyType" class="grid grid-cols-2 gap-3">
+      <div>
+        <Label class="text-xs text-muted-foreground">{{ t('providers.fields.proxyUsername') }}</Label>
+        <Input :model-value="proxyUsername" type="text" class="mt-1" :placeholder="t('providers.fields.proxyAuthOptional')" @update:model-value="emit('update:proxyUsername', $event)" />
+      </div>
+      <div>
+        <Label class="text-xs text-muted-foreground">{{ t('providers.fields.proxyPassword') }}</Label>
+        <Input :model-value="proxyPassword" type="password" class="mt-1" :placeholder="t('providers.fields.proxyAuthOptional')" @update:model-value="emit('update:proxyPassword', $event)" />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@/components/ui/select'
+
+defineProps({
+  proxyType: { type: String, default: '' },
+  proxyUrl: { type: String, default: '' },
+  proxyUsername: { type: String, default: '' },
+  proxyPassword: { type: String, default: '' },
+})
+
+const emit = defineEmits(['update:proxyType', 'update:proxyUrl', 'update:proxyUsername', 'update:proxyPassword', 'clear'])
+
+const { t } = useI18n()
+
+function onTypeChange(val: unknown) {
+  const value = String(val ?? '')
+  emit('update:proxyType', value)
+  if (!value) {
+    emit('clear')
+  }
+}
+</script>

--- a/frontend/src/composables/useProviderActions.ts
+++ b/frontend/src/composables/useProviderActions.ts
@@ -1,0 +1,111 @@
+import { ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { toast } from 'vue-sonner'
+import { api, getApiMessage } from '@/api/client'
+import type { Provider } from '@/types/mapping'
+
+const MASK_VISIBLE_LEN = 7
+const MASK_ASTERISK_COUNT = 7
+const COPY_FEEDBACK_MS = 2000
+
+export function useProviderActions() {
+  const { t } = useI18n()
+
+  const providers = ref<Provider[]>([])
+  const reloading = ref(false)
+  const copiedId = ref<string | null>(null)
+  const deleteTarget = ref<Provider | null>(null)
+  const toggleTarget = ref<Provider | null>(null)
+  const pendingToggleId = ref<string | null>(null)
+  const pendingToggleActive = ref(false)
+  const toggleDependencies = ref<string[]>([])
+
+  async function loadProviders() {
+    try {
+      providers.value = await api.getProviders()
+    } catch (e: unknown) {
+      console.error('Failed to load providers:', e)
+      toast.error(getApiMessage(e, t('providers.toast.loadFailed')))
+    }
+  }
+
+  function maskKey(key: string): string {
+    if (!key) return ''
+    return key.slice(0, MASK_VISIBLE_LEN) + '*'.repeat(MASK_ASTERISK_COUNT)
+  }
+
+  async function copyKey(key: string, id: string) {
+    await navigator.clipboard.writeText(key)
+    copiedId.value = id
+    setTimeout(() => { copiedId.value = null }, COPY_FEEDBACK_MS)
+  }
+
+  function confirmDelete(p: Provider) { deleteTarget.value = p }
+
+  async function confirmToggle(p: Provider) {
+    toggleTarget.value = p
+    pendingToggleId.value = p.id
+    pendingToggleActive.value = !!p.is_active
+    toggleDependencies.value = []
+    if (p.is_active) {
+      try {
+        toggleDependencies.value = (await api.getProviderDependencies(p.id)).references
+      } catch { toggleDependencies.value = [] }
+    }
+  }
+
+  async function handleToggle() {
+    const id = pendingToggleId.value
+    if (!id) return
+    const wasActive = pendingToggleActive.value
+    toggleTarget.value = null
+    pendingToggleId.value = null
+    try {
+      const res = await api.updateProvider(id, { is_active: wasActive ? 0 : 1 })
+      if (res.cascadedGroups?.length) {
+        const disabled = res.cascadedGroups.filter((g: { disabled: boolean }) => g.disabled).length
+        const cleaned = res.cascadedGroups.length - disabled
+        const parts: string[] = []
+        if (cleaned > 0) parts.push(t('providers.toast.cascadeClean', { count: cleaned }))
+        if (disabled > 0) parts.push(t('providers.toast.cascadeDisable', { count: disabled }))
+        toast.warning(t('providers.toast.cascadeAuto', { actions: parts.join(', ') }))
+      }
+      await loadProviders()
+    } catch (e: unknown) {
+      console.error('Failed to toggle provider:', e)
+      toast.error(getApiMessage(e, t('providers.toast.toggleFailed')))
+    }
+  }
+
+  async function handleDelete() {
+    const target = deleteTarget.value
+    if (!target) return
+    deleteTarget.value = null
+    try {
+      await api.deleteProvider(target.id)
+      await loadProviders()
+    } catch (e: unknown) {
+      toast.error(getApiMessage(e, t('providers.toast.deleteFailed')))
+    }
+  }
+
+  async function handleReload() {
+    reloading.value = true
+    try {
+      const result = await api.reloadTransformRules()
+      toast.success(t('providers.toast.reloadSuccess', { pluginCount: result.loadedPlugins.length, rulesCount: result.rulesCount }))
+    } catch (e: unknown) {
+      toast.error(getApiMessage(e, t('providers.toast.reloadFailed')))
+    } finally {
+      reloading.value = false
+    }
+  }
+
+  return {
+    providers, reloading, copiedId,
+    deleteTarget, toggleTarget, pendingToggleId, pendingToggleActive, toggleDependencies,
+    maskKey, copyKey,
+    loadProviders, confirmDelete, confirmToggle, handleToggle,
+    handleDelete, handleReload,
+  }
+}

--- a/frontend/src/composables/useProviderForm.ts
+++ b/frontend/src/composables/useProviderForm.ts
@@ -1,0 +1,224 @@
+import { ref, computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import * as z from 'zod'
+import type { ProviderPayload } from '@/api/client'
+import type { Provider, ModelInfo } from '@/types/mapping'
+import { DEFAULT_CONTEXT_WINDOW } from '@/constants'
+import type { ModelConfig } from '@/components/quick-setup/types'
+import { useTransformRules } from '@/composables/useTransformRules'
+import { useProviderPresets } from '@/composables/useProviderPresets'
+
+const DEFAULT_CONCURRENCY = 3
+const DEFAULT_CONCURRENCY_AUTO = 10
+const DEFAULT_QUEUE_TIMEOUT_MS = 120_000
+const DEFAULT_QUEUE_SIZE = 10
+const MAX_CONCURRENCY = 100
+const MAX_QUEUE_SIZE = 1000
+const CONTEXT_K = 1000
+const CONTEXT_M = 1_000_000
+const MS_PER_SECOND = 1000
+
+export type ConcurrencyMode = 'auto' | 'manual' | 'none'
+
+interface FormState {
+  name: string
+  api_type: string
+  base_url: string
+  upstream_path: string
+  api_key: string
+  models: ModelInfo[]
+  is_active: boolean
+  max_concurrency: number
+  queue_timeout_ms: number
+  max_queue_size: number
+  adaptive_enabled: boolean
+  proxy_type: string
+  proxy_url: string
+  proxy_username: string
+  proxy_password: string
+}
+
+const DEFAULT_FORM: FormState = {
+  name: '', api_type: 'anthropic', base_url: '', upstream_path: '', api_key: '',
+  models: [], is_active: true, max_concurrency: DEFAULT_CONCURRENCY_AUTO,
+  queue_timeout_ms: DEFAULT_QUEUE_TIMEOUT_MS, max_queue_size: DEFAULT_QUEUE_SIZE,
+  adaptive_enabled: true, proxy_type: '', proxy_url: '', proxy_username: '', proxy_password: '',
+}
+
+const CONTEXT_WINDOW_OPTIONS = [
+  { label: '8K', value: '8000' }, { label: '16K', value: '16000' },
+  { label: '32K', value: '32000' }, { label: '64K', value: '64000' },
+  { label: '128K', value: '128000' }, { label: '160K', value: '160000' },
+  { label: '200K', value: '200000' }, { label: '256K', value: '256000' },
+  { label: '1M', value: '1000000' },
+] as const
+
+export const API_TYPE_LABELS: Record<string, string> = {
+  openai: 'OpenAI Chat Completions', 'openai-responses': 'OpenAI Responses', anthropic: 'Anthropic Messages',
+}
+
+export { CONTEXT_WINDOW_OPTIONS, MS_PER_SECOND, CONTEXT_K, CONTEXT_M }
+
+type ProviderFormPayload = Pick<ProviderPayload,
+  'name' | 'api_type' | 'base_url' | 'upstream_path' | 'models' |
+  'is_active' | 'max_concurrency' | 'queue_timeout_ms' | 'max_queue_size' |
+  'adaptive_enabled' | 'proxy_type' | 'proxy_url' | 'proxy_username' | 'proxy_password'
+> & { api_key?: string }
+
+export function useProviderForm() {
+  const { t } = useI18n()
+  const { transformForm, loadTransformRules, saveTransformRules } = useTransformRules()
+
+  const form = ref<FormState>({ ...DEFAULT_FORM })
+  const errors = ref<Record<string, string>>({})
+  const concurrencyMode = ref<ConcurrencyMode>('auto')
+  const dialogOpen = ref(false)
+  const editingId = ref<string | null>(null)
+  const modelInput = ref('')
+  const modelContextWindow = ref(DEFAULT_CONTEXT_WINDOW)
+  const contextWindowSelect = computed({
+    get: () => String(modelContextWindow.value),
+    set: (val: string) => { modelContextWindow.value = Number(val) },
+  })
+
+  const presetHook = useProviderPresets(form)
+
+  function validate(): boolean {
+    const schema = z.object({
+      name: z.string().min(1, t('providers.validation.nameRequired')).regex(/^[a-zA-Z0-9_-]+$/, t('providers.validation.namePattern')),
+      base_url: z.string().min(1, t('providers.validation.baseUrlRequired')).url(t('providers.validation.baseUrlInvalid')),
+    })
+    const errs: Record<string, string> = {}
+    const result = schema.safeParse({ name: form.value.name.trim(), base_url: form.value.base_url.trim() })
+    if (!result.success) {
+      for (const issue of result.error.issues) {
+        const field = issue.path[0] as string
+        if (!errs[field]) errs[field] = issue.message
+      }
+    }
+    if (!editingId.value && !form.value.api_key.trim()) errs.api_key = t('providers.validation.apiKeyRequired')
+    if (concurrencyMode.value !== 'none') {
+      const mc = form.value.max_concurrency
+      if (!mc || mc < 1 || mc > MAX_CONCURRENCY) errs.max_concurrency = t('providers.validation.concurrencyRange', { min: 1, max: MAX_CONCURRENCY })
+      if (form.value.queue_timeout_ms < 0) errs.queue_timeout_ms = t('providers.validation.negativeNotAllowed')
+      const qs = form.value.max_queue_size
+      if (!qs || qs < 1 || qs > MAX_QUEUE_SIZE) errs.max_queue_size = t('providers.validation.queueSizeRange', { min: 1, max: MAX_QUEUE_SIZE })
+    }
+    errors.value = errs
+    return Object.keys(errs).length === 0
+  }
+
+  function buildPayload(): ProviderFormPayload {
+    const payload: ProviderFormPayload = {
+      name: form.value.name, api_type: form.value.api_type, base_url: form.value.base_url,
+      upstream_path: form.value.upstream_path || undefined,
+      models: form.value.models.map(m => ({
+        name: m.name, context_window: m.context_window ?? undefined,
+        patches: m.patches ?? undefined, stream_timeout_ms: m.stream_timeout_ms ?? undefined,
+      })),
+      is_active: form.value.is_active ? 1 : 0,
+      max_concurrency: concurrencyMode.value === 'none' ? 0 : form.value.max_concurrency,
+      queue_timeout_ms: concurrencyMode.value === 'none' ? 0 : form.value.queue_timeout_ms,
+      max_queue_size: concurrencyMode.value === 'none' ? DEFAULT_QUEUE_SIZE : form.value.max_queue_size,
+      adaptive_enabled: concurrencyMode.value === 'auto' ? 1 : 0,
+      proxy_type: form.value.proxy_type || null,
+      proxy_url: form.value.proxy_type ? form.value.proxy_url : null,
+      proxy_username: form.value.proxy_type ? form.value.proxy_username : null,
+      proxy_password: form.value.proxy_type && form.value.proxy_password ? form.value.proxy_password : null,
+    }
+    if (form.value.api_key) payload.api_key = form.value.api_key
+    return payload
+  }
+
+  function addModel() {
+    const input = modelInput.value.trim()
+    if (!input) return
+    const names = input.split(/[,，]/).map(s => s.trim()).filter(Boolean)
+    for (const name of names) {
+      if (!form.value.models.some(m => m.name === name)) {
+        form.value.models.push({ name, context_window: modelContextWindow.value || DEFAULT_CONTEXT_WINDOW, patches: [] })
+      }
+    }
+    modelInput.value = ''
+    modelContextWindow.value = DEFAULT_CONTEXT_WINDOW
+  }
+
+  function removeModel(index: number) { form.value.models.splice(index, 1) }
+
+  function updateModel(index: number, updated: ModelConfig) {
+    form.value.models[index].context_window = updated.contextWindow
+    form.value.models[index].patches = updated.patches
+  }
+
+  function updateModelTimeout(index: number, seconds: string | number) {
+    const val = Number(seconds)
+    form.value.models[index].stream_timeout_ms = val > 0 ? val * MS_PER_SECOND : null
+  }
+
+  function onConcurrencyModeChange(mode: ConcurrencyMode) {
+    concurrencyMode.value = mode
+    if (mode === 'auto') {
+      if (!form.value.max_concurrency || form.value.max_concurrency < 1) form.value.max_concurrency = DEFAULT_CONCURRENCY_AUTO
+      form.value.adaptive_enabled = true
+    } else if (mode === 'manual') {
+      if (!form.value.max_concurrency || form.value.max_concurrency < 1) form.value.max_concurrency = DEFAULT_CONCURRENCY
+      form.value.adaptive_enabled = false
+    }
+  }
+
+  function isOfficialOpenai(url: string): boolean {
+    return url.includes('api.openai.com')
+  }
+
+  function openCreate() {
+    editingId.value = null
+    form.value = { ...DEFAULT_FORM, models: [] }
+    concurrencyMode.value = 'auto'
+    modelInput.value = ''
+    modelContextWindow.value = DEFAULT_CONTEXT_WINDOW
+    presetHook.presetGroup.value = ''
+    presetHook.presetPlan.value = ''
+    errors.value = {}
+    dialogOpen.value = true
+  }
+
+  function openEdit(p: Provider) {
+    editingId.value = p.id
+    const mc = p.max_concurrency ?? 0
+    if (mc === 0) concurrencyMode.value = 'none'
+    else if (p.adaptive_enabled) concurrencyMode.value = 'auto'
+    else concurrencyMode.value = 'manual'
+    form.value = {
+      name: p.name, api_type: p.api_type, base_url: p.base_url,
+      upstream_path: p.upstream_path || '', api_key: '',
+      models: (p.models || []).map(m => ({
+        name: m.name, context_window: m.context_window ?? DEFAULT_CONTEXT_WINDOW,
+        patches: m.patches ?? [], stream_timeout_ms: m.stream_timeout_ms ?? null,
+      })),
+      is_active: !!p.is_active,
+      max_concurrency: concurrencyMode.value === 'none' ? DEFAULT_CONCURRENCY_AUTO : mc,
+      queue_timeout_ms: p.queue_timeout_ms ?? DEFAULT_QUEUE_TIMEOUT_MS,
+      max_queue_size: p.max_queue_size ?? DEFAULT_QUEUE_SIZE,
+      adaptive_enabled: concurrencyMode.value === 'auto',
+      proxy_type: p.proxy_type || '', proxy_url: p.proxy_url || '',
+      proxy_username: p.proxy_username || '', proxy_password: '',
+    }
+    presetHook.presetGroup.value = ''
+    presetHook.presetPlan.value = ''
+    modelInput.value = ''
+    modelContextWindow.value = DEFAULT_CONTEXT_WINDOW
+    errors.value = {}
+    dialogOpen.value = true
+    loadTransformRules(p.id)
+  }
+
+  return {
+    form, errors, concurrencyMode, dialogOpen, editingId,
+    modelInput, modelContextWindow, contextWindowSelect,
+    transformForm, presetHook,
+    validate, buildPayload,
+    addModel, removeModel, updateModel, updateModelTimeout,
+    onConcurrencyModeChange, isOfficialOpenai,
+    openCreate, openEdit, saveTransformRules,
+  }
+}

--- a/frontend/src/composables/useProviderPresets.ts
+++ b/frontend/src/composables/useProviderPresets.ts
@@ -1,0 +1,85 @@
+import { ref, computed } from 'vue'
+import { api, type ProviderGroup } from '@/api/client'
+import type { ModelInfo } from '@/types/mapping'
+import { getDefaultContextWindow } from '@/components/quick-setup/types'
+
+const DEFAULT_PATCHES_BY_KEYWORD = 'deepseek'
+
+export function useProviderPresets(form: { value: { name: string; api_type: string; base_url: string; models: ModelInfo[] } }) {
+  const providerPresets = ref<ProviderGroup[]>([])
+  const presetGroup = ref('')
+  const presetPlan = ref('')
+
+  const availablePlans = computed(() => {
+    if (!presetGroup.value) return []
+    return providerPresets.value.find(g => g.group === presetGroup.value)?.presets ?? []
+  })
+
+  function onGroupChange() {
+    if (presetGroup.value === '__custom__') {
+      presetPlan.value = ''
+      form.value.name = ''
+      form.value.api_type = 'openai'
+      form.value.base_url = ''
+      form.value.models = []
+      return
+    }
+    const plans = providerPresets.value.find(g => g.group === presetGroup.value)?.presets
+    if (plans?.length) {
+      presetPlan.value = plans[0].plan
+      onPresetChange()
+    } else {
+      presetPlan.value = ''
+    }
+  }
+
+  function onPresetChange() {
+    const preset = availablePlans.value.find(p => p.plan === presetPlan.value)
+    if (!preset) return
+    form.value.name = preset.presetName
+    form.value.api_type = preset.apiType
+    form.value.base_url = preset.baseUrl
+    form.value.models = preset.models.map(name => ({
+      name,
+      context_window: getDefaultContextWindow(name),
+      patches: getDefaultPatches(name, preset.apiType),
+    }))
+  }
+
+  function getDefaultPatches(modelName: string, apiType: string): string[] {
+    const patches: string[] = []
+    if (modelName.toLowerCase().includes(DEFAULT_PATCHES_BY_KEYWORD)) {
+      if (apiType === 'anthropic') {
+        patches.push('thinking-param', 'cache-control', 'thinking-blocks', 'orphan-tool-results')
+      } else {
+        patches.push('non-ds-tools', 'orphan-tool-results-oa')
+      }
+    }
+    return patches
+  }
+
+  async function loadPresets() {
+    try {
+      const result = await api.recommended.getProviders()
+      providerPresets.value = result
+    } catch {
+      providerPresets.value = []
+    }
+  }
+
+  function resetPreset() {
+    presetGroup.value = ''
+    presetPlan.value = ''
+  }
+
+  return {
+    providerPresets,
+    presetGroup,
+    presetPlan,
+    availablePlans,
+    onGroupChange,
+    onPresetChange,
+    loadPresets,
+    resetPreset,
+  }
+}

--- a/frontend/src/i18n/locales/en/providers.json
+++ b/frontend/src/i18n/locales/en/providers.json
@@ -36,7 +36,18 @@
     "availableModels": "Available Models",
     "modelInputPlaceholder": "Enter model names, separated by commas",
     "context": "Context",
-    "addModel": "Add"
+    "addModel": "Add",
+    "proxyTitle": "Proxy Configuration",
+    "proxyType": "Proxy Type",
+    "proxyNoProxy": "No Proxy",
+    "proxyHttp": "HTTP",
+    "proxySocks5": "SOCKS5",
+    "proxyUrl": "Proxy URL",
+    "proxyUrlPlaceholderHttp": "http://127.0.0.1:7890",
+    "proxyUrlPlaceholderSocks5": "socks5://127.0.0.1:1080",
+    "proxyUsername": "Username",
+    "proxyPassword": "Password",
+    "proxyAuthOptional": "Optional"
   },
   "concurrency": {
     "title": "Concurrency Control",

--- a/frontend/src/i18n/locales/en/providers.json
+++ b/frontend/src/i18n/locales/en/providers.json
@@ -47,7 +47,12 @@
     "proxyUrlPlaceholderSocks5": "socks5://127.0.0.1:1080",
     "proxyUsername": "Username",
     "proxyPassword": "Password",
-    "proxyAuthOptional": "Optional"
+    "proxyAuthOptional": "Optional",
+    "upstreamPath": "Upstream Path",
+    "upstreamPathPlaceholder": "Default: /v1/chat/completions or /v1/messages",
+    "upstreamPathHint": "Leave empty for API type default path",
+    "timeoutLabel": "Timeout(s)",
+    "timeoutPlaceholder": "Default"
   },
   "concurrency": {
     "title": "Concurrency Control",

--- a/frontend/src/i18n/locales/zh-CN/providers.json
+++ b/frontend/src/i18n/locales/zh-CN/providers.json
@@ -36,7 +36,18 @@
     "availableModels": "可用模型",
     "modelInputPlaceholder": "输入模型名称，多个用逗号分隔",
     "context": "上下文",
-    "addModel": "添加"
+    "addModel": "添加",
+    "proxyTitle": "代理配置",
+    "proxyType": "代理类型",
+    "proxyNoProxy": "无代理",
+    "proxyHttp": "HTTP",
+    "proxySocks5": "SOCKS5",
+    "proxyUrl": "代理地址",
+    "proxyUrlPlaceholderHttp": "http://127.0.0.1:7890",
+    "proxyUrlPlaceholderSocks5": "socks5://127.0.0.1:1080",
+    "proxyUsername": "用户名",
+    "proxyPassword": "密码",
+    "proxyAuthOptional": "可选"
   },
   "concurrency": {
     "title": "并发控制",

--- a/frontend/src/i18n/locales/zh-CN/providers.json
+++ b/frontend/src/i18n/locales/zh-CN/providers.json
@@ -47,7 +47,12 @@
     "proxyUrlPlaceholderSocks5": "socks5://127.0.0.1:1080",
     "proxyUsername": "用户名",
     "proxyPassword": "密码",
-    "proxyAuthOptional": "可选"
+    "proxyAuthOptional": "可选",
+    "upstreamPath": "上游路径",
+    "upstreamPathPlaceholder": "默认: /v1/chat/completions 或 /v1/messages",
+    "upstreamPathHint": "留空使用 API 类型默认路径",
+    "timeoutLabel": "超时(秒)",
+    "timeoutPlaceholder": "默认"
   },
   "concurrency": {
     "title": "并发控制",

--- a/frontend/src/types/mapping.ts
+++ b/frontend/src/types/mapping.ts
@@ -41,6 +41,10 @@ export interface Provider {
   queue_timeout_ms: number
   max_queue_size: number
   adaptive_enabled: number
+  proxy_type: string | null
+  proxy_url: string | null
+  proxy_username: string | null
+  proxy_password: string | null
 }
 
 /** Provider 精简信息（映射配置、下拉选择等场景使用） */

--- a/frontend/src/views/Providers.vue
+++ b/frontend/src/views/Providers.vue
@@ -35,7 +35,12 @@
             <TableCell>
               <Badge variant="secondary">{{ API_TYPE_LABELS[p.api_type] ?? p.api_type }}</Badge>
             </TableCell>
-            <TableCell class="text-muted-foreground">{{ p.base_url }}</TableCell>
+            <TableCell>
+              <div class="flex items-center gap-1">
+                <span class="text-muted-foreground">{{ p.base_url }}</span>
+                <Shield v-if="p.proxy_type" class="w-3 h-3 text-muted-foreground" :title="`Proxy: ${p.proxy_type.toUpperCase()}`" />
+              </div>
+            </TableCell>
             <TableCell class="text-muted-foreground text-xs">{{ p.upstream_path || (p.api_type === 'anthropic' ? '/v1/messages' : '/v1/chat/completions') }}</TableCell>
             <TableCell>
               <div class="flex items-center gap-1">
@@ -157,6 +162,38 @@
             <Label class="text-xs">Upstream Path</Label>
             <Input v-model="form.upstream_path" placeholder="默认: /v1/chat/completions 或 /v1/messages" class="mt-1 font-mono text-xs" />
             <p class="text-xs text-muted-foreground mt-0.5">留空使用 API 类型默认路径</p>
+          </div>
+
+          <!-- Proxy Configuration -->
+          <div class="border rounded-md p-3 space-y-3">
+            <div class="text-xs font-medium text-muted-foreground">{{ t('providers.fields.proxyTitle') }}</div>
+            <div class="grid grid-cols-2 gap-3">
+              <div>
+                <Label class="text-xs text-muted-foreground">{{ t('providers.fields.proxyType') }}</Label>
+                <Select v-model="form.proxy_type" class="mt-1" @update:model-value="onProxyTypeChange">
+                  <SelectTrigger><SelectValue /></SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="">{{ t('providers.fields.proxyNoProxy') }}</SelectItem>
+                    <SelectItem value="http">{{ t('providers.fields.proxyHttp') }}</SelectItem>
+                    <SelectItem value="socks5">{{ t('providers.fields.proxySocks5') }}</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div v-if="form.proxy_type">
+                <Label class="text-xs text-muted-foreground">{{ t('providers.fields.proxyUrl') }}</Label>
+                <Input v-model="form.proxy_url" type="text" class="mt-1 font-mono text-xs" :placeholder="form.proxy_type === 'socks5' ? t('providers.fields.proxyUrlPlaceholderSocks5') : t('providers.fields.proxyUrlPlaceholderHttp')" />
+              </div>
+            </div>
+            <div v-if="form.proxy_type" class="grid grid-cols-2 gap-3">
+              <div>
+                <Label class="text-xs text-muted-foreground">{{ t('providers.fields.proxyUsername') }}</Label>
+                <Input v-model="form.proxy_username" type="text" class="mt-1" :placeholder="t('providers.fields.proxyAuthOptional')" />
+              </div>
+              <div>
+                <Label class="text-xs text-muted-foreground">{{ t('providers.fields.proxyPassword') }}</Label>
+                <Input v-model="form.proxy_password" type="password" class="mt-1" :placeholder="t('providers.fields.proxyAuthOptional')" />
+              </div>
+            </div>
           </div>
 
           <!-- 可用模型 -->
@@ -289,7 +326,7 @@ import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@
 import { Table, TableHeader, TableBody, TableRow, TableHead, TableCell } from '@/components/ui/table'
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog'
 import { AlertDialog, AlertDialogContent, AlertDialogHeader, AlertDialogTitle, AlertDialogDescription, AlertDialogFooter, AlertDialogCancel, AlertDialogAction } from '@/components/ui/alert-dialog'
-import { RotateCw, Copy, Check } from 'lucide-vue-next'
+import { RotateCw, Copy, Check, Shield } from 'lucide-vue-next'
 import ConcurrencyControl from '@/components/shared/ConcurrencyControl.vue'
 import TransformRulesForm from '@/components/shared/TransformRulesForm.vue'
 import ModelCard from '@/components/quick-setup/ModelCard.vue'
@@ -315,7 +352,7 @@ const CONTEXT_WINDOW_OPTIONS = [
   { label: '1M', value: '1000000' },
 ] as const
 const API_TYPE_LABELS: Record<string, string> = { openai: 'OpenAI Chat Completions', 'openai-responses': 'OpenAI Responses', anthropic: 'Anthropic Messages' }
-const DEFAULT_FORM = { name: '', api_type: 'anthropic', base_url: '', upstream_path: '' as string, api_key: '', models: [] as ModelInfo[], is_active: true, max_concurrency: DEFAULT_CONCURRENCY_AUTO, queue_timeout_ms: DEFAULT_QUEUE_TIMEOUT_MS, max_queue_size: DEFAULT_QUEUE_SIZE, adaptive_enabled: true }
+const DEFAULT_FORM = { name: '', api_type: 'anthropic', base_url: '', upstream_path: '' as string, api_key: '', models: [] as ModelInfo[], is_active: true, max_concurrency: DEFAULT_CONCURRENCY_AUTO, queue_timeout_ms: DEFAULT_QUEUE_TIMEOUT_MS, max_queue_size: DEFAULT_QUEUE_SIZE, adaptive_enabled: true, proxy_type: '' as string, proxy_url: '', proxy_username: '', proxy_password: '' }
 const modelInput = ref('')
 const modelContextWindow = ref(DEFAULT_CONTEXT_WINDOW)
 const contextWindowSelect = computed({
@@ -480,6 +517,14 @@ function onConcurrencyModeChange(mode: ConcurrencyMode) {
   }
 }
 
+function onProxyTypeChange(val: unknown) {
+  if (!val) {
+    form.value.proxy_url = ''
+    form.value.proxy_username = ''
+    form.value.proxy_password = ''
+  }
+}
+
 function openCreate() {
   editingId.value = null
   form.value = { ...DEFAULT_FORM, models: [] }
@@ -501,7 +546,7 @@ function openEdit(p: Provider) {
   } else {
     concurrencyMode.value = 'manual'
   }
-  form.value = { name: p.name, api_type: p.api_type, base_url: p.base_url, upstream_path: p.upstream_path || '', api_key: '', models: (p.models || []).map(m => ({ name: m.name, context_window: m.context_window ?? DEFAULT_CONTEXT_WINDOW, patches: m.patches ?? [], stream_timeout_ms: m.stream_timeout_ms ?? null })), is_active: !!p.is_active, max_concurrency: concurrencyMode.value === 'none' ? DEFAULT_CONCURRENCY_AUTO : mc, queue_timeout_ms: p.queue_timeout_ms ?? DEFAULT_QUEUE_TIMEOUT_MS, max_queue_size: p.max_queue_size ?? DEFAULT_QUEUE_SIZE, adaptive_enabled: concurrencyMode.value === 'auto' }
+  form.value = { name: p.name, api_type: p.api_type, base_url: p.base_url, upstream_path: p.upstream_path || '', api_key: '', models: (p.models || []).map(m => ({ name: m.name, context_window: m.context_window ?? DEFAULT_CONTEXT_WINDOW, patches: m.patches ?? [], stream_timeout_ms: m.stream_timeout_ms ?? null })), is_active: !!p.is_active, max_concurrency: concurrencyMode.value === 'none' ? DEFAULT_CONCURRENCY_AUTO : mc, queue_timeout_ms: p.queue_timeout_ms ?? DEFAULT_QUEUE_TIMEOUT_MS, max_queue_size: p.max_queue_size ?? DEFAULT_QUEUE_SIZE, adaptive_enabled: concurrencyMode.value === 'auto', proxy_type: p.proxy_type || '', proxy_url: p.proxy_url || '', proxy_username: p.proxy_username || '', proxy_password: '' }
   modelInput.value = ''
   modelContextWindow.value = DEFAULT_CONTEXT_WINDOW
   presetGroup.value = ''
@@ -511,7 +556,7 @@ function openEdit(p: Provider) {
   loadTransformRules(p.id)
 }
 
-type ProviderFormPayload = Pick<ProviderPayload, 'name' | 'api_type' | 'base_url' | 'upstream_path' | 'models' | 'is_active' | 'max_concurrency' | 'queue_timeout_ms' | 'max_queue_size' | 'adaptive_enabled'> & { api_key?: string }
+type ProviderFormPayload = Pick<ProviderPayload, 'name' | 'api_type' | 'base_url' | 'upstream_path' | 'models' | 'is_active' | 'max_concurrency' | 'queue_timeout_ms' | 'max_queue_size' | 'adaptive_enabled' | 'proxy_type' | 'proxy_url' | 'proxy_username' | 'proxy_password'> & { api_key?: string }
 
 function buildPayload(): ProviderFormPayload {
   const payload: ProviderFormPayload = {
@@ -525,6 +570,10 @@ function buildPayload(): ProviderFormPayload {
     queue_timeout_ms: concurrencyMode.value === 'none' ? 0 : form.value.queue_timeout_ms,
     max_queue_size: concurrencyMode.value === 'none' ? DEFAULT_QUEUE_SIZE : form.value.max_queue_size,
     adaptive_enabled: concurrencyMode.value === 'auto' ? 1 : 0,
+    proxy_type: form.value.proxy_type || null,
+    proxy_url: form.value.proxy_type ? form.value.proxy_url : null,
+    proxy_username: form.value.proxy_type ? form.value.proxy_username : null,
+    proxy_password: form.value.proxy_type && form.value.proxy_password ? form.value.proxy_password : null,
   }
   if (form.value.api_key) payload.api_key = form.value.api_key
   return payload

--- a/frontend/src/views/Providers.vue
+++ b/frontend/src/views/Providers.vue
@@ -66,18 +66,10 @@
             </TableCell>
             <TableCell>
               <Button variant="ghost" size="sm" class="gap-1.5" @click="confirmToggle(p)">
-                <span
-                  class="relative inline-flex h-4 w-7 shrink-0 items-center rounded-full transition-colors"
-                  :class="p.is_active ? 'bg-primary' : 'bg-input'"
-                >
-                  <span
-                    class="inline-block h-3 w-3 rounded-full bg-background shadow-sm transition-transform"
-                    :class="p.is_active ? 'translate-x-3.5' : 'translate-x-0.5'"
-                  />
+                <span class="relative inline-flex h-4 w-7 shrink-0 items-center rounded-full transition-colors" :class="p.is_active ? 'bg-primary' : 'bg-input'">
+                  <span class="inline-block h-3 w-3 rounded-full bg-background shadow-sm transition-transform" :class="p.is_active ? 'translate-x-3.5' : 'translate-x-0.5'" />
                 </span>
-                <Badge :variant="p.is_active ? 'default' : 'secondary'">
-                  {{ p.is_active ? t('common.enabled') : t('common.disabled') }}
-                </Badge>
+                <Badge :variant="p.is_active ? 'default' : 'secondary'">{{ p.is_active ? t('common.enabled') : t('common.disabled') }}</Badge>
               </Button>
             </TableCell>
             <TableCell class="text-right">
@@ -120,15 +112,12 @@
               </Select>
             </div>
           </div>
-
           <!-- 未选模板提示 (仅新建模式) -->
           <div v-if="!presetGroup && !editingId" class="flex flex-col items-center justify-center py-10 text-muted-foreground">
             <svg class="w-10 h-10 mb-3 opacity-30" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M9 12l2 2 4-4"/></svg>
             <span class="text-sm">{{ t('providers.template.selectFirst') }}</span>
           </div>
-
           <template v-if="presetGroup || editingId">
-          <!-- 基本信息 2x2 -->
           <div class="grid grid-cols-2 gap-3">
             <div>
               <Label class="text-xs text-muted-foreground">{{ t('providers.fields.name') }}</Label>
@@ -157,45 +146,17 @@
               <p v-if="errors.api_key" class="text-xs text-destructive mt-0.5">{{ errors.api_key }}</p>
             </div>
           </div>
-          <!-- Upstream Path -->
           <div>
-            <Label class="text-xs">Upstream Path</Label>
-            <Input v-model="form.upstream_path" placeholder="默认: /v1/chat/completions 或 /v1/messages" class="mt-1 font-mono text-xs" />
-            <p class="text-xs text-muted-foreground mt-0.5">留空使用 API 类型默认路径</p>
+            <Label class="text-xs">{{ t('providers.fields.upstreamPath') }}</Label>
+            <Input v-model="form.upstream_path" :placeholder="t('providers.fields.upstreamPathPlaceholder')" class="mt-1 font-mono text-xs" />
+            <p class="text-xs text-muted-foreground mt-0.5">{{ t('providers.fields.upstreamPathHint') }}</p>
           </div>
-
-          <!-- Proxy Configuration -->
-          <div class="border rounded-md p-3 space-y-3">
-            <div class="text-xs font-medium text-muted-foreground">{{ t('providers.fields.proxyTitle') }}</div>
-            <div class="grid grid-cols-2 gap-3">
-              <div>
-                <Label class="text-xs text-muted-foreground">{{ t('providers.fields.proxyType') }}</Label>
-                <Select v-model="form.proxy_type" class="mt-1" @update:model-value="onProxyTypeChange">
-                  <SelectTrigger><SelectValue /></SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="">{{ t('providers.fields.proxyNoProxy') }}</SelectItem>
-                    <SelectItem value="http">{{ t('providers.fields.proxyHttp') }}</SelectItem>
-                    <SelectItem value="socks5">{{ t('providers.fields.proxySocks5') }}</SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
-              <div v-if="form.proxy_type">
-                <Label class="text-xs text-muted-foreground">{{ t('providers.fields.proxyUrl') }}</Label>
-                <Input v-model="form.proxy_url" type="text" class="mt-1 font-mono text-xs" :placeholder="form.proxy_type === 'socks5' ? t('providers.fields.proxyUrlPlaceholderSocks5') : t('providers.fields.proxyUrlPlaceholderHttp')" />
-              </div>
-            </div>
-            <div v-if="form.proxy_type" class="grid grid-cols-2 gap-3">
-              <div>
-                <Label class="text-xs text-muted-foreground">{{ t('providers.fields.proxyUsername') }}</Label>
-                <Input v-model="form.proxy_username" type="text" class="mt-1" :placeholder="t('providers.fields.proxyAuthOptional')" />
-              </div>
-              <div>
-                <Label class="text-xs text-muted-foreground">{{ t('providers.fields.proxyPassword') }}</Label>
-                <Input v-model="form.proxy_password" type="password" class="mt-1" :placeholder="t('providers.fields.proxyAuthOptional')" />
-              </div>
-            </div>
-          </div>
-
+          <ProxyConfigForm
+            :proxy-type="form.proxy_type" :proxy-url="form.proxy_url" :proxy-username="form.proxy_username" :proxy-password="form.proxy_password"
+            @update:proxy-type="form.proxy_type = $event" @update:proxy-url="form.proxy_url = $event"
+            @update:proxy-username="form.proxy_username = $event" @update:proxy-password="form.proxy_password = $event"
+            @clear="form.proxy_url = ''; form.proxy_username = ''; form.proxy_password = ''"
+          />
           <!-- 可用模型 -->
           <div>
             <Label class="text-xs text-muted-foreground mb-2">{{ t('providers.fields.availableModels') }}</Label>
@@ -203,21 +164,14 @@
               <div v-for="(m, i) in form.models" :key="i">
                 <ModelCard
                   :model="{ name: m.name, contextWindow: m.context_window ?? 200000, enabled: true, patches: m.patches ?? [] }"
-                  :api-type="form.api_type"
-                  :is-deep-seek="m.name.toLowerCase().includes('deepseek')"
+                  :api-type="form.api_type" :is-deep-seek="m.name.toLowerCase().includes('deepseek')"
                   :is-non-openai-endpoint="!isOfficialOpenai(form.base_url)"
-                  @update:model="updateModel(i, $event)"
-                  @remove="removeModel(i)"
+                  @update:model="updateModel(i, $event)" @remove="removeModel(i)"
                 />
                 <div class="flex items-center gap-1.5 mt-1.5">
-                  <Label class="text-xs text-muted-foreground whitespace-nowrap">Timeout(s)</Label>
-                  <Input
-                    type="number"
-                    :model-value="m.stream_timeout_ms ? Math.round(m.stream_timeout_ms / 1000) : ''"
-                    @update:model-value="updateModelTimeout(i, $event)"
-                    placeholder="默认"
-                    class="h-7 text-xs"
-                    min="1"
+                  <Label class="text-xs text-muted-foreground whitespace-nowrap">{{ t('providers.fields.timeoutLabel') }}</Label>
+                  <Input type="number" :model-value="m.stream_timeout_ms ? Math.round(m.stream_timeout_ms / 1000) : ''"
+                    @update:model-value="updateModelTimeout(i, $event)" :placeholder="t('providers.fields.timeoutPlaceholder')" class="h-7 text-xs" min="1"
                   />
                 </div>
               </div>
@@ -233,31 +187,20 @@
               <Button type="button" variant="outline" size="sm" @click="addModel" :disabled="!modelInput.trim()">{{ t('providers.fields.addModel') }}</Button>
             </div>
           </div>
-
-          <!-- 并发控制 + 转换规则 2 columns -->
           <div class="grid grid-cols-2 gap-4">
-            <!-- 并发控制 -->
             <div class="border rounded-md p-3 space-y-3">
               <div class="text-xs font-medium text-muted-foreground">{{ t('providers.concurrency.title') }}</div>
-              <ConcurrencyControl
-                :mode="concurrencyMode"
-                :max-concurrency="form.max_concurrency"
-                :queue-timeout-ms="form.queue_timeout_ms"
-                :max-queue-size="form.max_queue_size"
-                compact
-                @update:mode="(v: unknown) => onConcurrencyModeChange(v as 'auto' | 'manual' | 'none')"
+              <ConcurrencyControl :mode="concurrencyMode" :max-concurrency="form.max_concurrency"
+                :queue-timeout-ms="form.queue_timeout_ms" :max-queue-size="form.max_queue_size" compact
+                @update:mode="(v: unknown) => onConcurrencyModeChange(v as ConcurrencyMode)"
                 @update:max-concurrency="form.max_concurrency = $event"
                 @update:queue-timeout-ms="form.queue_timeout_ms = $event"
                 @update:max-queue-size="form.max_queue_size = $event"
               />
             </div>
-
-            <!-- 转换规则 -->
             <div class="border rounded-md p-3 space-y-3">
               <div class="text-xs font-medium text-muted-foreground">{{ t('providers.transform.title') }}</div>
-              <TransformRulesForm
-                :inject-headers="transformForm.injectHeadersInput"
-                :drop-fields="transformForm.dropFieldsInput"
+              <TransformRulesForm :inject-headers="transformForm.injectHeadersInput" :drop-fields="transformForm.dropFieldsInput"
                 :request-defaults="transformForm.requestDefaultsInput"
                 @update:inject-headers="transformForm.injectHeadersInput = $event"
                 @update:drop-fields="transformForm.dropFieldsInput = $event"
@@ -265,9 +208,7 @@
               />
             </div>
           </div>
-
           </template>
-
           <DialogFooter>
             <Button type="button" variant="outline" @click="dialogOpen = false">{{ t('common.cancel') }}</Button>
             <Button type="submit">{{ t('common.save') }}</Button>
@@ -310,14 +251,10 @@
   </div>
 </template>
 <script setup lang="ts">
-import { ref, computed, onMounted } from 'vue'
+import { onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { toast } from 'vue-sonner'
-import * as z from 'zod'
-import { api, getApiMessage, type ProviderPayload, type ProviderGroup } from '@/api/client'
-import type { Provider, ModelInfo } from '@/types/mapping'
-import { DEFAULT_CONTEXT_WINDOW } from '@/constants'
-import { getDefaultContextWindow } from '@/components/quick-setup/types'
+import { api, getApiMessage } from '@/api/client'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -329,255 +266,31 @@ import { AlertDialog, AlertDialogContent, AlertDialogHeader, AlertDialogTitle, A
 import { RotateCw, Copy, Check, Shield } from 'lucide-vue-next'
 import ConcurrencyControl from '@/components/shared/ConcurrencyControl.vue'
 import TransformRulesForm from '@/components/shared/TransformRulesForm.vue'
+import ProxyConfigForm from '@/components/shared/ProxyConfigForm.vue'
 import ModelCard from '@/components/quick-setup/ModelCard.vue'
-import type { ModelConfig } from '@/components/quick-setup/types'
-import { useTransformRules } from '@/composables/useTransformRules'
-const DEFAULT_CONCURRENCY = 3
-const DEFAULT_CONCURRENCY_AUTO = 10
-const DEFAULT_QUEUE_TIMEOUT_MS = 120_000
-const DEFAULT_QUEUE_SIZE = 10
-const MAX_CONCURRENCY = 100
-const MAX_QUEUE_SIZE = 1000
-const CONTEXT_K = 1000
-const CONTEXT_M = 1_000_000
-const CONTEXT_WINDOW_OPTIONS = [
-  { label: '8K', value: '8000' },
-  { label: '16K', value: '16000' },
-  { label: '32K', value: '32000' },
-  { label: '64K', value: '64000' },
-  { label: '128K', value: '128000' },
-  { label: '160K', value: '160000' },
-  { label: '200K', value: '200000' },
-  { label: '256K', value: '256000' },
-  { label: '1M', value: '1000000' },
-] as const
-const API_TYPE_LABELS: Record<string, string> = { openai: 'OpenAI Chat Completions', 'openai-responses': 'OpenAI Responses', anthropic: 'Anthropic Messages' }
-const DEFAULT_FORM = { name: '', api_type: 'anthropic', base_url: '', upstream_path: '' as string, api_key: '', models: [] as ModelInfo[], is_active: true, max_concurrency: DEFAULT_CONCURRENCY_AUTO, queue_timeout_ms: DEFAULT_QUEUE_TIMEOUT_MS, max_queue_size: DEFAULT_QUEUE_SIZE, adaptive_enabled: true, proxy_type: '' as string, proxy_url: '', proxy_username: '', proxy_password: '' }
-const modelInput = ref('')
-const modelContextWindow = ref(DEFAULT_CONTEXT_WINDOW)
-const contextWindowSelect = computed({
-  get: () => String(modelContextWindow.value),
-  set: (val: string) => { modelContextWindow.value = Number(val) },
-})
-const providers = ref<Provider[]>([])
-const providerPresets = ref<ProviderGroup[]>([])
-const dialogOpen = ref(false)
-const editingId = ref<string | null>(null)
-const deleteTarget = ref<Provider | null>(null)
-const toggleTarget = ref<Provider | null>(null)
-const pendingToggleId = ref<string | null>(null)
-const pendingToggleActive = ref<boolean>(false)
-const toggleDependencies = ref<string[]>([])
-const form = ref({ ...DEFAULT_FORM })
-const errors = ref<Record<string, string>>({})
-type ConcurrencyMode = 'auto' | 'manual' | 'none'
-const concurrencyMode = ref<ConcurrencyMode>('auto')
-// Transform rules state
+import { useProviderForm, API_TYPE_LABELS, CONTEXT_WINDOW_OPTIONS, CONTEXT_K, CONTEXT_M } from '@/composables/useProviderForm'
+import type { ConcurrencyMode } from '@/composables/useProviderForm'
+import { useProviderActions } from '@/composables/useProviderActions'
+
 const { t } = useI18n()
-const { transformForm, loadTransformRules, saveTransformRules } = useTransformRules()
-const copiedId = ref<string | null>(null)
-const reloading = ref(false)
-const MASK_VISIBLE_LEN = 7, MASK_ASTERISK_COUNT = 7, COPY_FEEDBACK_MS = 2000
-function validate(): boolean {
-  const providerSchema = z.object({
-    name: z.string().min(1, t('providers.validation.nameRequired')).regex(/^[a-zA-Z0-9_-]+$/, t('providers.validation.namePattern')),
-    base_url: z.string().min(1, t('providers.validation.baseUrlRequired')).url(t('providers.validation.baseUrlInvalid')),
-  })
-  const errs: Record<string, string> = {}
-  const result = providerSchema.safeParse({ name: form.value.name.trim(), base_url: form.value.base_url.trim() })
-  if (!result.success) {
-    for (const issue of result.error.issues) {
-      const field = issue.path[0] as string
-      if (!errs[field]) errs[field] = issue.message
-    }
-  }
-  if (!editingId.value && !form.value.api_key.trim()) errs.api_key = t('providers.validation.apiKeyRequired')
-  if (concurrencyMode.value !== 'none') {
-    const mc = form.value.max_concurrency
-    if (!mc || mc < 1 || mc > MAX_CONCURRENCY) errs.max_concurrency = t('providers.validation.concurrencyRange', { min: 1, max: MAX_CONCURRENCY })
-    if (form.value.queue_timeout_ms < 0) errs.queue_timeout_ms = t('providers.validation.negativeNotAllowed')
-    const qs = form.value.max_queue_size
-    if (!qs || qs < 1 || qs > MAX_QUEUE_SIZE) errs.max_queue_size = t('providers.validation.queueSizeRange', { min: 1, max: MAX_QUEUE_SIZE })
-  }
-  errors.value = errs
-  return Object.keys(errs).length === 0
-}
-function maskKey(key: string): string {
-  if (!key) return ''
-  const visible = key.slice(0, MASK_VISIBLE_LEN)
-  return visible + '*'.repeat(MASK_ASTERISK_COUNT)
-}
+const {
+  form, errors, concurrencyMode, dialogOpen, editingId,
+  modelInput, contextWindowSelect, transformForm, presetHook,
+  validate, buildPayload, addModel, removeModel, updateModel, updateModelTimeout,
+  onConcurrencyModeChange, isOfficialOpenai, openCreate, openEdit, saveTransformRules,
+} = useProviderForm()
+const { providerPresets, presetGroup, presetPlan, availablePlans, onGroupChange, onPresetChange, loadPresets } = presetHook
+const {
+  providers, reloading, copiedId, deleteTarget, toggleTarget, toggleDependencies,
+  maskKey, copyKey, loadProviders, confirmDelete, confirmToggle, handleToggle, handleDelete, handleReload,
+} = useProviderActions()
+
 function formatContextWindow(tokens: number): string {
   if (tokens >= CONTEXT_M) return `${tokens / CONTEXT_M}M`
   if (tokens >= CONTEXT_K) return `${tokens / CONTEXT_K}K`
   return String(tokens)
 }
-async function copyKey(key: string, id: string) {
-  await navigator.clipboard.writeText(key)
-  copiedId.value = id
-  setTimeout(() => { copiedId.value = null }, COPY_FEEDBACK_MS)
-}
-const presetGroup = ref(''), presetPlan = ref('')
-const availablePlans = computed(() => {
-  if (!presetGroup.value) return []
-  return providerPresets.value.find(g => g.group === presetGroup.value)?.presets ?? []
-})
-function onGroupChange() {
-  if (presetGroup.value === '__custom__') {
-    presetPlan.value = ''
-    form.value.name = ''
-    form.value.api_type = 'openai'
-    form.value.base_url = ''
-    form.value.models = []
-    return
-  }
-  const plans = providerPresets.value.find(g => g.group === presetGroup.value)?.presets
-  if (plans?.length) {
-    presetPlan.value = plans[0].plan
-    onPresetChange()
-  } else {
-    presetPlan.value = ''
-  }
-}
-function onPresetChange() {
-  const preset = availablePlans.value.find(p => p.plan === presetPlan.value)
-  if (!preset) return
-  form.value.name = preset.presetName
-  form.value.api_type = preset.apiType
-  form.value.base_url = preset.baseUrl
-  form.value.models = preset.models.map(name => ({
-    name,
-    context_window: getDefaultContextWindow(name),
-    patches: getDefaultPatches(name, preset.apiType),
-  }))
-}
-async function loadProviders() {
-  try {
-    const data = await api.getProviders()
-    providers.value = data
-  } catch (e: unknown) {
-    console.error('Failed to load providers:', e)
-    toast.error(getApiMessage(e, t('providers.toast.loadFailed')))
-  }
-}
-function addModel() {
-  const input = modelInput.value.trim()
-  if (!input) return
-  const names = input.split(/[,，]/).map(s => s.trim()).filter(Boolean)
-  for (const name of names) {
-    if (!form.value.models.some(m => m.name === name)) {
-      form.value.models.push({ name, context_window: modelContextWindow.value || DEFAULT_CONTEXT_WINDOW, patches: [] })
-    }
-  }
-  modelInput.value = ''
-  modelContextWindow.value = DEFAULT_CONTEXT_WINDOW
-}
-function removeModel(index: number) {
-  form.value.models.splice(index, 1)
-}
 
-function isOfficialOpenai(url: string): boolean {
-  return url.includes('api.openai.com')
-}
-
-function updateModel(index: number, updated: ModelConfig) {
-  form.value.models[index].context_window = updated.contextWindow
-  form.value.models[index].patches = updated.patches
-}
-
-function updateModelTimeout(index: number, seconds: string | number) {
-  const val = Number(seconds)
-  if (val > 0) {
-    form.value.models[index].stream_timeout_ms = val * 1000
-  } else {
-    form.value.models[index].stream_timeout_ms = null
-  }
-}
-
-function getDefaultPatches(modelName: string, apiType: string): string[] {
-  const patches: string[] = []
-  if (modelName.toLowerCase().includes('deepseek')) {
-    if (apiType === 'anthropic') {
-      patches.push('thinking-param', 'cache-control', 'thinking-blocks', 'orphan-tool-results')
-    } else {
-      patches.push('non-ds-tools', 'orphan-tool-results-oa')
-    }
-  }
-  return patches
-}
-
-function onConcurrencyModeChange(mode: ConcurrencyMode) {
-  concurrencyMode.value = mode
-  if (mode === 'auto') {
-    if (!form.value.max_concurrency || form.value.max_concurrency < 1) form.value.max_concurrency = DEFAULT_CONCURRENCY_AUTO
-    form.value.adaptive_enabled = true
-  } else if (mode === 'manual') {
-    if (!form.value.max_concurrency || form.value.max_concurrency < 1) form.value.max_concurrency = DEFAULT_CONCURRENCY
-    form.value.adaptive_enabled = false
-  }
-}
-
-function onProxyTypeChange(val: unknown) {
-  if (!val) {
-    form.value.proxy_url = ''
-    form.value.proxy_username = ''
-    form.value.proxy_password = ''
-  }
-}
-
-function openCreate() {
-  editingId.value = null
-  form.value = { ...DEFAULT_FORM, models: [] }
-  concurrencyMode.value = 'auto'
-  modelInput.value = ''
-  modelContextWindow.value = DEFAULT_CONTEXT_WINDOW
-  presetGroup.value = ''
-  presetPlan.value = ''
-  errors.value = {}
-  dialogOpen.value = true
-}
-function openEdit(p: Provider) {
-  editingId.value = p.id
-  const mc = p.max_concurrency ?? 0
-  if (mc === 0) {
-    concurrencyMode.value = 'none'
-  } else if (p.adaptive_enabled) {
-    concurrencyMode.value = 'auto'
-  } else {
-    concurrencyMode.value = 'manual'
-  }
-  form.value = { name: p.name, api_type: p.api_type, base_url: p.base_url, upstream_path: p.upstream_path || '', api_key: '', models: (p.models || []).map(m => ({ name: m.name, context_window: m.context_window ?? DEFAULT_CONTEXT_WINDOW, patches: m.patches ?? [], stream_timeout_ms: m.stream_timeout_ms ?? null })), is_active: !!p.is_active, max_concurrency: concurrencyMode.value === 'none' ? DEFAULT_CONCURRENCY_AUTO : mc, queue_timeout_ms: p.queue_timeout_ms ?? DEFAULT_QUEUE_TIMEOUT_MS, max_queue_size: p.max_queue_size ?? DEFAULT_QUEUE_SIZE, adaptive_enabled: concurrencyMode.value === 'auto', proxy_type: p.proxy_type || '', proxy_url: p.proxy_url || '', proxy_username: p.proxy_username || '', proxy_password: '' }
-  modelInput.value = ''
-  modelContextWindow.value = DEFAULT_CONTEXT_WINDOW
-  presetGroup.value = ''
-  presetPlan.value = ''
-  errors.value = {}
-  dialogOpen.value = true
-  loadTransformRules(p.id)
-}
-
-type ProviderFormPayload = Pick<ProviderPayload, 'name' | 'api_type' | 'base_url' | 'upstream_path' | 'models' | 'is_active' | 'max_concurrency' | 'queue_timeout_ms' | 'max_queue_size' | 'adaptive_enabled' | 'proxy_type' | 'proxy_url' | 'proxy_username' | 'proxy_password'> & { api_key?: string }
-
-function buildPayload(): ProviderFormPayload {
-  const payload: ProviderFormPayload = {
-    name: form.value.name,
-    api_type: form.value.api_type,
-    base_url: form.value.base_url,
-    upstream_path: form.value.upstream_path || undefined,
-    models: form.value.models.map(m => ({ name: m.name, context_window: m.context_window ?? undefined, patches: m.patches ?? undefined, stream_timeout_ms: m.stream_timeout_ms ?? undefined })),
-    is_active: form.value.is_active ? 1 : 0,
-    max_concurrency: concurrencyMode.value === 'none' ? 0 : form.value.max_concurrency,
-    queue_timeout_ms: concurrencyMode.value === 'none' ? 0 : form.value.queue_timeout_ms,
-    max_queue_size: concurrencyMode.value === 'none' ? DEFAULT_QUEUE_SIZE : form.value.max_queue_size,
-    adaptive_enabled: concurrencyMode.value === 'auto' ? 1 : 0,
-    proxy_type: form.value.proxy_type || null,
-    proxy_url: form.value.proxy_type ? form.value.proxy_url : null,
-    proxy_username: form.value.proxy_type ? form.value.proxy_username : null,
-    proxy_password: form.value.proxy_type && form.value.proxy_password ? form.value.proxy_password : null,
-  }
-  if (form.value.api_key) payload.api_key = form.value.api_key
-  return payload
-}
 async function handleSave() {
   if (!validate()) return
   try {
@@ -591,7 +304,6 @@ async function handleSave() {
       const result = await api.createProvider(payload)
       providerId = result.id
     }
-    // Save transform rules along with the provider
     await saveTransformRules(providerId)
     dialogOpen.value = false
     await loadProviders()
@@ -600,72 +312,8 @@ async function handleSave() {
     toast.error(getApiMessage(e, t('providers.toast.saveFailed')))
   }
 }
-function confirmDelete(p: Provider) {
-  deleteTarget.value = p
-}
-async function confirmToggle(p: Provider) {
-  toggleTarget.value = p
-  pendingToggleId.value = p.id
-  pendingToggleActive.value = !!p.is_active
-  toggleDependencies.value = []
-  if (p.is_active) {
-    try {
-      const result = await api.getProviderDependencies(p.id)
-      toggleDependencies.value = result.references
-    } catch { /* eslint-disable-line taste/no-silent-catch -- 依赖查询失败不阻塞 toggle 弹框 */ }
-  }
-}
-async function handleToggle() {
-  const id = pendingToggleId.value
-  if (!id) return
-  const wasActive = pendingToggleActive.value
-  toggleTarget.value = null
-  pendingToggleId.value = null
-  try {
-    const res = await api.updateProvider(id, { is_active: wasActive ? 0 : 1 })
-    if (res.cascadedGroups?.length) {
-      const disabled = res.cascadedGroups.filter((g: { disabled: boolean }) => g.disabled).length
-      const cleaned = res.cascadedGroups.length - disabled
-      const parts: string[] = []
-      if (cleaned > 0) parts.push(t('providers.toast.cascadeClean', { count: cleaned }))
-      if (disabled > 0) parts.push(t('providers.toast.cascadeDisable', { count: disabled }))
-      toast.warning(t('providers.toast.cascadeAuto', { actions: parts.join(', ') }))
-    }
-    await loadProviders()
-  } catch (e: unknown) {
-    console.error('Failed to toggle provider:', e)
-    toast.error(getApiMessage(e, t('providers.toast.toggleFailed')))
-  }
-}
-async function handleDelete() {
-  const target = deleteTarget.value
-  if (!target) return
-  deleteTarget.value = null
-  try {
-    await api.deleteProvider(target.id)
-    await loadProviders()
-  } catch (e: unknown) {
-    toast.error(getApiMessage(e, t('providers.toast.deleteFailed')))
-  }
-}
-async function handleReload() {
-  reloading.value = true
-  try {
-    const result = await api.reloadTransformRules()
-    toast.success(t('providers.toast.reloadSuccess', { pluginCount: result.loadedPlugins.length, rulesCount: result.rulesCount }))
-  } catch (e: unknown) {
-    toast.error(getApiMessage(e, t('providers.toast.reloadFailed')))
-  } finally {
-    reloading.value = false
-  }
-}
+
 onMounted(async () => {
-  const [presetsResult] = await Promise.allSettled([api.recommended.getProviders(), loadProviders()])
-  if (presetsResult.status === 'fulfilled') {
-    providerPresets.value = presetsResult.value
-  } else {
-    providerPresets.value = []
-    console.error('Failed to load provider presets:', presetsResult.reason)
-  }
+  await Promise.allSettled([loadPresets(), loadProviders()])
 })
 </script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
     },
     "core": {
       "name": "@llm-router/core",
-      "version": "0.9.23",
+      "version": "0.9.24",
       "devDependencies": {
         "@types/node": "^24.12.2",
         "typescript": "^5.8.3",
@@ -948,6 +948,7 @@
       "resolved": "https://registry.npmmirror.com/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -3123,6 +3124,7 @@
       "resolved": "https://registry.npmmirror.com/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
       "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -3204,6 +3206,7 @@
       "resolved": "https://registry.npmmirror.com/@noble/ciphers/-/ciphers-1.3.0.tgz",
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -3675,8 +3678,7 @@
       "optional": true,
       "os": [
         "android"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
       "version": "4.60.2",
@@ -3690,8 +3692,7 @@
       "optional": true,
       "os": [
         "android"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.60.2",
@@ -3705,8 +3706,7 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
       "version": "4.60.2",
@@ -3720,8 +3720,7 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
       "version": "4.60.2",
@@ -3735,8 +3734,7 @@
       "optional": true,
       "os": [
         "freebsd"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
       "version": "4.60.2",
@@ -3750,8 +3748,7 @@
       "optional": true,
       "os": [
         "freebsd"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
       "version": "4.60.2",
@@ -3765,8 +3762,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
       "version": "4.60.2",
@@ -3780,8 +3776,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
       "version": "4.60.2",
@@ -3795,8 +3790,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
       "version": "4.60.2",
@@ -3810,8 +3804,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
       "version": "4.60.2",
@@ -3825,8 +3818,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
       "version": "4.60.2",
@@ -3840,8 +3832,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
       "version": "4.60.2",
@@ -3855,8 +3846,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
       "version": "4.60.2",
@@ -3870,8 +3860,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
       "version": "4.60.2",
@@ -3885,8 +3874,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
       "version": "4.60.2",
@@ -3900,8 +3888,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
       "version": "4.60.2",
@@ -3915,8 +3902,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.60.2",
@@ -3930,8 +3916,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
       "version": "4.60.2",
@@ -3945,8 +3930,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
       "version": "4.60.2",
@@ -3960,8 +3944,7 @@
       "optional": true,
       "os": [
         "openbsd"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
       "version": "4.60.2",
@@ -3975,8 +3958,7 @@
       "optional": true,
       "os": [
         "openharmony"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
       "version": "4.60.2",
@@ -3990,8 +3972,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
       "version": "4.60.2",
@@ -4005,8 +3986,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
       "version": "4.60.2",
@@ -4020,8 +4000,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.60.2",
@@ -4035,8 +4014,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@silvia-odwyer/photon-node": {
       "version": "0.3.4",
@@ -4994,6 +4972,7 @@
       "integrity": "sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.1",
         "@typescript-eslint/types": "8.59.1",
@@ -5623,6 +5602,7 @@
       "resolved": "https://registry.npmmirror.com/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5643,7 +5623,6 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmmirror.com/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -6119,6 +6098,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -6327,6 +6307,7 @@
       "resolved": "https://registry.npmmirror.com/chart.js/-/chart.js-4.5.1.tgz",
       "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@kurkle/color": "^0.3.0"
       },
@@ -7314,6 +7295,7 @@
       "resolved": "https://registry.npmmirror.com/eslint/-/eslint-10.3.0.tgz",
       "integrity": "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -8687,6 +8669,7 @@
       "resolved": "https://registry.npmmirror.com/hono/-/hono-4.12.16.tgz",
       "integrity": "sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -8748,7 +8731,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmmirror.com/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
@@ -9112,6 +9094,7 @@
       "resolved": "https://registry.npmmirror.com/jiti/-/jiti-2.6.1.tgz",
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -9409,6 +9392,7 @@
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "dev": true,
       "license": "MPL-2.0",
+      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.3"
       },
@@ -10820,6 +10804,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -12238,7 +12223,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmmirror.com/smart-buffer/-/smart-buffer-4.2.0.tgz",
       "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6.0.0",
@@ -12249,7 +12233,6 @@
       "version": "2.8.8",
       "resolved": "https://registry.npmmirror.com/socks/-/socks-2.8.8.tgz",
       "integrity": "sha512-NlGELfPrgX2f1TAAcz0WawlLn+0r3FyhhCRpFFK2CemXenPYvzMWWZINv3eDNo9ucdwme7oCHRY0Jnbs4aIkog==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ip-address": "^10.1.1",
@@ -12264,7 +12247,6 @@
       "version": "8.0.5",
       "resolved": "https://registry.npmmirror.com/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
       "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
@@ -12279,7 +12261,6 @@
       "version": "10.2.0",
       "resolved": "https://registry.npmmirror.com/ip-address/-/ip-address-10.2.0.tgz",
       "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -12510,6 +12491,7 @@
       "resolved": "https://registry.npmmirror.com/stylus/-/stylus-0.57.0.tgz",
       "integrity": "sha512-yOI6G8WYfr0q8v8rRvE91wbxFU+rJPo760Va4MF6K0I6BZjO4r+xSynkvyPBP9tV1CIEUeRsiidjIs2rzb1CnQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "css": "^3.0.0",
         "debug": "^4.3.2",
@@ -12756,6 +12738,7 @@
       "resolved": "https://registry.npmmirror.com/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -13144,7 +13127,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13162,7 +13144,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13180,7 +13161,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13198,7 +13178,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13216,7 +13195,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13234,7 +13212,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13252,7 +13229,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13270,7 +13246,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13288,7 +13263,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13306,7 +13280,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13324,7 +13297,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13342,7 +13314,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13360,7 +13331,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13378,7 +13348,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13396,7 +13365,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13414,7 +13382,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13432,7 +13399,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13450,7 +13416,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13468,7 +13433,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13486,7 +13450,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13504,7 +13467,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13522,7 +13484,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13540,7 +13501,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13558,7 +13518,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13576,7 +13535,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13594,7 +13552,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13704,6 +13661,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -13901,6 +13859,7 @@
       "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -15162,6 +15121,7 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -15243,6 +15203,7 @@
       "resolved": "https://registry.npmmirror.com/vue/-/vue-3.5.33.tgz",
       "integrity": "sha512-1AgChhx5w3ALgT4oK3acm2Es/7jyZhWSVUfs3rOBlGQC0rjEDkS7G4lWlJJGGNQD+BV3reCwbQrOe1mPNwKHBQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.33",
         "@vue/compiler-sfc": "3.5.33",
@@ -15652,6 +15613,7 @@
       "integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
       "devOptional": true,
       "license": "ISC",
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -15801,6 +15763,7 @@
       "resolved": "https://registry.npmmirror.com/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -15854,9 +15817,11 @@
         "fastify": "^5.3.3",
         "fastify-plugin": "^5.1.0",
         "gpt-tokenizer": "^3.4.0",
+        "https-proxy-agent": "^7.0.6",
         "jsonwebtoken": "^9.0.3",
         "pino": "^9.6.0",
-        "pino-pretty": "^13.1.3"
+        "pino-pretty": "^13.1.3",
+        "socks-proxy-agent": "^8.0.5"
       },
       "bin": {
         "llm-simple-router": "dist/cli.js"

--- a/router/package.json
+++ b/router/package.json
@@ -31,18 +31,20 @@
     "prepublishOnly": "node scripts/prepublish.mjs"
   },
   "dependencies": {
-    "@llm-router/core": "*",
     "@fastify/cookie": "^11.0.2",
     "@fastify/static": "^9.1.0",
+    "@llm-router/core": "*",
     "@sinclair/typebox": "^0.34.49",
     "better-sqlite3": "^11.9.1",
     "dotenv": "^16.4.7",
     "fastify": "^5.3.3",
     "fastify-plugin": "^5.1.0",
     "gpt-tokenizer": "^3.4.0",
+    "https-proxy-agent": "^7.0.6",
     "jsonwebtoken": "^9.0.3",
     "pino": "^9.6.0",
-    "pino-pretty": "^13.1.3"
+    "pino-pretty": "^13.1.3",
+    "socks-proxy-agent": "^8.0.5"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/router/src/admin/providers.ts
+++ b/router/src/admin/providers.ts
@@ -8,6 +8,7 @@ import { getSetting } from "../db/settings.js";
 import type { StateRegistry } from "../core/registry.js";
 import type { AdaptiveController } from "@llm-router/core/concurrency";
 import type { RequestTracker } from "@llm-router/core/monitor";
+import type { ProxyAgentFactory } from "../proxy/transport/proxy-agent.js";
 import { HTTP_CREATED, HTTP_NOT_FOUND, HTTP_CONFLICT, HTTP_BAD_REQUEST } from "./constants.js";
 import { API_CODE, apiError } from "./api-response.js";
 import { parseModels, buildModelInfoList, type ModelEntry } from "../config/model-context.js";
@@ -121,6 +122,10 @@ const CreateProviderSchema = Type.Object({
   queue_timeout_ms: Type.Optional(Type.Integer({ minimum: 0 })),
   max_queue_size: Type.Optional(Type.Integer({ minimum: 1 })),
   adaptive_enabled: Type.Optional(Type.Integer({ minimum: 0, maximum: 1 })),
+  proxy_type: Type.Optional(Type.Union([Type.Literal("http"), Type.Literal("socks5")])),
+  proxy_url: Type.Optional(Type.String({ minLength: 1 })),
+  proxy_username: Type.Optional(Type.String()),
+  proxy_password: Type.Optional(Type.String()),
 });
 
 const UpdateProviderSchema = Type.Object({
@@ -139,6 +144,10 @@ const UpdateProviderSchema = Type.Object({
   queue_timeout_ms: Type.Optional(Type.Integer({ minimum: 0 })),
   max_queue_size: Type.Optional(Type.Integer({ minimum: 1 })),
   adaptive_enabled: Type.Optional(Type.Integer({ minimum: 0, maximum: 1 })),
+  proxy_type: Type.Optional(Type.Union([Type.Literal("http"), Type.Literal("socks5")])),
+  proxy_url: Type.Optional(Type.String({ minLength: 1 })),
+  proxy_username: Type.Optional(Type.String()),
+  proxy_password: Type.Optional(Type.String()),
 });
 
 interface ProviderRoutesOptions {
@@ -146,10 +155,11 @@ interface ProviderRoutesOptions {
   stateRegistry?: StateRegistry;
   tracker?: RequestTracker;
   adaptiveController?: AdaptiveController;
+  proxyAgentFactory?: ProxyAgentFactory;
 }
 
 export const adminProviderRoutes: FastifyPluginCallback<ProviderRoutesOptions> = (app, options, done) => {
-  const { db, stateRegistry, tracker, adaptiveController } = options;
+  const { db, stateRegistry, tracker, adaptiveController, proxyAgentFactory } = options;
 
   app.get("/admin/api/providers", async (_request, reply) => {
     const encryptionKey = getSetting(db, "encryption_key")!;
@@ -171,6 +181,10 @@ export const adminProviderRoutes: FastifyPluginCallback<ProviderRoutesOptions> =
         queue_timeout_ms: s.queue_timeout_ms,
         max_queue_size: s.max_queue_size,
         adaptive_enabled: s.adaptive_enabled,
+        proxy_type: s.proxy_type,
+        proxy_url: s.proxy_url,
+        proxy_username: s.proxy_username ? decrypt(s.proxy_username, encryptionKey) : null,
+        proxy_password: s.proxy_password ? decrypt(s.proxy_password, encryptionKey) : null,
         concurrency_status: stateRegistry?.getProviderStatus(s.id) ?? { active: 0, queued: 0 },
         created_at: s.created_at,
         updated_at: s.updated_at,
@@ -190,6 +204,11 @@ export const adminProviderRoutes: FastifyPluginCallback<ProviderRoutesOptions> =
     const encryptedKey = encrypt(body.api_key, getSetting(db, "encryption_key")!);
     const { entries: normalizedModels, overrides: contextOverrides } = extractModelOverrides((body.models ?? []) as ModelInput[]);
     const isAdaptiveEnabled = body.adaptive_enabled ?? 0;
+    if (body.proxy_type && !body.proxy_url) {
+      return reply.code(HTTP_BAD_REQUEST).send(apiError(API_CODE.VALIDATION_FAILED, "proxy_url is required when proxy_type is set"));
+    }
+    const encryptedProxyUsername = body.proxy_username ? encrypt(body.proxy_username, getSetting(db, "encryption_key")!) : null;
+    const encryptedProxyPassword = body.proxy_password ? encrypt(body.proxy_password, getSetting(db, "encryption_key")!) : null;
     const id = createProvider(db, {
       name: body.name,
       api_type: body.api_type,
@@ -203,6 +222,10 @@ export const adminProviderRoutes: FastifyPluginCallback<ProviderRoutesOptions> =
       queue_timeout_ms: body.queue_timeout_ms ?? PROVIDER_CONCURRENCY_DEFAULTS.queue_timeout_ms,
       max_queue_size: body.max_queue_size ?? PROVIDER_CONCURRENCY_DEFAULTS.max_queue_size,
       adaptive_enabled: isAdaptiveEnabled,
+      proxy_type: body.proxy_type ?? null,
+      proxy_url: body.proxy_type ? body.proxy_url! : null,
+      proxy_username: encryptedProxyUsername,
+      proxy_password: encryptedProxyPassword,
     });
     if (contextOverrides.length > 0) {
       setModelInfoForProvider(db, id, contextOverrides.map(o => ({ model_name: o.name, context_window: o.context_window })));
@@ -240,7 +263,7 @@ export const adminProviderRoutes: FastifyPluginCallback<ProviderRoutesOptions> =
     if (body.name !== undefined && !PROVIDER_NAME_RE.test(body.name)) {
       return reply.code(HTTP_BAD_REQUEST).send(apiError(API_CODE.VALIDATION_FAILED, "Provider 名称仅允许英文大小写字母、数字、横线和下划线"));
     }
-    const fields: Partial<Pick<Provider, 'name' | 'api_type' | 'base_url' | 'upstream_path' | 'api_key' | 'api_key_preview' | 'models' | 'is_active' | 'max_concurrency' | 'queue_timeout_ms' | 'max_queue_size' | 'adaptive_enabled'>> = {};
+    const fields: Partial<Pick<Provider, 'name' | 'api_type' | 'base_url' | 'upstream_path' | 'api_key' | 'api_key_preview' | 'models' | 'is_active' | 'max_concurrency' | 'queue_timeout_ms' | 'max_queue_size' | 'adaptive_enabled' | 'proxy_type' | 'proxy_url' | 'proxy_username' | 'proxy_password'>> = {};
     if (body.name !== undefined) fields.name = body.name;
     if (body.api_type !== undefined) fields.api_type = body.api_type;
     if (body.base_url !== undefined) fields.base_url = body.base_url;
@@ -263,7 +286,26 @@ export const adminProviderRoutes: FastifyPluginCallback<ProviderRoutesOptions> =
       fields.api_key = encrypt(body.api_key, getSetting(db, "encryption_key")!);
       fields.api_key_preview = body.api_key.length > API_KEY_PREVIEW_MIN_LENGTH ? `${body.api_key.slice(0, API_KEY_PREVIEW_PREFIX_LEN)}...${body.api_key.slice(-API_KEY_PREVIEW_PREFIX_LEN)}` : "****";
     }
+    // Proxy field handling
+    if (body.proxy_type !== undefined) {
+      fields.proxy_type = body.proxy_type || null;
+      if (!body.proxy_type) {
+        fields.proxy_url = null;
+        fields.proxy_username = null;
+        fields.proxy_password = null;
+      }
+    }
+    if (body.proxy_url !== undefined && body.proxy_type) {
+      fields.proxy_url = body.proxy_url;
+    }
+    if (body.proxy_username !== undefined && body.proxy_type) {
+      fields.proxy_username = body.proxy_username ? encrypt(body.proxy_username, getSetting(db, "encryption_key")!) : null;
+    }
+    if (body.proxy_password !== undefined && body.proxy_type) {
+      fields.proxy_password = body.proxy_password ? encrypt(body.proxy_password, getSetting(db, "encryption_key")!) : null;
+    }
     updateProvider(db, id, fields);
+    proxyAgentFactory?.invalidate(id);
     const updated = getProviderById(db, id)!;
 
     let cascade: CascadeResult | undefined;
@@ -357,6 +399,7 @@ export const adminProviderRoutes: FastifyPluginCallback<ProviderRoutesOptions> =
         }
       } catch { continue }
     }
+    proxyAgentFactory?.invalidate(id);
     deleteProvider(db, id);
     stateRegistry?.removeProvider(id);
     adaptiveController?.remove(id);

--- a/router/src/admin/routes.ts
+++ b/router/src/admin/routes.ts
@@ -23,6 +23,7 @@ import { adminScheduleRoutes } from "./schedules.js";
 import type { StateRegistry } from "../core/registry.js";
 import type { RequestTracker } from "@llm-router/core/monitor";
 import type { AdaptiveController } from "@llm-router/core/concurrency";
+import type { ProxyAgentFactory } from "../proxy/transport/proxy-agent.js";
 
 interface AdminRoutesOptions {
   db: Database.Database;
@@ -33,6 +34,7 @@ interface AdminRoutesOptions {
   logsDir?: string;
   pluginRegistry?: import("../proxy/transform/plugin-registry.js").PluginRegistry;
   closeFn?: () => Promise<void>;
+  proxyAgentFactory?: ProxyAgentFactory;
 }
 
 export const adminRoutes: FastifyPluginCallback<AdminRoutesOptions> = (app, options, done) => {
@@ -40,7 +42,7 @@ export const adminRoutes: FastifyPluginCallback<AdminRoutesOptions> = (app, opti
   app.register(adminSetupRoutes, { db: options.db });
   app.register(adminAuthPlugin, { db: options.db });
   app.register(adminLoginRoutes, { db: options.db });
-  app.register(adminProviderRoutes, { db: options.db, stateRegistry: options.stateRegistry, tracker: options.tracker, adaptiveController: options.adaptiveController });
+  app.register(adminProviderRoutes, { db: options.db, stateRegistry: options.stateRegistry, tracker: options.tracker, adaptiveController: options.adaptiveController, proxyAgentFactory: options.proxyAgentFactory });
   app.register(adminMappingRoutes, { db: options.db });
   app.register(adminGroupRoutes, { db: options.db });
   app.register(adminScheduleRoutes, { db: options.db });

--- a/router/src/core/container.ts
+++ b/router/src/core/container.ts
@@ -9,6 +9,7 @@ export const SERVICE_KEYS = {
   adaptiveController: "adaptiveController",
   pluginRegistry: "pluginRegistry",
   logFileWriter: "logFileWriter",
+  proxyAgentFactory: "proxyAgentFactory",
 } as const;
 
 export type ServiceKey = (typeof SERVICE_KEYS)[keyof typeof SERVICE_KEYS];

--- a/router/src/db/migrations/041_add_provider_proxy.sql
+++ b/router/src/db/migrations/041_add_provider_proxy.sql
@@ -1,0 +1,7 @@
+-- 041_add_provider_proxy.sql
+-- Add per-provider proxy support (SOCKS5 / HTTP CONNECT)
+
+ALTER TABLE providers ADD COLUMN proxy_type TEXT DEFAULT NULL;
+ALTER TABLE providers ADD COLUMN proxy_url TEXT DEFAULT NULL;
+ALTER TABLE providers ADD COLUMN proxy_username TEXT DEFAULT NULL;
+ALTER TABLE providers ADD COLUMN proxy_password TEXT DEFAULT NULL;

--- a/router/src/db/providers.ts
+++ b/router/src/db/providers.ts
@@ -16,6 +16,10 @@ export interface Provider {
   queue_timeout_ms: number;
   max_queue_size: number;
   adaptive_enabled: number;
+  proxy_type: string | null;
+  proxy_url: string | null;
+  proxy_username: string | null;
+  proxy_password: string | null;
   created_at: string;
   updated_at: string;
 }
@@ -58,7 +62,7 @@ export const PROVIDER_CONCURRENCY_DEFAULTS = {
 } as const;
 
 const PROVIDER_FIELDS = new Set([
-  "name", "api_type", "base_url", "upstream_path", "api_key", "api_key_preview", "models", "is_active", "max_concurrency", "queue_timeout_ms", "max_queue_size", "adaptive_enabled",
+  "name", "api_type", "base_url", "upstream_path", "api_key", "api_key_preview", "models", "is_active", "max_concurrency", "queue_timeout_ms", "max_queue_size", "adaptive_enabled", "proxy_type", "proxy_url", "proxy_username", "proxy_password",
 ]);
 
 export function getActiveProviders(
@@ -93,13 +97,17 @@ export function createProvider(
     queue_timeout_ms?: number;
     max_queue_size?: number;
     adaptive_enabled?: number;
+    proxy_type?: string | null;
+    proxy_url?: string | null;
+    proxy_username?: string | null;
+    proxy_password?: string | null;
   },
 ): string {
   const id = randomUUID();
   const now = new Date().toISOString();
   db.prepare(
-    `INSERT INTO providers (id, name, api_type, base_url, upstream_path, api_key, api_key_preview, models, is_active, max_concurrency, queue_timeout_ms, max_queue_size, adaptive_enabled, created_at, updated_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    `INSERT INTO providers (id, name, api_type, base_url, upstream_path, api_key, api_key_preview, models, is_active, max_concurrency, queue_timeout_ms, max_queue_size, adaptive_enabled, proxy_type, proxy_url, proxy_username, proxy_password, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
     id, provider.name, provider.api_type, provider.base_url,
     provider.upstream_path ?? null,
@@ -110,6 +118,10 @@ export function createProvider(
     provider.queue_timeout_ms ?? PROVIDER_CONCURRENCY_DEFAULTS.queue_timeout_ms,
     provider.max_queue_size ?? PROVIDER_CONCURRENCY_DEFAULTS.max_queue_size,
     provider.adaptive_enabled ?? 0,
+    provider.proxy_type ?? null,
+    provider.proxy_url ?? null,
+    provider.proxy_username ?? null,
+    provider.proxy_password ?? null,
     now, now,
   );
   return id;
@@ -118,7 +130,7 @@ export function createProvider(
 export function updateProvider(
   db: Database.Database,
   id: string,
-  fields: Partial<Pick<Provider, "name" | "api_type" | "base_url" | "upstream_path" | "api_key" | "api_key_preview" | "models" | "is_active" | "max_concurrency" | "queue_timeout_ms" | "max_queue_size" | "adaptive_enabled">>,
+  fields: Partial<Pick<Provider, "name" | "api_type" | "base_url" | "upstream_path" | "api_key" | "api_key_preview" | "models" | "is_active" | "max_concurrency" | "queue_timeout_ms" | "max_queue_size" | "adaptive_enabled" | "proxy_type" | "proxy_url" | "proxy_username" | "proxy_password">>,
 ): void {
   buildUpdateQuery(db, "providers", id, fields, PROVIDER_FIELDS, { updatedAt: true });
 }

--- a/router/src/index.ts
+++ b/router/src/index.ts
@@ -36,6 +36,7 @@ import fastifyStatic from "@fastify/static";
 import { ServiceContainer, SERVICE_KEYS } from "./core/container.js";
 import Database from "better-sqlite3";
 import { LogFileWriter } from "./storage/log-file-writer.js";
+import { ProxyAgentFactory } from "./proxy/transport/proxy-agent.js";
 import { scheduleLogFileMaintenance } from "./storage/log-file-compressor.js";
 import { getDetailLogEnabled, getLogFileRetentionDays } from "./db/settings.js";
 import { dirname, join } from "node:path";
@@ -253,12 +254,16 @@ export async function buildApp(
   pluginRegistry.scanPluginsDir(pluginsDir);
   container.register(SERVICE_KEYS.pluginRegistry, () => pluginRegistry);
 
+  // 注册 ProxyAgentFactory
+  container.register(SERVICE_KEYS.proxyAgentFactory, () => new ProxyAgentFactory());
+
   // 从容器解析所有服务
   const matcher = container.resolve<RetryRuleMatcher>(SERVICE_KEYS.matcher);
   const semaphoreManager = container.resolve<SemaphoreManager>(SERVICE_KEYS.semaphoreManager);
   const tracker = container.resolve<RequestTracker>(SERVICE_KEYS.tracker);
   const usageWindowTracker = container.resolve<UsageWindowTracker>(SERVICE_KEYS.usageWindowTracker);
   const adaptiveController = container.resolve<AdaptiveController>(SERVICE_KEYS.adaptiveController);
+  const proxyAgentFactory = container.resolve<ProxyAgentFactory>(SERVICE_KEYS.proxyAgentFactory);
 
   // Wire adaptive controller to tracker
   tracker.setAdaptiveStatusProvider(adaptiveController);
@@ -291,7 +296,7 @@ export async function buildApp(
   // 但 restart API 需要在运行时调用它
   const closeRef = { fn: async () => {} };
 
-  app.register(adminRoutes, { db, stateRegistry, tracker, adaptiveController, logFileWriter, logsDir, closeFn: () => closeRef.fn(), pluginRegistry });
+  app.register(adminRoutes, { db, stateRegistry, tracker, adaptiveController, logFileWriter, logsDir, closeFn: () => closeRef.fn(), pluginRegistry, proxyAgentFactory });
 
   // 前端静态文件服务（生产环境）
   const frontendDist = path.resolve(
@@ -342,6 +347,7 @@ export async function buildApp(
     // 关闭所有 SSE 长连接，防止 app.close() 因 hijack 的连接无限等待
     tracker.closeAllClients();
     semaphoreManager.removeAll();
+    proxyAgentFactory.invalidateAll();
     const sessionTracker = container.resolve<SessionTracker>(SERVICE_KEYS.sessionTracker);
     sessionTracker.stop();
     await app.close();

--- a/router/src/proxy/handler/anthropic.ts
+++ b/router/src/proxy/handler/anthropic.ts
@@ -12,6 +12,7 @@ import type { RequestTracker } from "@llm-router/core/monitor";
 import { AdaptiveController } from "@llm-router/core/concurrency";
 import { HTTP_BAD_GATEWAY } from "../../core/constants.js";
 import { SERVICE_KEYS } from "../../core/container.js";
+import type { ProxyAgentFactory } from "../transport/proxy-agent.js";
 
 export interface AnthropicProxyOptions {
   db: Database.Database;
@@ -58,7 +59,7 @@ const anthropicProxyRaw: FastifyPluginCallback<AnthropicProxyOptions> = (app, op
       const e = anthropicErrors.providerUnavailable();
       return reply.code(e.statusCode).send(e.body);
     }
-    const deps: RouteHandlerDeps = { db, orchestrator, container };
+    const deps: RouteHandlerDeps = { db, orchestrator, container, proxyAgentFactory: container.resolve<ProxyAgentFactory>(SERVICE_KEYS.proxyAgentFactory) };
     return handleProxyRequest(request, reply, "anthropic", MESSAGES_PATH, anthropicErrors, deps);
   });
 

--- a/router/src/proxy/handler/openai.ts
+++ b/router/src/proxy/handler/openai.ts
@@ -12,6 +12,7 @@ import type { RequestTracker } from "@llm-router/core/monitor";
 import { AdaptiveController } from "@llm-router/core/concurrency";
 import { HTTP_OK, HTTP_BAD_GATEWAY, MS_PER_SECOND } from "../../core/constants.js";
 import { SERVICE_KEYS } from "../../core/container.js";
+import type { ProxyAgentFactory } from "../transport/proxy-agent.js";
 
 export interface OpenaiProxyOptions {
   db: Database.Database;
@@ -66,7 +67,7 @@ const openaiProxyRaw: FastifyPluginCallback<OpenaiProxyOptions> = (app, opts, do
       });
       return sendError(reply, openaiErrors.providerUnavailable());
     }
-    const deps: RouteHandlerDeps = { db, orchestrator, container };
+    const deps: RouteHandlerDeps = { db, orchestrator, container, proxyAgentFactory: container.resolve<ProxyAgentFactory>(SERVICE_KEYS.proxyAgentFactory) };
     return handleProxyRequest(request, reply, "openai", CHAT_COMPLETIONS_PATH, openaiErrors, deps, {
       beforeSendProxy: (body, isStream) => {
         if (isStream && !body.stream_options) {

--- a/router/src/proxy/handler/proxy-handler.ts
+++ b/router/src/proxy/handler/proxy-handler.ts
@@ -22,6 +22,7 @@ import { insertRejectedLog } from "../log-helpers.js";
 import type { RetryRuleMatcher } from "../orchestration/retry-rules.js";
 import type { ProxyOrchestrator } from "../orchestration/orchestrator.js";
 import type { ProxyErrorFormatter, ProxyErrorResponse } from "../proxy-core.js";
+import type { ProxyAgentFactory } from "../transport/proxy-agent.js";
 import { ToolLoopGuard } from "@llm-router/core/loop-prevention";
 import { buildTransportFn } from "../transport/transport-fn.js";
 import { applyOverflowRedirect } from "../routing/overflow.js";
@@ -102,6 +103,7 @@ export interface RouteHandlerDeps {
   db: Database.Database;
   orchestrator: ProxyOrchestrator;
   container: ServiceContainer;
+  proxyAgentFactory?: ProxyAgentFactory;
 }
 
 import { getConfig } from "../../config/index.js";
@@ -409,6 +411,7 @@ async function executeFailoverLoop(ctx: FailoverContext): Promise<FastifyReply> 
       streamTimeoutMs: getModelStreamTimeout(provider, resolved.backend_model), tracker, matcher, request,
       streamLoopEnabled, formatTransform, responseTransform, injectedHeaders,
       timeoutContext: { modelId: resolved.backend_model, providerId: provider.id },
+      proxyAgentFactory: deps.proxyAgentFactory,
     });
 
     const pipelineSnapshot = iterationSnapshot.toJSON();

--- a/router/src/proxy/handler/responses.ts
+++ b/router/src/proxy/handler/responses.ts
@@ -12,6 +12,7 @@ import type { RequestTracker } from "@llm-router/core/monitor";
 import { AdaptiveController } from "@llm-router/core/concurrency";
 import { HTTP_BAD_GATEWAY } from "../../core/constants.js";
 import { SERVICE_KEYS } from "../../core/container.js";
+import type { ProxyAgentFactory } from "../transport/proxy-agent.js";
 
 export interface ResponsesProxyOptions {
   db: Database.Database;
@@ -62,7 +63,7 @@ const responsesProxyRaw: FastifyPluginCallback<ResponsesProxyOptions> = (app, op
       });
       return sendError(reply, responsesErrors.providerUnavailable());
     }
-    const deps: RouteHandlerDeps = { db, orchestrator, container };
+    const deps: RouteHandlerDeps = { db, orchestrator, container, proxyAgentFactory: container.resolve<ProxyAgentFactory>(SERVICE_KEYS.proxyAgentFactory) };
     return handleProxyRequest(request, reply, "openai-responses", RESPONSES_PATH, responsesErrors, deps);
   };
 

--- a/router/src/proxy/transport/http.ts
+++ b/router/src/proxy/transport/http.ts
@@ -1,5 +1,6 @@
 import { request as httpRequestFn } from "http";
 import { request as httpsRequestFn } from "https";
+import type { Agent } from "http";
 import { UPSTREAM_SUCCESS, filterHeaders } from "../types.js";
 import { buildUpstreamUrl } from "../proxy-core.js";
 import type { RawHeaders, TransportResult } from "../types.js";
@@ -24,10 +25,11 @@ export interface UpstreamRequestOptions {
 }
 
 export const _transportInternals = {
-  createUpstreamRequest(url: URL, options: UpstreamRequestOptions) {
+  createUpstreamRequest(url: URL, options: UpstreamRequestOptions, agent?: Agent) {
+    const opts = agent ? { ...options, agent } : options;
     return url.protocol === "https:"
-      ? httpsRequestFn(options)
-      : httpRequestFn(options);
+      ? httpsRequestFn(opts)
+      : httpRequestFn(opts);
   },
 };
 
@@ -64,6 +66,7 @@ export function callNonStream(
   clientHeaders: RawHeaders,
   upstreamPath: string,
   buildHeaders: BuildHeadersFn,
+  agent?: Agent,
 ): Promise<TransportResult> {
   return new Promise((resolve) => {
     const url = new URL(buildUpstreamUrl(backend.base_url, upstreamPath));
@@ -75,7 +78,7 @@ export function callNonStream(
     );
     const options = buildRequestOptions(url, upstreamHeaders);
 
-    const req = _transportInternals.createUpstreamRequest(url, options);
+    const req = _transportInternals.createUpstreamRequest(url, options, agent);
 
     req.on("response", (res) => {
       const chunks: Buffer[] = [];
@@ -127,13 +130,14 @@ export function callGet(
   clientHeaders: RawHeaders,
   upstreamPath: string,
   buildHeaders: (cliHdrs: RawHeaders, key: string) => Record<string, string>,
+  agent?: Agent,
 ): Promise<GetTransportResult> {
   return new Promise((resolve, reject) => {
     const url = new URL(buildUpstreamUrl(backend.base_url, upstreamPath));
     const headers = buildHeaders(clientHeaders, apiKey);
     const options = buildRequestOptions(url, headers, "GET");
 
-    const req = _transportInternals.createUpstreamRequest(url, options);
+    const req = _transportInternals.createUpstreamRequest(url, options, agent);
     req.on("response", (res) => {
       const chunks: Buffer[] = [];
       res.on("data", (chunk: Buffer) => chunks.push(chunk));

--- a/router/src/proxy/transport/proxy-agent.ts
+++ b/router/src/proxy/transport/proxy-agent.ts
@@ -1,0 +1,77 @@
+import type { Agent } from "http";
+import { HttpsProxyAgent } from "https-proxy-agent";
+import { SocksProxyAgent } from "socks-proxy-agent";
+
+interface CachedEntry {
+  agent: Agent;
+  proxyUrl: string;
+}
+
+export interface ProxyConfig {
+  id: string;
+  proxy_type: string | null;
+  proxy_url: string | null;
+  proxy_username: string | null;
+  proxy_password: string | null;
+}
+
+export class ProxyAgentFactory {
+  private readonly cache = new Map<string, CachedEntry>();
+
+  getAgent(provider: ProxyConfig): Agent | undefined {
+    if (!provider.proxy_type || !provider.proxy_url) {
+      return undefined;
+    }
+
+    const fullUrl = this.buildProxyUrl(provider);
+    const cached = this.cache.get(provider.id);
+    if (cached && cached.proxyUrl === fullUrl) {
+      return cached.agent;
+    }
+
+    if (cached) {
+      cached.agent.destroy();
+      this.cache.delete(provider.id);
+    }
+
+    const agent = this.createAgent(provider.proxy_type, fullUrl);
+    this.cache.set(provider.id, { agent, proxyUrl: fullUrl });
+    return agent;
+  }
+
+  invalidate(providerId: string): void {
+    const cached = this.cache.get(providerId);
+    if (cached) {
+      cached.agent.destroy();
+      this.cache.delete(providerId);
+    }
+  }
+
+  invalidateAll(): void {
+    for (const cached of this.cache.values()) {
+      cached.agent.destroy();
+    }
+    this.cache.clear();
+  }
+
+  private createAgent(proxyType: string, proxyUrl: string): Agent {
+    if (proxyType === "socks5") {
+      return new SocksProxyAgent(proxyUrl) as unknown as Agent;
+    }
+    return new HttpsProxyAgent(proxyUrl) as unknown as Agent;
+  }
+
+  private buildProxyUrl(provider: ProxyConfig): string {
+    let url = provider.proxy_url!;
+    const username = provider.proxy_username;
+    const password = provider.proxy_password;
+
+    if (username) {
+      const parsed = new URL(url);
+      parsed.username = username;
+      if (password) parsed.password = password;
+      url = parsed.toString();
+    }
+    return url;
+  }
+}

--- a/router/src/proxy/transport/stream.ts
+++ b/router/src/proxy/transport/stream.ts
@@ -1,4 +1,5 @@
 import { PassThrough, Transform } from "stream";
+import type { Agent } from "http";
 import type { FastifyReply } from "fastify";
 import { UPSTREAM_SUCCESS, filterHeaders } from "../types.js";
 import { buildUpstreamUrl } from "../proxy-core.js";
@@ -320,6 +321,7 @@ export function callStream(
   formatTransform?: import("stream").Transform,
   timeoutContext?: { modelId: string; providerId: string },
   onTimeoutAbort?: () => void,
+  agent?: Agent,
 ): Promise<TransportResult> {
   return new Promise((resolve) => {
     const effectiveResolve = compatResolve ?? resolve;
@@ -328,7 +330,7 @@ export function callStream(
     const upstreamHeaders = buildHeaders(clientHeaders, apiKey, Buffer.byteLength(payload));
     const options = buildRequestOptions(url, upstreamHeaders);
 
-    const upstreamReq = _transportInternals.createUpstreamRequest(url, options);
+    const upstreamReq = _transportInternals.createUpstreamRequest(url, options, agent);
 
     upstreamReq.on("response", (upstreamRes) => {
       const statusCode = upstreamRes.statusCode || UPSTREAM_BAD_GATEWAY;

--- a/router/src/proxy/transport/transport-fn.ts
+++ b/router/src/proxy/transport/transport-fn.ts
@@ -40,6 +40,8 @@ function toStreamMetrics(m: MetricsResult) {
   };
 }
 
+import type { ProxyAgentFactory } from "./proxy-agent.js";
+
 export interface TransportFnParams {
   provider: NonNullable<ReturnType<typeof getProviderById>>;
   apiKey: string;
@@ -61,6 +63,7 @@ export interface TransportFnParams {
   responseTransform?: (body: string) => string;
   injectedHeaders?: Record<string, string>;
   timeoutContext?: { modelId: string; providerId: string };
+  proxyAgentFactory?: ProxyAgentFactory;
 }
 
 export function buildTransportFn(p: TransportFnParams): (target: Target) => Promise<TransportResult> {
@@ -68,6 +71,7 @@ export function buildTransportFn(p: TransportFnParams): (target: Target) => Prom
     const base = buildUpstreamHeaders(cliHdrs, key, bytes, p.apiType);
     return p.injectedHeaders ? { ...base, ...p.injectedHeaders } : base;
   };
+  const agent = p.proxyAgentFactory?.getAgent(p.provider);
   // _target 未使用 — resilience 层始终传入当前 resolved target；
   // 跨 target failover 由外层 executeFailoverLoop 的 ProviderSwitchNeeded 处理
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -92,14 +96,14 @@ export function buildTransportFn(p: TransportFnParams): (target: Target) => Prom
       const streamResult = await callStream(
         p.provider, p.apiKey, p.body, p.cliHdrs, p.reply, p.streamTimeoutMs,
         p.upstreamPath, buildHeaders, metricsTransform, checkEarlyError, undefined, streamLoopGuard, p.formatTransform,
-        p.timeoutContext,
+        p.timeoutContext, undefined, agent,
       );
       const m = (streamResult.kind === "stream_success" || streamResult.kind === "stream_abort")
         ? streamResult.metrics : undefined;
       if (m) p.tracker?.update(p.logId, { streamMetrics: toStreamMetrics(m) });
       return streamResult;
     }
-    let result = await callNonStream(p.provider, p.apiKey, p.body, p.cliHdrs, p.upstreamPath, buildHeaders);
+    let result = await callNonStream(p.provider, p.apiKey, p.body, p.cliHdrs, p.upstreamPath, buildHeaders, agent);
     if (result.kind === "success") {
       const mr = MetricsExtractor.fromNonStreamResponse(p.apiType, result.body);
       if (mr) p.tracker?.update(p.logId, { streamMetrics: toStreamMetrics(mr) });

--- a/router/tests/anthropic-proxy.test.ts
+++ b/router/tests/anthropic-proxy.test.ts
@@ -37,6 +37,20 @@ function closeServer(server: Server): Promise<void> {
   });
 }
 
+/** Get a port that is guaranteed to have no listener */
+async function getDeadPort(): Promise<{ port: number }> {
+  const net = await import('net');
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address() as net.AddressInfo;
+      const port = addr.port;
+      server.close(() => resolve({ port }));
+    });
+    server.on('error', reject);
+  });
+}
+
 function buildTestApp(mockDb: Database.Database): FastifyInstance {
   const app = Fastify();
   const semaphoreManager = new ProviderSemaphoreManager();
@@ -337,7 +351,9 @@ describe("Anthropic proxy", () => {
 
   // 5. 后端不可达 - 502
   it("should return 502 when backend is unreachable", async () => {
-    insertMockBackend(mockDb, "http://127.0.0.1:19999");
+    // 使用随机未被占用的端口，避免冲突
+    const { port: deadPort } = await getDeadPort();
+    insertMockBackend(mockDb, `http://127.0.0.1:${deadPort}`);
     insertModelMapping(mockDb, "claude-3-opus-20240229", "claude-3-opus-20240229");
 
     app = buildTestApp(mockDb);

--- a/router/tests/anthropic-proxy.test.ts
+++ b/router/tests/anthropic-proxy.test.ts
@@ -9,6 +9,7 @@ import { setSetting } from "../src/db/settings.js";
 import { SemaphoreManager as ProviderSemaphoreManager } from "@llm-router/core/concurrency";
 import { RequestTracker } from "@llm-router/core/monitor";
 import { ServiceContainer, SERVICE_KEYS } from "../src/core/container.js";
+import { ProxyAgentFactory } from "../src/proxy/transport/proxy-agent.js";
 
 
 const TEST_ENCRYPTION_KEY =
@@ -49,6 +50,7 @@ function buildTestApp(mockDb: Database.Database): FastifyInstance {
   container.register("adaptiveController", () => undefined);
   container.register(SERVICE_KEYS.logFileWriter, () => null);
   container.register(SERVICE_KEYS.pluginRegistry, () => undefined);
+  container.register(SERVICE_KEYS.proxyAgentFactory, () => new ProxyAgentFactory());
 
   app.register(anthropicProxy, { db: mockDb, container });
 

--- a/router/tests/db.test.ts
+++ b/router/tests/db.test.ts
@@ -39,7 +39,7 @@ describe("initDatabase", () => {
       .prepare("SELECT name FROM migrations")
       .all() as { name: string }[];
 
-    expect(rows.length).toBe(41);
+    expect(rows.length).toBe(42);
     expect(rows[0].name).toBe("001_init.sql");
     expect(rows[1].name).toBe("002_add_request_response_body.sql");
     expect(rows[2].name).toBe("003_add_full_request_chain_log.sql");

--- a/router/tests/failover-log-grouping.test.ts
+++ b/router/tests/failover-log-grouping.test.ts
@@ -12,6 +12,7 @@ import { RetryRuleMatcher } from "../src/proxy/orchestration/retry-rules.js";
 import { SemaphoreManager as ProviderSemaphoreManager } from "@llm-router/core/concurrency";
 import { RequestTracker } from "@llm-router/core/monitor";
 import { ServiceContainer, SERVICE_KEYS } from "../src/core/container.js";
+import { ProxyAgentFactory } from "../src/proxy/transport/proxy-agent.js";
 
 
 const API_KEY = "sk-test-router";
@@ -161,6 +162,7 @@ describe("Failover log grouping", () => {
     container.register("adaptiveController", () => undefined);
     container.register(SERVICE_KEYS.logFileWriter, () => null);
   container.register(SERVICE_KEYS.pluginRegistry, () => undefined);
+  container.register(SERVICE_KEYS.proxyAgentFactory, () => new ProxyAgentFactory());
     app = Fastify();
     app.register(authMiddleware, { db });
     app.register(openaiProxy, { db: db, container });
@@ -259,6 +261,7 @@ describe("Failover log grouping", () => {
     container.register("adaptiveController", () => undefined);
     container.register(SERVICE_KEYS.logFileWriter, () => null);
   container.register(SERVICE_KEYS.pluginRegistry, () => undefined);
+  container.register(SERVICE_KEYS.proxyAgentFactory, () => new ProxyAgentFactory());
     app = Fastify();
     app.register(authMiddleware, { db });
     app.register(openaiProxy, { db: db, container });
@@ -341,6 +344,7 @@ describe("Failover log grouping", () => {
     container.register("adaptiveController", () => undefined);
     container.register(SERVICE_KEYS.logFileWriter, () => null);
   container.register(SERVICE_KEYS.pluginRegistry, () => undefined);
+  container.register(SERVICE_KEYS.proxyAgentFactory, () => new ProxyAgentFactory());
     app = Fastify();
     app.register(authMiddleware, { db });
     app.register(openaiProxy, { db: db, container });
@@ -429,6 +433,7 @@ describe("Failover log grouping", () => {
     container.register("adaptiveController", () => undefined);
     container.register(SERVICE_KEYS.logFileWriter, () => null);
   container.register(SERVICE_KEYS.pluginRegistry, () => undefined);
+  container.register(SERVICE_KEYS.proxyAgentFactory, () => new ProxyAgentFactory());
     container.register("semaphoreManager", () => new ProviderSemaphoreManager());
     matcher.load(db);
     app = Fastify();

--- a/router/tests/logging.test.ts
+++ b/router/tests/logging.test.ts
@@ -17,6 +17,7 @@ import { setSetting } from "../src/db/settings.js";
 import { SemaphoreManager as ProviderSemaphoreManager } from "@llm-router/core/concurrency";
 import { RequestTracker } from "@llm-router/core/monitor";
 import { ServiceContainer, SERVICE_KEYS } from "../src/core/container.js";
+import { ProxyAgentFactory } from "../src/proxy/transport/proxy-agent.js";
 
 
 const API_KEY = "sk-test-router";
@@ -69,6 +70,7 @@ function createApp() {
   container.register("adaptiveController", () => undefined);
     container.register(SERVICE_KEYS.logFileWriter, () => null);
   container.register(SERVICE_KEYS.pluginRegistry, () => undefined);
+  container.register(SERVICE_KEYS.proxyAgentFactory, () => new ProxyAgentFactory());
   app.register(authMiddleware, { db });
   app.register(openaiProxy, { db: db, container });
   app.register(anthropicProxy, { db: db, container });

--- a/router/tests/metrics.test.ts
+++ b/router/tests/metrics.test.ts
@@ -29,7 +29,7 @@ describe("request_metrics migration and insertMetrics", () => {
       .prepare("SELECT name FROM migrations")
       .all() as { name: string }[];
 
-    expect(rows).toHaveLength(41);
+    expect(rows).toHaveLength(42);
     expect(rows[5].name).toBe("006_create_request_metrics.sql");
     expect(rows[6].name).toBe("007_add_retry_fields.sql");
     expect(rows[7].name).toBe("008_create_router_keys.sql");

--- a/router/tests/models-proxy.test.ts
+++ b/router/tests/models-proxy.test.ts
@@ -6,6 +6,7 @@ import { encrypt } from "../src/utils/crypto.js";
 import { initDatabase } from "../src/db/index.js";
 import { setSetting } from "../src/db/settings.js";
 import { ServiceContainer, SERVICE_KEYS } from "../src/core/container.js";
+import { ProxyAgentFactory } from "../src/proxy/transport/proxy-agent.js";
 
 const TEST_ENCRYPTION_KEY =
   "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
@@ -63,6 +64,7 @@ function buildApp(db: Database.Database): FastifyInstance {
   container.register("adaptiveController", () => undefined);
   container.register(SERVICE_KEYS.logFileWriter, () => null);
   container.register(SERVICE_KEYS.pluginRegistry, () => undefined);
+  container.register(SERVICE_KEYS.proxyAgentFactory, () => new ProxyAgentFactory());
   app.register(openaiProxy, { db, container });
   return app;
 }

--- a/router/tests/openai-proxy.test.ts
+++ b/router/tests/openai-proxy.test.ts
@@ -11,6 +11,7 @@ import { RequestTracker } from "@llm-router/core/monitor";
 import { createMockBackend } from "./helpers/mock-backend.js";
 import { TEST_ENCRYPTION_KEY } from "./helpers/test-setup.js";
 import { ServiceContainer, SERVICE_KEYS } from "../src/core/container.js";
+import { ProxyAgentFactory } from "../src/proxy/transport/proxy-agent.js";
 
 
 function closeServer(server: Server): Promise<void> {
@@ -32,6 +33,7 @@ function buildTestApp(mockDb: Database.Database): FastifyInstance {
   container.register("adaptiveController", () => undefined);
   container.register(SERVICE_KEYS.logFileWriter, () => null);
   container.register(SERVICE_KEYS.pluginRegistry, () => undefined);
+  container.register(SERVICE_KEYS.proxyAgentFactory, () => new ProxyAgentFactory());
 
   app.register(openaiProxy, { db: mockDb, container });
 

--- a/router/tests/openai-proxy.test.ts
+++ b/router/tests/openai-proxy.test.ts
@@ -20,6 +20,20 @@ function closeServer(server: Server): Promise<void> {
   });
 }
 
+/** Get a port that is guaranteed to have no listener */
+async function getDeadPort(): Promise<{ port: number }> {
+  const net = await import('net');
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address() as net.AddressInfo;
+      const port = addr.port;
+      server.close(() => resolve({ port }));
+    });
+    server.on('error', reject);
+  });
+}
+
 function buildTestApp(mockDb: Database.Database): FastifyInstance {
   const app = Fastify();
   const semaphoreManager = new ProviderSemaphoreManager();
@@ -287,8 +301,9 @@ describe("OpenAI proxy", () => {
 
   // 5. 后端不可达 - 返回 502
   it("should return 502 when backend is unreachable", async () => {
-    // 指向一个不存在的端口
-    insertMockBackend(mockDb, "http://127.0.0.1:19999");
+    // 使用随机未被占用的端口，避免冲突
+    const { port: deadPort } = await getDeadPort();
+    insertMockBackend(mockDb, `http://127.0.0.1:${deadPort}`);
     insertModelMapping(mockDb, "gpt-4", "gpt-4");
 
     app = buildTestApp(mockDb);

--- a/router/tests/overflow-redirect.test.ts
+++ b/router/tests/overflow-redirect.test.ts
@@ -10,6 +10,7 @@ import { RequestTracker } from "@llm-router/core/monitor";
 import { createMockBackend } from "./helpers/mock-backend.js";
 import { TEST_ENCRYPTION_KEY } from "./helpers/test-setup.js";
 import { ServiceContainer, SERVICE_KEYS } from "../src/core/container.js";
+import { ProxyAgentFactory } from "../src/proxy/transport/proxy-agent.js";
 
 
 function insertProvider(
@@ -62,6 +63,7 @@ function buildTestApp(db: Database.Database): FastifyInstance {
   container.register("adaptiveController", () => undefined);
     container.register(SERVICE_KEYS.logFileWriter, () => null);
   container.register(SERVICE_KEYS.pluginRegistry, () => undefined);
+  container.register(SERVICE_KEYS.proxyAgentFactory, () => new ProxyAgentFactory());
   app.register(openaiProxy, { db: db, container });
   return app;
 }

--- a/router/tests/proxy-agent.test.ts
+++ b/router/tests/proxy-agent.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { ProxyAgentFactory } from "../src/proxy/transport/proxy-agent.js";
+
+describe("ProxyAgentFactory", () => {
+  let factory: ProxyAgentFactory;
+
+  beforeEach(() => {
+    factory = new ProxyAgentFactory();
+  });
+
+  it("returns undefined when proxy_type is null", () => {
+    const agent = factory.getAgent({
+      id: "p1", proxy_type: null, proxy_url: null, proxy_username: null, proxy_password: null,
+    });
+    expect(agent).toBeUndefined();
+  });
+
+  it("returns undefined when proxy_url is null", () => {
+    const agent = factory.getAgent({
+      id: "p1", proxy_type: "http", proxy_url: null, proxy_username: null, proxy_password: null,
+    });
+    expect(agent).toBeUndefined();
+  });
+
+  it("creates agent for HTTP proxy type", () => {
+    const agent = factory.getAgent({
+      id: "p1", proxy_type: "http", proxy_url: "http://127.0.0.1:7890", proxy_username: null, proxy_password: null,
+    });
+    expect(agent).toBeDefined();
+  });
+
+  it("creates agent for SOCKS5 proxy type", () => {
+    const agent = factory.getAgent({
+      id: "p1", proxy_type: "socks5", proxy_url: "socks5://127.0.0.1:1080", proxy_username: null, proxy_password: null,
+    });
+    expect(agent).toBeDefined();
+  });
+
+  it("returns cached agent on second call", () => {
+    const first = factory.getAgent({
+      id: "p1", proxy_type: "http", proxy_url: "http://127.0.0.1:7890", proxy_username: null, proxy_password: null,
+    });
+    const second = factory.getAgent({
+      id: "p1", proxy_type: "http", proxy_url: "http://127.0.0.1:7890", proxy_username: null, proxy_password: null,
+    });
+    expect(first).toBe(second);
+  });
+
+  it("creates new agent when URL changes", () => {
+    const first = factory.getAgent({
+      id: "p1", proxy_type: "http", proxy_url: "http://127.0.0.1:7890", proxy_username: null, proxy_password: null,
+    });
+    const second = factory.getAgent({
+      id: "p1", proxy_type: "http", proxy_url: "http://127.0.0.1:8080", proxy_username: null, proxy_password: null,
+    });
+    expect(first).not.toBe(second);
+  });
+
+  it("invalidate removes cached agent", () => {
+    const agent = factory.getAgent({
+      id: "p1", proxy_type: "http", proxy_url: "http://127.0.0.1:7890", proxy_username: null, proxy_password: null,
+    });
+    factory.invalidate("p1");
+    const after = factory.getAgent({
+      id: "p1", proxy_type: "http", proxy_url: "http://127.0.0.1:7890", proxy_username: null, proxy_password: null,
+    });
+    expect(after).not.toBe(agent);
+  });
+
+  it("invalidateAll clears all caches", () => {
+    factory.getAgent({ id: "p1", proxy_type: "http", proxy_url: "http://127.0.0.1:7890", proxy_username: null, proxy_password: null });
+    factory.getAgent({ id: "p2", proxy_type: "socks5", proxy_url: "socks5://127.0.0.1:1080", proxy_username: null, proxy_password: null });
+    factory.invalidateAll();
+    const a1 = factory.getAgent({ id: "p1", proxy_type: "http", proxy_url: "http://127.0.0.1:7890", proxy_username: null, proxy_password: null });
+    expect(a1).toBeDefined();
+  });
+
+  it("builds proxy URL with embedded credentials without throwing", () => {
+    const agent = factory.getAgent({
+      id: "p1", proxy_type: "http", proxy_url: "http://proxy.example.com:8080", proxy_username: "user", proxy_password: "pass",
+    });
+    expect(agent).toBeDefined();
+  });
+
+  it("invalidate non-existent provider is a no-op", () => {
+    expect(() => factory.invalidate("nonexistent")).not.toThrow();
+  });
+});

--- a/router/tests/proxy-handler.test.ts
+++ b/router/tests/proxy-handler.test.ts
@@ -33,6 +33,7 @@ import { resolveMapping } from "../src/proxy/routing/mapping-resolver.js";
 import { logResilienceResult, collectTransportMetrics } from "../src/proxy/proxy-logging.js";
 import { insertRejectedLog } from "../src/proxy/log-helpers.js";
 import { ServiceContainer, SERVICE_KEYS } from "../src/core/container.js";
+import { ProxyAgentFactory } from "../src/proxy/transport/proxy-agent.js";
 
 
 const errors: ProxyErrorFormatter = {
@@ -73,6 +74,7 @@ function createDeps(overrides = {}) {
   container.register("semaphoreManager", () => undefined);
   container.register(SERVICE_KEYS.logFileWriter, () => null);
   container.register(SERVICE_KEYS.pluginRegistry, () => undefined);
+  container.register(SERVICE_KEYS.proxyAgentFactory, () => new ProxyAgentFactory());
   return {
     db: {} as any,
     orchestrator: { handle: vi.fn() } as any,

--- a/router/tests/proxy-semaphore.test.ts
+++ b/router/tests/proxy-semaphore.test.ts
@@ -9,6 +9,7 @@ import { openaiProxy } from "../src/proxy/handler/openai.js";
 import { SemaphoreManager as ProviderSemaphoreManager } from "@llm-router/core/concurrency";
 import { RequestTracker } from "@llm-router/core/monitor";
 import { ServiceContainer, SERVICE_KEYS } from "../src/core/container.js";
+import { ProxyAgentFactory } from "../src/proxy/transport/proxy-agent.js";
 
 
 const TEST_ENCRYPTION_KEY =
@@ -50,6 +51,7 @@ function buildTestApp(
   container.register("adaptiveController", () => undefined);
   container.register(SERVICE_KEYS.logFileWriter, () => null);
   container.register(SERVICE_KEYS.pluginRegistry, () => undefined);
+  container.register(SERVICE_KEYS.proxyAgentFactory, () => new ProxyAgentFactory());
   const app = Fastify();
   app.register(openaiProxy, { db: mockDb, container });
   return app;

--- a/router/tests/proxy/transform/integration.test.ts
+++ b/router/tests/proxy/transform/integration.test.ts
@@ -11,6 +11,7 @@ import { anthropicProxy } from "../../../src/proxy/handler/anthropic.js";
 import { SemaphoreManager as ProviderSemaphoreManager } from "@llm-router/core/concurrency";
 import { RequestTracker } from "@llm-router/core/monitor";
 import { ServiceContainer, SERVICE_KEYS } from "../../../src/core/container.js";
+import { ProxyAgentFactory } from "../../../src/proxy/transport/proxy-agent.js";
 import { createMockBackend } from "../../helpers/mock-backend.js";
 import { TEST_ENCRYPTION_KEY } from "../../helpers/test-setup.js";
 
@@ -29,6 +30,7 @@ function buildOAApp(db: Database.Database): FastifyInstance {
   container.register(SERVICE_KEYS.adaptiveController, () => undefined);
   container.register(SERVICE_KEYS.logFileWriter, () => null);
   container.register(SERVICE_KEYS.pluginRegistry, () => undefined);
+  container.register(SERVICE_KEYS.proxyAgentFactory, () => new ProxyAgentFactory());
   app.register(openaiProxy, { db, container });
   return app;
 }
@@ -46,6 +48,7 @@ function buildAntApp(db: Database.Database): FastifyInstance {
   container.register(SERVICE_KEYS.adaptiveController, () => undefined);
   container.register(SERVICE_KEYS.logFileWriter, () => null);
   container.register(SERVICE_KEYS.pluginRegistry, () => undefined);
+  container.register(SERVICE_KEYS.proxyAgentFactory, () => new ProxyAgentFactory());
   app.register(anthropicProxy, { db, container });
   return app;
 }

--- a/router/tests/retry-integration.test.ts
+++ b/router/tests/retry-integration.test.ts
@@ -10,6 +10,7 @@ import { RetryRuleMatcher } from "../src/proxy/orchestration/retry-rules.js";
 import { SemaphoreManager as ProviderSemaphoreManager } from "@llm-router/core/concurrency";
 import { RequestTracker } from "@llm-router/core/monitor";
 import { ServiceContainer, SERVICE_KEYS } from "../src/core/container.js";
+import { ProxyAgentFactory } from "../src/proxy/transport/proxy-agent.js";
 
 
 const TEST_KEY =
@@ -116,6 +117,7 @@ describe("Retry integration", () => {
     container.register("adaptiveController", () => undefined);
     container.register(SERVICE_KEYS.logFileWriter, () => null);
   container.register(SERVICE_KEYS.pluginRegistry, () => undefined);
+  container.register(SERVICE_KEYS.proxyAgentFactory, () => new ProxyAgentFactory());
     container.register("semaphoreManager", () => new ProviderSemaphoreManager());
     matcher.load(db);
     app = Fastify();
@@ -175,6 +177,7 @@ describe("Retry integration", () => {
     container.register("adaptiveController", () => undefined);
     container.register(SERVICE_KEYS.logFileWriter, () => null);
   container.register(SERVICE_KEYS.pluginRegistry, () => undefined);
+  container.register(SERVICE_KEYS.proxyAgentFactory, () => new ProxyAgentFactory());
     container.register("semaphoreManager", () => new ProviderSemaphoreManager());
     app = Fastify();
     app.register(anthropicProxy, { db: db, container });
@@ -234,6 +237,7 @@ describe("Retry integration", () => {
     container.register("adaptiveController", () => undefined);
     container.register(SERVICE_KEYS.logFileWriter, () => null);
   container.register(SERVICE_KEYS.pluginRegistry, () => undefined);
+  container.register(SERVICE_KEYS.proxyAgentFactory, () => new ProxyAgentFactory());
     app = Fastify();
     app.register(anthropicProxy, { db: db, container });
 

--- a/router/tests/stream-timeout.test.ts
+++ b/router/tests/stream-timeout.test.ts
@@ -9,6 +9,7 @@ import { openaiProxy } from "../src/proxy/handler/openai.js";
 import { SemaphoreManager as ProviderSemaphoreManager } from "@llm-router/core/concurrency";
 import { RequestTracker } from "@llm-router/core/monitor";
 import { ServiceContainer, SERVICE_KEYS } from "../src/core/container.js";
+import { ProxyAgentFactory } from "../src/proxy/transport/proxy-agent.js";
 import { createMockBackend } from "./helpers/mock-backend.js";
 import { getModelStreamTimeout, DEFAULT_STREAM_TIMEOUT_MS } from "../src/db/providers.js";
 
@@ -30,6 +31,7 @@ function buildTestApp(mockDb: Database.Database): FastifyInstance {
   container.register("adaptiveController", () => undefined);
   container.register(SERVICE_KEYS.logFileWriter, () => null);
   container.register(SERVICE_KEYS.pluginRegistry, () => undefined);
+  container.register(SERVICE_KEYS.proxyAgentFactory, () => new ProxyAgentFactory());
 
   app.register(openaiProxy, { db: mockDb, container });
 


### PR DESCRIPTION
Closes #66

## Summary

Add per-provider network proxy configuration, allowing each Provider to route API requests through a SOCKS5 or HTTP proxy.

## Changes

### Backend
- **DB migration 041**: Add `proxy_type`, `proxy_url`, `proxy_username`, `proxy_password` columns to `providers` table
- **ProxyAgentFactory** (`router/src/proxy/transport/proxy-agent.ts`): Singleton that creates and caches `http.Agent` per provider using `https-proxy-agent` (HTTP) or `socks-proxy-agent` (SOCKS5). Credentials embedded into proxy URL before agent creation.
- **Transport layer**: `http.ts`, `stream.ts` accept optional `agent` parameter, passed through to `http.request()`/`https.request()`
- **Admin API**: Encrypt/decrypt proxy credentials (AES-256-GCM, same as API keys), CRUD endpoints for proxy fields
- **ServiceContainer**: Register `ProxyAgentFactory` as lazy singleton

### Frontend
- **Providers.vue**: Proxy configuration section (type select, URL, username, password fields), Shield icon indicator in table
- **Composables**: Extract `useProviderForm`, `useProviderActions`, `useProviderPresets` to reduce file size from 622 to 319 lines
- **ProxyConfigForm.vue**: Reusable proxy configuration component
- **i18n**: Full en + zh-CN translations for all proxy-related strings

### Tests
- **proxy-agent.test.ts**: 10 unit tests for ProxyAgentFactory (creation, caching, invalidation, SOCKS5/HTTP types)
- **Admin API tests**: Proxy field encryption/decryption, CRUD with proxy config
- **Flaky test fix**: Replace hardcoded port 19999 with dynamic dead port allocation in unreachable backend tests

## Design Decisions
- Per-provider granularity (no shared proxy templates)
- Proxy credentials encrypted with AES-256-GCM (same mechanism as API keys)
- Proxy is fully transparent to retry/failover/orchestration logic
- `https-proxy-agent` v9 + `socks-proxy-agent` v10 (NOT `proxy-agent` unified package)

## Verification
- All 921 tests pass (78 files)
- ESLint: 0 errors, 0 warnings (backend + frontend)
- vue-tsc: 0 errors
- vue_rules_checker: pass
- Build: success (core + router + frontend)