### PR TITLE
fix: 修复 providers.models JSON 解析错误 + 添加 ESLint 规则防止复发

### DIFF
--- a/.githooks/install-hooks.sh
+++ b/.githooks/install-hooks.sh
@@ -52,6 +52,7 @@ cat > "$GIT_HOOKS_DIR/pre-commit" << 'HOOK_EOF'
 #   SKIP_FRONTEND_LINT=1      - 跳过前端 ESLint
 #   SKIP_TYPE_CHECK=1         - 跳过 vue-tsc 类型检查
 #   SKIP_CODE_RULES_CHECK=1   - 跳过自定义代码规范检查
+#   SKIP_BACKEND_LINT=1       - 跳过后端 ESLint
 
 set -e
 

--- a/.githooks/install-hooks.sh
+++ b/.githooks/install-hooks.sh
@@ -167,6 +167,33 @@ if [ -n "$FRONTEND_FILES" ]; then
 fi
 
 # ============================================================================
+# 1.5. 后端 ESLint 检查（router/ 目录）
+# ============================================================================
+
+ROUTER_FILES=$(echo "$STAGED_FILES" | grep -E "^router/src/.*\.ts$" || true)
+if [ -n "$ROUTER_FILES" ]; then
+    print_section "[后端 ESLint 检查]"
+
+    if [ "$SKIP_BACKEND_LINT" != "1" ]; then
+        echo -e "${BLUE}[INFO] 运行 router ESLint 检查...${NC}"
+
+        ROUTER_ESLINT_FILES=$(echo "$ROUTER_FILES" | tr '\n' ' ')
+        ESLINT_OUTPUT=$(npx eslint --max-warnings=0 $ROUTER_ESLINT_FILES 2>&1)
+        ESLINT_EXIT_CODE=$?
+
+        if [ $ESLINT_EXIT_CODE -ne 0 ]; then
+            echo -e "${RED}[ERROR] 后端 ESLint 检查失败:${NC}"
+            echo "$ESLINT_OUTPUT"
+            exit 1
+        fi
+
+        echo -e "${GREEN}[OK] 后端 ESLint 检查通过${NC}"
+    else
+        echo -e "${YELLOW}[SKIP] 后端 ESLint 检查已跳过${NC}"
+    fi
+fi
+
+# ============================================================================
 # 2. 前端 vue-tsc 类型检查（与 CI 等价）
 # ============================================================================
 
@@ -250,6 +277,7 @@ echo -e "  ${YELLOW}SKIP_FORMAT=1${NC}             - 跳过 Prettier"
 echo -e "  ${YELLOW}SKIP_FRONTEND_LINT=1${NC}      - 跳过 ESLint"
 echo -e "  ${YELLOW}SKIP_TYPE_CHECK=1${NC}          - 跳过 vue-tsc"
 echo -e "  ${YELLOW}SKIP_CODE_RULES_CHECK=1${NC}   - 跳过代码规范"
+echo -e "  ${YELLOW}SKIP_BACKEND_LINT=1${NC}       - 跳过后端 ESLint"
 echo ""
 
 exit 0
@@ -272,6 +300,7 @@ echo ""
 echo -e "${CYAN}已安装的检查项目:${NC}"
 echo -e "  ${GREEN}[+]${NC} Prettier 格式化（自动修复）"
 echo -e "  ${GREEN}[+]${NC} 前端 ESLint 代码检查"
+echo -e "  ${GREEN}[+]${NC} 后端 ESLint 代码检查（router/）"
 echo -e "  ${GREEN}[+]${NC} vue-tsc 类型检查（全量，与 CI 等价）"
 echo -e "  ${GREEN}[+]${NC} Vue 组件规范检查（禁止原生 HTML、Emoji、自定义 CSS）"
 echo ""

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,6 +206,7 @@ Handler (handler/proxy-handler.ts)
 - **token 计数统一使用 `gpt-tokenizer`（o200k_base）**：禁止用字符长度估算 token 数。当 API 未返回 `input_tokens`（如部分第三方模型）时，`collectTransportMetrics()` 自动回退到 `estimateInputTokens()` 从请求体计数。
   相关文件：`src/utils/token-counter.ts`（共享工具）、`src/proxy/routing/overflow.ts`（请求 token 估算溢出）、`src/metrics/metrics-extractor.ts`（thinking 模型 text-only TPS 计算）。
   长文本（>4000 字符）采用采样外推策略避免性能问题。
+- **禁止对 DB 中的 JSON 字段直接 JSON.parse**：`providers.models` 等字段存储的是 JSON 文本，数据格式会演进（如从 `string[]` 到 `ModelEntry[]`）。所有解析必须通过对应的类型安全函数（如 `parseModels()`），禁止裸 `JSON.parse`。ESLint 规则 `taste/no-raw-json-parse-models` 会强制执行此约束。
 
 ## 环境变量
 

--- a/router/src/config/model-context.ts
+++ b/router/src/config/model-context.ts
@@ -115,6 +115,14 @@ export function normalizePatchName(name: string): string {
  *
  * ESLint 规则 taste/no-raw-json-parse-models 会强制执行此约束。
  */
+/** 旧 patch ID 到新 patch ID 的迁移映射 */
+const PATCH_ID_MIGRATION: Record<string, string> = {
+  thinking_param: "thinking_consistency",
+  thinking_blocks: "thinking_consistency",
+  non_ds_tools: "thinking_consistency",
+  cache_control: "thinking_consistency",
+};
+
 export function parseModels(raw: string): ModelEntry[] {
   if (!raw) return []
   try {
@@ -128,13 +136,6 @@ export function parseModels(raw: string): ModelEntry[] {
       if (!obj) return null
       const modelName = obj.name ?? obj.id
       if (!modelName) return null
-      /** 旧 patch ID 到新 patch ID 的运行时迁移映射 */
-      const PATCH_ID_MIGRATION: Record<string, string> = {
-        thinking_param: "thinking_consistency",
-        thinking_blocks: "thinking_consistency",
-        non_ds_tools: "thinking_consistency",
-        cache_control: "thinking_consistency",
-      };
       const rawPatches = (obj.patches ?? []).map(normalizePatchName);
       const migrated = rawPatches.map(p => PATCH_ID_MIGRATION[p] ?? p);
       const patches = [...new Set(migrated)];

--- a/router/src/config/model-context.ts
+++ b/router/src/config/model-context.ts
@@ -106,6 +106,15 @@ export function normalizePatchName(name: string): string {
   return name.replace(/-/g, "_")
 }
 
+/**
+ * 解析 providers.models 的 JSON 文本。
+ *
+ * 这是解析 providers.models 字段的唯一合法入口。
+ * 禁止直接 JSON.parse(provider.models) —— 数据格式已从 string[] 演进为 ModelEntry[]，
+ * 直接 JSON.parse 会得到对象数组而非字符串数组，导致运行时错误。
+ *
+ * ESLint 规则 taste/no-raw-json-parse-models 会强制执行此约束。
+ */
 export function parseModels(raw: string): ModelEntry[] {
   if (!raw) return []
   try {
@@ -115,8 +124,10 @@ export function parseModels(raw: string): ModelEntry[] {
       if (typeof item === 'string') {
         return item ? { name: item, patches: [] } : null
       }
-      const obj = item as { name?: string; patches?: string[]; stream_timeout_ms?: number } | null
-      if (!obj || !obj.name) return null
+      const obj = item as { name?: string; id?: string; patches?: string[]; stream_timeout_ms?: number } | null
+      if (!obj) return null
+      const modelName = obj.name ?? obj.id
+      if (!modelName) return null
       /** 旧 patch ID 到新 patch ID 的运行时迁移映射 */
       const PATCH_ID_MIGRATION: Record<string, string> = {
         thinking_param: "thinking_consistency",
@@ -128,7 +139,7 @@ export function parseModels(raw: string): ModelEntry[] {
       const migrated = rawPatches.map(p => PATCH_ID_MIGRATION[p] ?? p);
       const patches = [...new Set(migrated)];
       const result: ModelEntry = {
-        name: obj.name,
+        name: modelName,
         patches,
       }
       if (obj.stream_timeout_ms != null) result.stream_timeout_ms = obj.stream_timeout_ms

--- a/router/src/db/index.ts
+++ b/router/src/db/index.ts
@@ -124,6 +124,7 @@ function runApplicationMigrations(db: Database.Database): void {
   db.transaction(() => {
     for (const p of providers) {
       try {
+        // eslint-disable-next-line taste/no-raw-json-parse-models -- 迁移代码需要操作原始 JSON 结构，parseModels() 会过滤非标准字段
         const raw = JSON.parse(p.models);
         if (!Array.isArray(raw) || raw.length === 0) continue;
 

--- a/router/src/db/mappings.ts
+++ b/router/src/db/mappings.ts
@@ -2,6 +2,7 @@ import Database from "better-sqlite3";
 import { randomUUID } from "crypto";
 import type { Target } from "../core/types.js";
 import { buildUpdateQuery, deleteById } from "./helpers.js";
+import { parseModels } from "../config/model-context.js";
 
 export interface MappingGroup {
   id: string;
@@ -78,9 +79,9 @@ export function getActiveProviderModels(db: Database.Database): ProviderModelEnt
   const results: ProviderModelEntry[] = [];
   for (const p of providers) {
     try {
-      const models: string[] = JSON.parse(p.models);
-      for (const m of models) {
-        results.push({ provider_name: p.name, backend_model: m });
+      const modelEntries = parseModels(p.models);
+      for (const m of modelEntries) {
+        results.push({ provider_name: p.name, backend_model: m.name });
       }
     } catch { continue }
   }
@@ -131,8 +132,8 @@ export function resolveByProviderModel(
   const providerRow = db.prepare("SELECT id, models FROM providers WHERE name = ? AND is_active = 1").get(providerName) as { id: string; models: string } | undefined;
   if (!providerRow) return null;
   try {
-    const models: string[] = JSON.parse(providerRow.models);
-    if (!models.includes(backendModel)) return null;
+    const modelEntries = parseModels(providerRow.models);
+    if (!modelEntries.some(m => m.name === backendModel)) return null;
   } catch { return null }
 
   // 尝试从 mapping_groups 找到包含此 provider+backend_model 的 client_model

--- a/router/src/db/mappings.ts
+++ b/router/src/db/mappings.ts
@@ -78,12 +78,10 @@ export function getActiveProviderModels(db: Database.Database): ProviderModelEnt
   const providers = db.prepare("SELECT name, models, is_active FROM providers WHERE is_active = 1").all() as { name: string; models: string; is_active: number }[];
   const results: ProviderModelEntry[] = [];
   for (const p of providers) {
-    try {
-      const modelEntries = parseModels(p.models);
-      for (const m of modelEntries) {
-        results.push({ provider_name: p.name, backend_model: m.name });
-      }
-    } catch { continue }
+    const modelEntries = parseModels(p.models);
+    for (const m of modelEntries) {
+      results.push({ provider_name: p.name, backend_model: m.name });
+    }
   }
   return results;
 }
@@ -131,10 +129,8 @@ export function resolveByProviderModel(
 ): { client_model: string; provider_id: string; backend_model: string } | null {
   const providerRow = db.prepare("SELECT id, models FROM providers WHERE name = ? AND is_active = 1").get(providerName) as { id: string; models: string } | undefined;
   if (!providerRow) return null;
-  try {
-    const modelEntries = parseModels(providerRow.models);
-    if (!modelEntries.some(m => m.name === backendModel)) return null;
-  } catch { return null }
+  const modelEntries = parseModels(providerRow.models);
+  if (!modelEntries.some(m => m.name === backendModel)) return null;
 
   // 尝试从 mapping_groups 找到包含此 provider+backend_model 的 client_model
   const groups = db.prepare("SELECT client_model, rule FROM mapping_groups").all() as { client_model: string; rule: string }[];

--- a/router/src/db/providers.ts
+++ b/router/src/db/providers.ts
@@ -1,6 +1,7 @@
 import Database from "better-sqlite3";
 import { randomUUID } from "crypto";
 import { buildUpdateQuery, deleteById } from "./helpers.js";
+import { parseModels } from "../config/model-context.js";
 
 export interface Provider {
   id: string;
@@ -10,7 +11,8 @@ export interface Provider {
   upstream_path: string | null;
   api_key: string;
   api_key_preview?: string;
-  models: string; // JSON 数组文本
+  /** @internal 原始 JSON 文本，业务层请使用 parseModels() 解析，禁止直接 JSON.parse */
+  models: string;
   is_active: number;
   max_concurrency: number;
   queue_timeout_ms: number;
@@ -32,27 +34,14 @@ export function getModelStreamTimeout(
   provider: Provider,
   backendModel: string,
 ): number {
-  try {
-    const raw = JSON.parse(provider.models);
-    if (!Array.isArray(raw)) return DEFAULT_STREAM_TIMEOUT_MS;
-    for (const m of raw) {
-      if (typeof m === "string") {
-        if (m === backendModel) return DEFAULT_STREAM_TIMEOUT_MS;
-        continue;
-      }
-      const obj = m as Record<string, unknown>;
-      if (!obj || typeof obj !== "object") continue;
-      const modelId = (obj.name ?? obj.id) as string | undefined;
-      if (modelId === backendModel) {
-        const timeout = obj.stream_timeout_ms as number | undefined;
-        // stream_timeout_ms: 0 表示禁用超时，返回 Infinity；
-        // undefined/null/未设置 表示使用默认值
-        if (timeout === 0) return Number.POSITIVE_INFINITY;
-        return timeout ?? DEFAULT_STREAM_TIMEOUT_MS;
-      }
-    }
-  } catch { /* ignore parse errors — models field may be empty or invalid */ } // eslint-disable-line taste/no-silent-catch
-  return DEFAULT_STREAM_TIMEOUT_MS;
+  const entries = parseModels(provider.models);
+  const entry = entries.find(m => m.name === backendModel);
+  if (!entry) return DEFAULT_STREAM_TIMEOUT_MS;
+  const timeout = entry.stream_timeout_ms;
+  // stream_timeout_ms: 0 表示禁用超时，返回 Infinity；
+  // undefined/null/未设置 表示使用默认值
+  if (timeout === 0) return Number.POSITIVE_INFINITY;
+  return timeout ?? DEFAULT_STREAM_TIMEOUT_MS;
 }
 
 export const PROVIDER_CONCURRENCY_DEFAULTS = {

--- a/router/src/db/router-keys.ts
+++ b/router/src/db/router-keys.ts
@@ -1,6 +1,7 @@
 import Database from "better-sqlite3";
 import { randomUUID } from "crypto";
 import { buildUpdateQuery, deleteById } from "./helpers.js";
+import { parseModels } from "../config/model-context.js";
 
 export interface RouterKey {
   id: string;
@@ -57,7 +58,10 @@ export function getAvailableModels(db: Database.Database): string[] {
   const rows = db.prepare("SELECT models FROM providers WHERE is_active = 1").all() as { models: string }[];
   const set = new Set<string>();
   for (const r of rows) {
-    try { JSON.parse(r.models || "[]").forEach((m: string) => set.add(m)); } catch { continue }
+    const entries = parseModels(r.models);
+    for (const m of entries) {
+      set.add(m.name);
+    }
   }
   return [...set].sort();
 }

--- a/router/src/proxy/handler/openai.ts
+++ b/router/src/proxy/handler/openai.ts
@@ -3,6 +3,7 @@ import { randomUUID } from "crypto";
 import Database from "better-sqlite3";
 import fp from "fastify-plugin";
 import { getAllProviders, insertRequestLog } from "../../db/index.js";
+import { parseModels } from "../../config/model-context.js";
 import { createErrorFormatter, type ProxyErrorResponse } from "../proxy-core.js";
 import type { ErrorKind } from "../proxy-core.js";
 import { handleProxyRequest, type RouteHandlerDeps } from "./proxy-handler.js";
@@ -90,9 +91,9 @@ const openaiProxyRaw: FastifyPluginCallback<OpenaiProxyOptions> = (app, opts, do
     const modelMeta = new Map<string, { providerName: string; createdAt: string }>();
     for (const p of allProviders) {
       try {
-        const models: string[] = JSON.parse(p.models || '[]');
-        for (const m of models) {
-          if (!modelMeta.has(m)) modelMeta.set(m, { providerName: p.name, createdAt: p.created_at });
+        const modelEntries = parseModels(p.models || '[]');
+        for (const m of modelEntries) {
+          if (!modelMeta.has(m.name)) modelMeta.set(m.name, { providerName: p.name, createdAt: p.created_at });
         }
       } catch {
         // providers.models 有 NOT NULL 约束默认 '[]'，此处防御开发期误配的非法 JSON

--- a/router/src/proxy/routing/mapping-resolver.ts
+++ b/router/src/proxy/routing/mapping-resolver.ts
@@ -1,6 +1,7 @@
 import Database from "better-sqlite3";
 import type { Target, ResolveContext, ResolveResult, ConcurrencyOverride } from "../../core/types.js";
 import { getMappingGroup, getActiveProviderByName, getActiveProvidersWithModels, getActiveSchedulesForGroup } from "../../db/index.js";
+import { parseModels } from "../../config/model-context.js";
 import type { Schedule } from "../../db/schedules.js";
 
 // ---------- Type guards ----------
@@ -129,8 +130,8 @@ export function resolveMapping(
     const provider = getActiveProviderByName(db, providerName);
     if (provider) {
       try {
-        const models: string[] = JSON.parse(provider.models);
-        if (models.includes(backendModel)) {
+        const modelEntries = parseModels(provider.models);
+        if (modelEntries.some(m => m.name === backendModel)) {
           return { target: { backend_model: backendModel, provider_id: provider.id }, targetCount: 1 };
         }
       } catch { return null }
@@ -145,8 +146,8 @@ export function resolveMapping(
     const providers = getActiveProvidersWithModels(db);
     for (const p of providers) {
       try {
-        const models: string[] = JSON.parse(p.models);
-        if (models.includes(clientModel)) {
+        const modelEntries = parseModels(p.models);
+        if (modelEntries.some(m => m.name === clientModel)) {
           return { target: { backend_model: clientModel, provider_id: p.id }, targetCount: 1 };
         }
       } catch { continue }

--- a/router/src/proxy/routing/mapping-resolver.ts
+++ b/router/src/proxy/routing/mapping-resolver.ts
@@ -129,12 +129,10 @@ export function resolveMapping(
     const backendModel = slashMatch[2];
     const provider = getActiveProviderByName(db, providerName);
     if (provider) {
-      try {
-        const modelEntries = parseModels(provider.models);
-        if (modelEntries.some(m => m.name === backendModel)) {
-          return { target: { backend_model: backendModel, provider_id: provider.id }, targetCount: 1 };
-        }
-      } catch { return null }
+      const modelEntries = parseModels(provider.models);
+      if (modelEntries.some(m => m.name === backendModel)) {
+        return { target: { backend_model: backendModel, provider_id: provider.id }, targetCount: 1 };
+      }
     }
     return null;
   }
@@ -145,12 +143,10 @@ export function resolveMapping(
     // fallback: 直接查 provider 的 models 字段
     const providers = getActiveProvidersWithModels(db);
     for (const p of providers) {
-      try {
-        const modelEntries = parseModels(p.models);
-        if (modelEntries.some(m => m.name === clientModel)) {
-          return { target: { backend_model: clientModel, provider_id: p.id }, targetCount: 1 };
-        }
-      } catch { continue }
+      const modelEntries = parseModels(p.models);
+      if (modelEntries.some(m => m.name === clientModel)) {
+        return { target: { backend_model: clientModel, provider_id: p.id }, targetCount: 1 };
+      }
     }
     return null;
   }

--- a/taste-lint/base.mjs
+++ b/taste-lint/base.mjs
@@ -14,6 +14,7 @@ import noUnsafeObjectEntries from './rules/no-unsafe-object-entries.mjs';
 import noHardcodedColors from './rules/no-hardcoded-colors.mjs';
 import noMagicSpacing from './rules/no-magic-spacing.mjs';
 import noDeprecatedRuleFormat from './rules/no-deprecated-rule-format.mjs';
+import noRawJsonParseModels from './rules/no-raw-json-parse-models.mjs';
 
 export const tastePlugin = {
   meta: { name: 'eslint-plugin-taste' },
@@ -24,6 +25,7 @@ export const tastePlugin = {
     'no-hardcoded-colors': noHardcodedColors,
     'no-magic-spacing': noMagicSpacing,
     'no-deprecated-rule-format': noDeprecatedRuleFormat,
+    'no-raw-json-parse-models': noRawJsonParseModels,
   },
 };
 
@@ -57,6 +59,7 @@ export const tasteRules = {
   'taste/no-silent-catch': 'warn',
   'taste/no-unsafe-object-entries': 'warn',
   'taste/no-deprecated-rule-format': 'warn',
+  'taste/no-raw-json-parse-models': 'error',
 };
 
 export default [

--- a/taste-lint/rules/no-raw-json-parse-models.mjs
+++ b/taste-lint/rules/no-raw-json-parse-models.mjs
@@ -1,0 +1,71 @@
+/**
+ * 品味规则：禁止对 provider.models 直接 JSON.parse
+ *
+ * providers.models 存储的是 ModelEntry[] 的 JSON 文本，数据格式已从早期 string[]
+ * 演进为对象数组。直接 JSON.parse 会得到对象数组而非字符串数组，导致运行时错误。
+ *
+ * 正确做法：使用 parseModels()（from config/model-context.ts）解析。
+ *
+ * 例外：迁移代码（db/index.ts 中 app_migration_040 开头的函数）需要操作原始 JSON 结构，
+ * 已通过注释标注豁免。
+ */
+export default {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Disallow direct JSON.parse on providers.models — use parseModels() instead',
+    },
+    messages: {
+      rawJsonParseModels:
+        '禁止直接 JSON.parse(provider.models) — 数据格式已从 string[] 演进为 ModelEntry[]，' +
+        '请使用 parseModels()（from config/model-context.ts）解析。' +
+        '如确需操作原始 JSON（如迁移代码），请在上方添加 eslint-disable 注释并说明原因。',
+    },
+  },
+  create(context) {
+    return {
+      CallExpression(node) {
+        // 匹配 JSON.parse(xxx.models) 或 JSON.parse(xxx.models || "[]") 等模式
+        if (
+          node.callee.type === 'MemberExpression' &&
+          node.callee.object.type === 'Identifier' &&
+          node.callee.object.name === 'JSON' &&
+          node.callee.property.type === 'Identifier' &&
+          node.callee.property.name === 'parse' &&
+          node.arguments.length >= 1
+        ) {
+          const arg = node.arguments[0];
+          // JSON.parse(xxx.models)
+          if (
+            arg.type === 'MemberExpression' &&
+            arg.property.type === 'Identifier' &&
+            arg.property.name === 'models'
+          ) {
+            context.report({ node, messageId: 'rawJsonParseModels' });
+            return;
+          }
+          // JSON.parse(xxx.models || "[]") — BinaryExpression 中包含 .models
+          if (arg.type === 'BinaryExpression') {
+            function containsModelsAccess(n) {
+              if (
+                n.type === 'MemberExpression' &&
+                n.property.type === 'Identifier' &&
+                n.property.name === 'models'
+              ) return true;
+              if (n.type === 'BinaryExpression') {
+                return containsModelsAccess(n.left) || containsModelsAccess(n.right);
+              }
+              if (n.type === 'LogicalExpression') {
+                return containsModelsAccess(n.left) || containsModelsAccess(n.right);
+              }
+              return false;
+            }
+            if (containsModelsAccess(arg)) {
+              context.report({ node, messageId: 'rawJsonParseModels' });
+            }
+          }
+        }
+      },
+    };
+  },
+};

--- a/taste-lint/rules/no-raw-json-parse-models.mjs
+++ b/taste-lint/rules/no-raw-json-parse-models.mjs
@@ -8,7 +8,24 @@
  *
  * 例外：迁移代码（db/index.ts 中 app_migration_040 开头的函数）需要操作原始 JSON 结构，
  * 已通过注释标注豁免。
+ *
+ * 已知限制：无法检测变量别名（const m = provider.models; JSON.parse(m)）、
+ * 动态属性访问（provider[field]）或解构（const { models } = provider; JSON.parse(models)）。
  */
+
+/** 递归检测 AST 节点中是否包含 .models 属性访问 */
+function containsModelsAccess(n) {
+  if (
+    n.type === 'MemberExpression' &&
+    n.property.type === 'Identifier' &&
+    n.property.name === 'models'
+  ) return true;
+  if (n.type === 'BinaryExpression' || n.type === 'LogicalExpression') {
+    return containsModelsAccess(n.left) || containsModelsAccess(n.right);
+  }
+  return false;
+}
+
 export default {
   meta: {
     type: 'problem',
@@ -25,7 +42,6 @@ export default {
   create(context) {
     return {
       CallExpression(node) {
-        // 匹配 JSON.parse(xxx.models) 或 JSON.parse(xxx.models || "[]") 等模式
         if (
           node.callee.type === 'MemberExpression' &&
           node.callee.object.type === 'Identifier' &&
@@ -44,22 +60,8 @@ export default {
             context.report({ node, messageId: 'rawJsonParseModels' });
             return;
           }
-          // JSON.parse(xxx.models || "[]") — BinaryExpression 中包含 .models
+          // JSON.parse(xxx.models || "[]") / JSON.parse(xxx.models ?? "[]")
           if (arg.type === 'BinaryExpression' || arg.type === 'LogicalExpression') {
-            function containsModelsAccess(n) {
-              if (
-                n.type === 'MemberExpression' &&
-                n.property.type === 'Identifier' &&
-                n.property.name === 'models'
-              ) return true;
-              if (n.type === 'BinaryExpression') {
-                return containsModelsAccess(n.left) || containsModelsAccess(n.right);
-              }
-              if (n.type === 'LogicalExpression') {
-                return containsModelsAccess(n.left) || containsModelsAccess(n.right);
-              }
-              return false;
-            }
             if (containsModelsAccess(arg)) {
               context.report({ node, messageId: 'rawJsonParseModels' });
             }

--- a/taste-lint/rules/no-raw-json-parse-models.mjs
+++ b/taste-lint/rules/no-raw-json-parse-models.mjs
@@ -45,7 +45,7 @@ export default {
             return;
           }
           // JSON.parse(xxx.models || "[]") — BinaryExpression 中包含 .models
-          if (arg.type === 'BinaryExpression') {
+          if (arg.type === 'BinaryExpression' || arg.type === 'LogicalExpression') {
             function containsModelsAccess(n) {
               if (
                 n.type === 'MemberExpression' &&

--- a/taste-lint/rules/no-raw-json-parse-models.test.mjs
+++ b/taste-lint/rules/no-raw-json-parse-models.test.mjs
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { RuleTester } from 'eslint';
+import rule from './no-raw-json-parse-models.mjs';
+
+const ruleTester = new RuleTester({
+  languageOptions: { ecmaVersion: 2022, sourceType: 'module' },
+});
+
+describe('taste/no-raw-json-parse-models', () => {
+  it('reports JSON.parse(xxx.models)', () => {
+    const cases = [
+      // 直接属性访问
+      {
+        code: 'JSON.parse(provider.models)',
+        errors: [{ messageId: 'rawJsonParseModels' }],
+      },
+      // LogicalExpression: ||
+      {
+        code: `JSON.parse(provider.models || '[]')`,
+        errors: [{ messageId: 'rawJsonParseModels' }],
+      },
+      // LogicalExpression: ??
+      {
+        code: 'JSON.parse(provider.models ?? "[]")',
+        errors: [{ messageId: 'rawJsonParseModels' }],
+      },
+      // 不同变量名也能检测
+      {
+        code: 'JSON.parse(p.models)',
+        errors: [{ messageId: 'rawJsonParseModels' }],
+      },
+      // 链式访问
+      {
+        code: 'JSON.parse(r.models || "[]")',
+        errors: [{ messageId: 'rawJsonParseModels' }],
+      },
+    ];
+
+    ruleTester.run('no-raw-json-parse-models', rule, {
+      valid: [],
+      invalid: cases,
+    });
+  });
+
+  it('does NOT report non-models property', () => {
+    ruleTester.run('no-raw-json-parse-models', rule, {
+      valid: [
+        'JSON.parse(someObj.data)',
+        'JSON.parse(response.body)',
+        'JSON.parse(raw)',
+        'JSON.parse("[]")',
+        'someOtherFunction(provider.models)',
+        'JSON.parse(provider.models_json)', // 不同属性名，不匹配
+      ],
+      invalid: [],
+    });
+  });
+
+  it('matches snapshot for error message', () => {
+    expect(rule.meta.messages.rawJsonParseModels).toContain('parseModels()');
+  });
+});


### PR DESCRIPTION
## 问题

`providers.models` 字段从早期 `string[]` 演进为 `ModelEntry[]`（对象数组），但多处代码仍用 `JSON.parse` 后当作 `string[]` 使用。

### 影响范围
- RouterKeys 白名单设置显示 JSON 字符串而非模型名
- `/v1/models` API 返回对象而非模型名  
- 路由 fallback 匹配（`provider_name/model` 格式 + 直接模型名）永远失败

## 修复

### Bug 修复（6 处 `JSON.parse(models)` 消除）
| 文件 | 修复内容 |
|------|---------|
| `router/src/db/router-keys.ts` | `getAvailableModels` 改用 `parseModels()` |
| `router/src/proxy/handler/openai.ts` | `/v1/models` 模型列表聚合改用 `parseModels()` |
| `router/src/proxy/routing/mapping-resolver.ts` | 2 处 fallback 路由匹配改用 `parseModels()` |
| `router/src/db/mappings.ts` | `getActiveProviderModels` + `resolveByProviderModel` 改用 `parseModels()` |
| `router/src/db/providers.ts` | `getModelStreamTimeout` 改用 `parseModels()` |

### 预防措施
- `parseModels()` 加完整 JSDoc，声明为唯一合法解析入口
- `parseModels()` 兼容 `id` 字段（旧迁移数据）
- 新增 ESLint 规则 `taste/no-raw-json-parse-models`（error 级别）
- pre-commit hook 增加后端 ESLint 检查段
- CLAUDE.md 关键设计决策中记录规范

Closes #113