### PR TITLE
refactor: 优化 restart 关闭策略 — 优雅等待 + spawn 错误监听 + 常量提取

### DIFF
--- a/router/src/admin/upgrade.ts
+++ b/router/src/admin/upgrade.ts
@@ -15,6 +15,9 @@ const GITEE_CONFIG_BASE = 'https://gitee.com/zzzzswszzzz/llm-simple-router/raw/m
 const CHECK_INTERVAL_MS = 60 * 60 * 1000 // eslint-disable-line no-magic-numbers
 const JSON_INDENT = 2
 
+const RESTART_FORCE_EXIT_MS = 3_000
+const RESTART_RESPONSE_FLUSH_MS = 300
+
 interface UpgradeRoutesOptions {
   db: Database.Database
   closeFn: () => Promise<void>
@@ -104,7 +107,7 @@ export const adminUpgradeRoutes: FastifyPluginCallback<UpgradeRoutesOptions> = (
     reply.send({ ok: true, method })
 
     // 给响应发送窗口
-    await new Promise((resolve) => setTimeout(resolve, 300)) // eslint-disable-line no-magic-numbers
+    await new Promise((resolve) => setTimeout(resolve, RESTART_RESPONSE_FLUSH_MS))
 
     try {
       req.log.info({ method, managed }, 'Restarting server...')
@@ -120,18 +123,20 @@ export const adminUpgradeRoutes: FastifyPluginCallback<UpgradeRoutesOptions> = (
           stdio: 'ignore',
           env: { ...process.env },
         })
+        child.on('error', (err) => {
+          req.log.error({ err, binPath }, 'Failed to spawn new process')
+        })
         child.unref()
       }
 
       // 强制退出兜底：即使 closeFn 卡住（如活跃代理 SSE 流），也能确保进程退出。
-      const RESTART_FORCE_EXIT_MS = 3000
       const forceExitTimer = setTimeout(() => {
         req.log.warn('Graceful shutdown timed out during restart, forcing exit')
         process.exit(0)
       }, RESTART_FORCE_EXIT_MS)
       forceExitTimer.unref()
 
-      // 尝试优雅关闭（closeFn 内部已调用 closeAllConnections 加速关闭）
+      // 尝试优雅关闭（closeFn 内部有 2s 优雅等待 + closeAllConnections 兜底）
       await options.closeFn()
 
       clearTimeout(forceExitTimer)

--- a/router/src/admin/upgrade.ts
+++ b/router/src/admin/upgrade.ts
@@ -109,11 +109,9 @@ export const adminUpgradeRoutes: FastifyPluginCallback<UpgradeRoutesOptions> = (
     try {
       req.log.info({ method, managed }, 'Restarting server...')
 
-      // 优雅关闭（释放端口、等待活跃请求完成）
-      await options.closeFn()
-
       if (!managed) {
-        // 无进程管理器（npx / 手动 node）：自 spawn 新进程
+        // 无进程管理器（npx / 手动 node）：先 spawn 新进程，再关闭旧进程。
+        // 必须在 closeFn 之前 spawn，否则 closeFn 可能因活跃 SSE 连接卡住导致新进程永远不启动。
         const binPath = resolveRestartBinPath()
         const args = process.argv.slice(2) // eslint-disable-line no-magic-numbers
         req.log.info({ binPath, args }, 'Spawning new process before exit')
@@ -125,12 +123,25 @@ export const adminUpgradeRoutes: FastifyPluginCallback<UpgradeRoutesOptions> = (
         child.unref()
       }
 
+      // 强制退出兜底：即使 closeFn 卡住（如活跃代理 SSE 流），也能确保进程退出。
+      const RESTART_FORCE_EXIT_MS = 3000
+      const forceExitTimer = setTimeout(() => {
+        req.log.warn('Graceful shutdown timed out during restart, forcing exit')
+        process.exit(0)
+      }, RESTART_FORCE_EXIT_MS)
+      forceExitTimer.unref()
+
+      // 尝试优雅关闭（closeFn 内部已调用 closeAllConnections 加速关闭）
+      await options.closeFn()
+
+      clearTimeout(forceExitTimer)
       req.log.info('Exiting current process')
       process.exit(0)
     } catch (err) {
-      // 重启失败时记录错误，保持服务运行
+      // 优雅关闭失败时也必须退出：新进程已经 spawn，旧进程必须让出端口
       const msg = err instanceof Error ? err.message : String(err)
       req.log.error({ err }, `Restart failed: ${msg}`)
+      process.exit(1)
     }
   })
 

--- a/router/src/index.ts
+++ b/router/src/index.ts
@@ -350,6 +350,11 @@ export async function buildApp(
     proxyAgentFactory.invalidateAll();
     const sessionTracker = container.resolve<SessionTracker>(SERVICE_KEYS.sessionTracker);
     sessionTracker.stop();
+    // 强制关闭所有活跃连接（包括代理 SSE 流），防止 app.close() 因长连接卡住。
+    // Node 18+ 支持 server.closeAllConnections()。
+    if (typeof app.server.closeAllConnections === 'function') {
+      app.server.closeAllConnections();
+    }
     await app.close();
     db.close();
   };

--- a/router/src/index.ts
+++ b/router/src/index.ts
@@ -350,12 +350,16 @@ export async function buildApp(
     proxyAgentFactory.invalidateAll();
     const sessionTracker = container.resolve<SessionTracker>(SERVICE_KEYS.sessionTracker);
     sessionTracker.stop();
-    // 强制关闭所有活跃连接（包括代理 SSE 流），防止 app.close() 因长连接卡住。
-    // Node 18+ 支持 server.closeAllConnections()。
-    if (typeof app.server.closeAllConnections === 'function') {
-      app.server.closeAllConnections();
-    }
+    // 等待活跃代理请求自然完成，超时后强制关闭所有连接。
+    // 先调用 app.close() 停止接受新连接并等待现有连接结束，
+    // 如果 2 秒内未完成则调用 closeAllConnections() 强制断开，防止 SSE 长连接导致无限等待。
+    const CLOSE_GRACE_PERIOD_MS = 2_000;
+    const forceClose = typeof app.server.closeAllConnections === 'function'
+      ? setTimeout(() => app.server.closeAllConnections!(), CLOSE_GRACE_PERIOD_MS)
+      : null;
+    if (forceClose) forceClose.unref();
     await app.close();
+    if (forceClose) clearTimeout(forceClose);
     db.close();
   };
 


### PR DESCRIPTION
- closeFn: closeAllConnections 改为延迟 2s 触发，给活跃代理请求一个优雅完成窗口
- restart handler: spawn 添加 child.on('error') 日志记录
- 魔法数字提取为模块级常量 RESTART_FORCE_EXIT_MS / RESTART_RESPONSE_FLUSH_MS