### PR TITLE
fix: tool_error_logs 外键约束失败 + 精简存储

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
     },
     "core": {
       "name": "@llm-router/core",
-      "version": "0.9.27",
+      "version": "0.9.28",
       "devDependencies": {
         "@types/node": "^24.12.2",
         "typescript": "^5.8.3",
@@ -948,6 +948,7 @@
       "resolved": "https://registry.npmmirror.com/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -3123,6 +3124,7 @@
       "resolved": "https://registry.npmmirror.com/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
       "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -3204,6 +3206,7 @@
       "resolved": "https://registry.npmmirror.com/@noble/ciphers/-/ciphers-1.3.0.tgz",
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -3675,8 +3678,7 @@
       "optional": true,
       "os": [
         "android"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
       "version": "4.60.2",
@@ -3690,8 +3692,7 @@
       "optional": true,
       "os": [
         "android"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.60.2",
@@ -3705,8 +3706,7 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
       "version": "4.60.2",
@@ -3720,8 +3720,7 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
       "version": "4.60.2",
@@ -3735,8 +3734,7 @@
       "optional": true,
       "os": [
         "freebsd"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
       "version": "4.60.2",
@@ -3750,8 +3748,7 @@
       "optional": true,
       "os": [
         "freebsd"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
       "version": "4.60.2",
@@ -3765,8 +3762,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
       "version": "4.60.2",
@@ -3780,8 +3776,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
       "version": "4.60.2",
@@ -3795,8 +3790,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
       "version": "4.60.2",
@@ -3810,8 +3804,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
       "version": "4.60.2",
@@ -3825,8 +3818,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
       "version": "4.60.2",
@@ -3840,8 +3832,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
       "version": "4.60.2",
@@ -3855,8 +3846,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
       "version": "4.60.2",
@@ -3870,8 +3860,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
       "version": "4.60.2",
@@ -3885,8 +3874,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
       "version": "4.60.2",
@@ -3900,8 +3888,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
       "version": "4.60.2",
@@ -3915,8 +3902,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.60.2",
@@ -3930,8 +3916,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
       "version": "4.60.2",
@@ -3945,8 +3930,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
       "version": "4.60.2",
@@ -3960,8 +3944,7 @@
       "optional": true,
       "os": [
         "openbsd"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
       "version": "4.60.2",
@@ -3975,8 +3958,7 @@
       "optional": true,
       "os": [
         "openharmony"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
       "version": "4.60.2",
@@ -3990,8 +3972,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
       "version": "4.60.2",
@@ -4005,8 +3986,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
       "version": "4.60.2",
@@ -4020,8 +4000,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.60.2",
@@ -4035,8 +4014,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@silvia-odwyer/photon-node": {
       "version": "0.3.4",
@@ -4994,6 +4972,7 @@
       "integrity": "sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.1",
         "@typescript-eslint/types": "8.59.1",
@@ -5623,6 +5602,7 @@
       "resolved": "https://registry.npmmirror.com/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6118,6 +6098,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -6326,6 +6307,7 @@
       "resolved": "https://registry.npmmirror.com/chart.js/-/chart.js-4.5.1.tgz",
       "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@kurkle/color": "^0.3.0"
       },
@@ -7313,6 +7295,7 @@
       "resolved": "https://registry.npmmirror.com/eslint/-/eslint-10.3.0.tgz",
       "integrity": "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -8686,6 +8669,7 @@
       "resolved": "https://registry.npmmirror.com/hono/-/hono-4.12.16.tgz",
       "integrity": "sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -9110,6 +9094,7 @@
       "resolved": "https://registry.npmmirror.com/jiti/-/jiti-2.6.1.tgz",
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -9407,6 +9392,7 @@
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "dev": true,
       "license": "MPL-2.0",
+      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.3"
       },
@@ -10818,6 +10804,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -12504,6 +12491,7 @@
       "resolved": "https://registry.npmmirror.com/stylus/-/stylus-0.57.0.tgz",
       "integrity": "sha512-yOI6G8WYfr0q8v8rRvE91wbxFU+rJPo760Va4MF6K0I6BZjO4r+xSynkvyPBP9tV1CIEUeRsiidjIs2rzb1CnQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "css": "^3.0.0",
         "debug": "^4.3.2",
@@ -12750,6 +12738,7 @@
       "resolved": "https://registry.npmmirror.com/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -13138,7 +13127,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13156,7 +13144,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13174,7 +13161,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13192,7 +13178,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13210,7 +13195,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13228,7 +13212,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13246,7 +13229,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13264,7 +13246,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13282,7 +13263,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13300,7 +13280,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13318,7 +13297,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13336,7 +13314,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13354,7 +13331,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13372,7 +13348,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13390,7 +13365,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13408,7 +13382,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13426,7 +13399,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13444,7 +13416,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13462,7 +13433,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13480,7 +13450,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13498,7 +13467,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13516,7 +13484,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13534,7 +13501,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13552,7 +13518,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13570,7 +13535,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13588,7 +13552,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13698,6 +13661,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -13895,6 +13859,7 @@
       "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -15156,6 +15121,7 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -15237,6 +15203,7 @@
       "resolved": "https://registry.npmmirror.com/vue/-/vue-3.5.33.tgz",
       "integrity": "sha512-1AgChhx5w3ALgT4oK3acm2Es/7jyZhWSVUfs3rOBlGQC0rjEDkS7G4lWlJJGGNQD+BV3reCwbQrOe1mPNwKHBQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.33",
         "@vue/compiler-sfc": "3.5.33",
@@ -15646,6 +15613,7 @@
       "integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
       "devOptional": true,
       "license": "ISC",
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -15795,6 +15763,7 @@
       "resolved": "https://registry.npmmirror.com/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/router/src/db/migrations/042_simplify_tool_error_logs.sql
+++ b/router/src/db/migrations/042_simplify_tool_error_logs.sql
@@ -1,0 +1,27 @@
+-- 042_simplify_tool_error_logs.sql
+-- 精简 tool_error_logs：去掉 tool_input / error_content 大字段，
+-- 改为通过 request_log_id + tool_use_id 从 request_logs 回溯完整数据。
+-- SQLite 不支持 DROP COLUMN（需 3.35+），重建表。
+
+DROP TABLE IF EXISTS tool_error_logs;
+
+CREATE TABLE tool_error_logs (
+  id TEXT PRIMARY KEY,
+  request_log_id TEXT REFERENCES request_logs(id) ON DELETE SET NULL,
+  tool_use_id TEXT NOT NULL,
+  provider_id TEXT NOT NULL,
+  backend_model TEXT NOT NULL,
+  client_agent_type TEXT NOT NULL DEFAULT 'unknown'
+    CHECK(client_agent_type IN ('claude-code', 'pi', 'unknown')),
+  tool_name TEXT NOT NULL,
+  router_key_id TEXT,
+  session_id TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX idx_tool_error_logs_time
+  ON tool_error_logs(created_at);
+CREATE INDEX idx_tool_error_logs_provider
+  ON tool_error_logs(provider_id, created_at);
+CREATE INDEX idx_tool_error_logs_tool
+  ON tool_error_logs(tool_name);

--- a/router/src/proxy/handler/proxy-handler-utils.ts
+++ b/router/src/proxy/handler/proxy-handler-utils.ts
@@ -14,8 +14,6 @@ export type ClientAgentType = "claude-code" | "pi" | "unknown";
 export interface FailedToolResult {
   toolName: string;
   toolUseId: string | undefined;
-  toolInput: string | undefined;
-  errorContent: string;
 }
 
 /**
@@ -37,7 +35,8 @@ export function detectClientAgentType(headers: RawHeaders): ClientAgentType {
  * 避免重复记录前轮请求已记录的 tool 失败。
  *
  * 通过向前扫描 assistant 消息中的 tool_use 块
- * 关联对应的 tool_name 和 tool_input。
+ * 关联对应的 tool_name。完整 input/error 内容通过
+ * request_log_id + tool_use_id 从 request_logs 回溯。
  */
 export function extractFailedToolResults(
   body: Record<string, unknown>,
@@ -48,9 +47,9 @@ export function extractFailedToolResults(
   }> | undefined;
   if (!messages || messages.length === 0) return [];
 
-  // 第一步：向后往前找最后一个包含 tool_result 的 user 消息
+  // 第一步：从后往前找最后一个包含 tool_result 的 user 消息
   let lastUserIndex = -1;
-  const resultBlocks: Array<{ tool_use_id?: string; content: unknown; is_error?: boolean }> = [];
+  const resultBlocks: Array<{ tool_use_id?: string; is_error?: boolean }> = [];
   for (let i = messages.length - 1; i >= 0; i--) {
     const msg = messages[i];
     if (msg.role !== "user") continue;
@@ -66,16 +65,15 @@ export function extractFailedToolResults(
   }
   if (lastUserIndex < 0) return [];
 
-  // 第二步：在整个 messages 中建立 tool_use_id → { name, input } 映射
-  const toolUseMap = new Map<string, { name: string; input: string }>();
+  // 第二步：建立 tool_use_id → tool_name 映射
+  const toolUseMap = new Map<string, string>();
   for (let i = 0; i < lastUserIndex; i++) {
     const msg = messages[i];
     if (msg.role !== "assistant") continue;
     const content = Array.isArray(msg.content) ? msg.content : [];
     for (const block of content) {
       if (block.type === "tool_use" && block.id) {
-        const inputText = block.input ? JSON.stringify(block.input) : "";
-        toolUseMap.set(block.id, { name: block.name ?? "unknown", input: inputText });
+        toolUseMap.set(block.id, block.name ?? "unknown");
       }
     }
   }
@@ -84,17 +82,11 @@ export function extractFailedToolResults(
   const failures: FailedToolResult[] = [];
   for (const block of resultBlocks) {
     if (block.is_error !== true) continue;
-    const toolUse = block.tool_use_id && typeof block.tool_use_id === "string"
-      ? toolUseMap.get(block.tool_use_id)
-      : undefined;
-    const errorContent = typeof block.content === "string"
-      ? block.content
-      : JSON.stringify(block.content ?? "");
+    const toolUseId = block.tool_use_id && typeof block.tool_use_id === "string"
+      ? block.tool_use_id : undefined;
     failures.push({
-      toolName: toolUse?.name ?? "unknown",
-      toolUseId: block.tool_use_id,
-      toolInput: toolUse?.input,
-      errorContent,
+      toolName: toolUseId ? (toolUseMap.get(toolUseId) ?? "unknown") : "unknown",
+      toolUseId,
     });
   }
   return failures;

--- a/router/src/proxy/handler/proxy-handler.ts
+++ b/router/src/proxy/handler/proxy-handler.ts
@@ -32,6 +32,7 @@ import { PipelineSnapshot, type StageRecord } from "../pipeline-snapshot.js";
 import { applyToolRoundLimit } from "../patch/tool-round-limiter.js";
 import { loadEnhancementConfig } from "../routing/enhancement-config.js";
 import { getTransportStatusCode, serializeBlocksForStorage, extractLastToolUse, extractFailedToolResults, detectClientAgentType } from "./proxy-handler-utils.js";
+import type { FailedToolResult } from "./proxy-handler-utils.js";
 import { logToolErrors } from "../tool-error-logger.js";
 
 const HTTP_ERROR_THRESHOLD = 400;
@@ -85,6 +86,7 @@ function rejectAndReply(
   error: ProxyErrorResponse,
   errorMessage: string,
   providerId?: string,
+  afterLog?: () => void,
 ): FastifyReply {
   insertRejectedLog({
     db: params.db, logId: params.logId, apiType: params.apiType, model: params.model,
@@ -96,6 +98,7 @@ function rejectAndReply(
     sessionId: params.sessionId, pipelineSnapshot: params.pipelineSnapshot,
     matcher: params.matcher, logFileWriter: params.logFileWriter,
   });
+  afterLog?.();
   return reply.code(error.statusCode).send(error.body);
 }
 
@@ -216,6 +219,13 @@ async function executeFailoverLoop(ctx: FailoverContext): Promise<FastifyReply> 
   const excludeTargets: Target[] = [];
   let rootLogId: string | null = null;
   let toolErrorsLogged = false;
+  let pendingToolErrors: FailedToolResult[] | null = null;
+  /** request_logs 写入后调用，将 pending 的 tool error logs 安全写入 DB */
+  const flushToolErrors = (providerId: string, model: string, reqLogId: string) => {
+    if (!pendingToolErrors) return;
+    logToolErrors(pendingToolErrors, { db: deps.db, providerId, backendModel: model, clientAgentType: detectClientAgentType(request.headers as RawHeaders), requestLogId: reqLogId, routerKeyId: request.routerKey?.id ?? null, sessionId });
+    pendingToolErrors = null;
+  };
   // TransformCoordinator 无状态，只需创建一次
   const coordinator = new TransformCoordinator();
   const enhancementConfig = loadEnhancementConfig(deps.db);
@@ -277,21 +287,14 @@ async function executeFailoverLoop(ctx: FailoverContext): Promise<FastifyReply> 
         `Provider '${resolved.provider_id}' unavailable`, resolved.provider_id);
     }
 
-    // 工具错误日志记录 — 首次迭代时执行，记录本轮请求中的 is_error tool_result
+    // 工具错误日志：首次迭代时提取 failures，延迟到 request_logs 写入后再记录
+    // 避免 request_log_id 外键引用尚未存在的 request_logs 记录
     if (enhancementConfig.tool_error_logging_enabled && !toolErrorsLogged) {
       toolErrorsLogged = true;
       const failures = extractFailedToolResults(pipelineBody);
       if (failures.length > 0) {
         request.log.info({ failures: failures.length, sessionId }, "Tool error results detected");
-        logToolErrors(failures, {
-          db: deps.db,
-          providerId: resolved.provider_id,
-          backendModel: resolved.backend_model ?? effectiveModel,
-          clientAgentType: detectClientAgentType(cliHdrs),
-          requestLogId: logId,
-          routerKeyId,
-          sessionId,
-        });
+        pendingToolErrors = failures;
       }
     }
 
@@ -359,7 +362,8 @@ async function executeFailoverLoop(ctx: FailoverContext): Promise<FastifyReply> 
     const encryptionKey = getSetting(deps.db, "encryption_key");
     if (!encryptionKey) {
       return rejectAndReply(reply, rCtx, errors.providerUnavailable(),
-        `Encryption key not configured`, provider.id);
+        `Encryption key not configured`, provider.id,
+        () => flushToolErrors(provider.id, resolved.backend_model ?? effectiveModel, logId));
     }
     const apiKey = decrypt(provider.api_key, encryptionKey);
     options?.beforeSendProxy?.(patchedBody, isStream);
@@ -435,6 +439,9 @@ async function executeFailoverLoop(ctx: FailoverContext): Promise<FastifyReply> 
       );
       collectTransportMetrics(deps.db, apiType, resilienceResult.result, isStream, lastLogId, provider.id, resolved.backend_model, request, routerKeyId, getTransportStatusCode(resilienceResult.result));
 
+      // request_logs 已写入，安全写入 pending tool error logs
+      flushToolErrors(resolved.provider_id, resolved.backend_model ?? effectiveModel, lastLogId);
+
       // Stream timeout: send 408 error with API-specific body to client
       if (resilienceResult.result.kind === "stream_abort" && resilienceResult.result.timeoutContext) {
         const { modelId, providerId } = resilienceResult.result.timeoutContext;
@@ -509,16 +516,20 @@ async function executeFailoverLoop(ctx: FailoverContext): Promise<FastifyReply> 
           );
         }
         request.log.debug({ logId, action: "provider_switch", targetProviderId: e.targetProviderId });
+        // request_logs 已写入（logResilienceResult），flush pending tool errors
+        flushToolErrors(resolved.provider_id, resolved.backend_model ?? effectiveModel, logId);
         excludeTargets.push(resolved);
         continue;
       }
       if (e instanceof SemaphoreQueueFullError) {
         return rejectAndReply(reply, rCtx, errors.concurrencyQueueFull(provider.id),
-          `Concurrency queue full for provider '${provider.id}'`, provider.id);
+          `Concurrency queue full for provider '${provider.id}'`, provider.id,
+          () => flushToolErrors(provider.id, resolved.backend_model ?? effectiveModel, logId));
       }
       if (e instanceof SemaphoreTimeoutError) {
         return rejectAndReply(reply, rCtx, errors.concurrencyTimeout(provider.id, e.timeoutMs),
-          `Concurrency wait timeout for provider '${provider.id}' (${e.timeoutMs}ms)`, provider.id);
+          `Concurrency wait timeout for provider '${provider.id}' (${e.timeoutMs}ms)`, provider.id,
+          () => flushToolErrors(provider.id, resolved.backend_model ?? effectiveModel, logId));
       }
       const errMsg = e instanceof Error ? e.message : String(e);
       request.log.debug({ logId, error: errMsg, action: "upstream_error" });
@@ -534,6 +545,8 @@ async function executeFailoverLoop(ctx: FailoverContext): Promise<FastifyReply> 
       }, (matcher || logFileWriter) ? {
         matcher, logFileWriter, responseBody: null,
       } : undefined);
+      // request_logs 已写入，flush pending tool errors
+      flushToolErrors(provider.id, resolved.backend_model ?? effectiveModel, logId);
       const err = errors.upstreamConnectionFailed();
       return reply.code(err.statusCode).send(err.body);
     }

--- a/router/src/proxy/tool-error-logger.ts
+++ b/router/src/proxy/tool-error-logger.ts
@@ -14,20 +14,20 @@ export interface ToolErrorLogContext {
 
 /**
  * 将失败的 tool_result 批量写入 tool_error_logs 表。
- * 每条失败记录独立一行。
+ * 每条失败记录独立一行。只存索引字段，
+ * 完整 tool_input / error_content 通过
+ * request_log_id + tool_use_id 从 request_logs 回溯。
  */
 export function logToolErrors(failures: FailedToolResult[], ctx: ToolErrorLogContext): void {
   if (failures.length === 0) return;
 
   const stmt = ctx.db.prepare(`
     INSERT INTO tool_error_logs
-      (id, request_log_id, provider_id, backend_model, client_agent_type,
-       tool_name, tool_use_id, tool_input, error_content,
-       router_key_id, session_id, created_at)
+      (id, request_log_id, tool_use_id, provider_id, backend_model,
+       client_agent_type, tool_name, router_key_id, session_id, created_at)
     VALUES
-      (@id, @request_log_id, @provider_id, @backend_model, @client_agent_type,
-       @tool_name, @tool_use_id, @tool_input, @error_content,
-       @router_key_id, @session_id, @created_at)
+      (@id, @request_log_id, @tool_use_id, @provider_id, @backend_model,
+       @client_agent_type, @tool_name, @router_key_id, @session_id, @created_at)
   `);
 
   const now = new Date().toISOString();
@@ -36,13 +36,11 @@ export function logToolErrors(failures: FailedToolResult[], ctx: ToolErrorLogCon
       stmt.run({
         id: randomUUID(),
         request_log_id: ctx.requestLogId,
+        tool_use_id: f.toolUseId ?? "unknown",
         provider_id: ctx.providerId,
         backend_model: ctx.backendModel,
         client_agent_type: ctx.clientAgentType,
         tool_name: f.toolName,
-        tool_use_id: f.toolUseId ?? null,
-        tool_input: f.toolInput ?? null,
-        error_content: f.errorContent,
         router_key_id: ctx.routerKeyId,
         session_id: ctx.sessionId ?? null,
         created_at: now,

--- a/router/tests/db.test.ts
+++ b/router/tests/db.test.ts
@@ -39,7 +39,7 @@ describe("initDatabase", () => {
       .prepare("SELECT name FROM migrations")
       .all() as { name: string }[];
 
-    expect(rows.length).toBe(42);
+    expect(rows.length).toBe(43);
     expect(rows[0].name).toBe("001_init.sql");
     expect(rows[1].name).toBe("002_add_request_response_body.sql");
     expect(rows[2].name).toBe("003_add_full_request_chain_log.sql");

--- a/router/tests/metrics.test.ts
+++ b/router/tests/metrics.test.ts
@@ -29,7 +29,7 @@ describe("request_metrics migration and insertMetrics", () => {
       .prepare("SELECT name FROM migrations")
       .all() as { name: string }[];
 
-    expect(rows).toHaveLength(42);
+    expect(rows).toHaveLength(43);
     expect(rows[5].name).toBe("006_create_request_metrics.sql");
     expect(rows[6].name).toBe("007_add_retry_fields.sql");
     expect(rows[7].name).toBe("008_create_router_keys.sql");


### PR DESCRIPTION
Bug 修复：
- logToolErrors 延迟到 request_logs 写入后再调用
- 避免 request_log_id 外键引用尚未存在的 request_logs 记录
- 所有 5 个 request_logs 写入路径后都有 flushToolErrors 调用

存储优化：
- 去掉 tool_input / error_content 两个大字段
- 通过 request_log_id + tool_use_id 从 request_logs 回溯完整数据
- 索引从 6 个精简到 3 个
- 每行从 KB 级降到 ~300 字节