### PR TITLE
feat: 实时监控活跃请求一键杀死

### DIFF
--- a/core/src/monitor/request-tracker.ts
+++ b/core/src/monitor/request-tracker.ts
@@ -48,6 +48,8 @@ export class RequestTracker {
   private streamAccumulators = new Map<string, StreamContentAccumulator>();
   private streamContentPending = new Set<string>();
   private streamContentTimer: ReturnType<typeof setTimeout> | null = null;
+  private killCallbacks = new Map<string, () => void>();
+  private killedRequests = new Set<string>();
 
   /** Visible for testing */
   readonly statsAggregator: StatsAggregator;
@@ -149,6 +151,9 @@ export class RequestTracker {
       return;
     }
 
+    const wasKilled = this.killedRequests.has(id);
+    if (wasKilled) this.killedRequests.delete(id);
+
     const now = Date.now();
     const latency = now - req.startTime;
     const statusCode = result.statusCode ?? 0;
@@ -165,13 +170,14 @@ export class RequestTracker {
 
     const completed: ActiveRequest = {
       ...req,
-      status: result.status,
+      status: wasKilled ? "failed" : result.status,
       completedAt: now,
       attempts: result.attempts ?? req.attempts,
     };
 
     this.streamContentPending.delete(id);
     this.activeMap.delete(id);
+    this.killCallbacks.delete(id);
     this.streamAccumulators.delete(id);
     this.recentCompleted.unshift(completed);
     if (this.recentCompleted.length > RECENT_COMPLETED_MAX) {
@@ -204,6 +210,29 @@ export class RequestTracker {
   /** Public alias for API endpoint use — returns full request data including clientRequest */
   getRequestById(id: string): ActiveRequest | undefined {
     return this.get(id);
+  }
+
+  /** 注册请求的终止回调，由 orchestrator 在请求开始时调用 */
+  registerKillCallback(id: string, callback: () => void): void {
+    this.killCallbacks.set(id, callback);
+  }
+
+  /** 主动终止指定请求。返回 true 表示成功终止，false 表示请求不存在或已完成 */
+  killRequest(id: string): boolean {
+    const callback = this.killCallbacks.get(id);
+    if (!callback) {
+      this.logger?.debug?.({ reqId: id }, "Tracker: killRequest not found (already completed or unknown)");
+      return false;
+    }
+    this.killedRequests.add(id);
+    this.killCallbacks.delete(id);
+    this.logger?.info?.({ reqId: id }, "Tracker: killRequest");
+    callback();
+    // transport 可能尚未 resolve（上游未响应时 StreamProxy 不存在），强制完成请求
+    if (this.activeMap.has(id)) {
+      this.complete(id, { status: "failed" });
+    }
+    return true;
   }
 
   // --- Stats / monitoring ---

--- a/core/tests/monitor/request-tracker.test.ts
+++ b/core/tests/monitor/request-tracker.test.ts
@@ -439,7 +439,101 @@ describe("RequestTracker", () => {
     });
   });
 
-  describe("getStats()", () => {
+  describe("killRequest()", () => {
+    it("returns true and invokes registered kill callback", () => {
+      const killCb = vi.fn();
+      tracker.start(createActiveRequest({ id: "kill-1" }));
+      tracker.registerKillCallback("kill-1", killCb);
+
+      const result = tracker.killRequest("kill-1");
+
+      expect(result).toBe(true);
+      expect(killCb).toHaveBeenCalledTimes(1);
+    });
+
+    it("returns false for non-existent request", () => {
+      const result = tracker.killRequest("nonexistent");
+      expect(result).toBe(false);
+    });
+
+    it("returns false for request without registered callback", () => {
+      tracker.start(createActiveRequest({ id: "no-cb" }));
+
+      const result = tracker.killRequest("no-cb");
+      expect(result).toBe(false);
+    });
+
+    it("logs info on successful kill", () => {
+      const logger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn() };
+      const localTracker = new RequestTracker({ logger });
+      const killCb = vi.fn();
+
+      localTracker.start(createActiveRequest({ id: "log-1" }));
+      localTracker.registerKillCallback("log-1", killCb);
+      localTracker.killRequest("log-1");
+
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.objectContaining({ reqId: "log-1" }),
+        "Tracker: killRequest",
+      );
+    });
+
+    it("logs debug when kill target not found", () => {
+      const logger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn() };
+      const localTracker = new RequestTracker({ logger });
+
+      localTracker.killRequest("ghost");
+
+      expect(logger.debug).toHaveBeenCalledWith(
+        expect.objectContaining({ reqId: "ghost" }),
+        "Tracker: killRequest not found (already completed or unknown)",
+      );
+    });
+  });
+
+  describe("kill + complete interaction", () => {
+    it("complete after kill forces status to failed", () => {
+      const killCb = vi.fn();
+      tracker.start(createActiveRequest({ id: "killed-1" }));
+      tracker.registerKillCallback("killed-1", killCb);
+
+      tracker.killRequest("killed-1");
+
+      // Simulate the abort completing the request
+      tracker.complete("killed-1", { status: "completed", statusCode: 200 });
+
+      const found = tracker.get("killed-1");
+      expect(found).toBeDefined();
+      expect(found!.status).toBe("failed");
+    });
+
+    it("normal complete clears kill callback so subsequent killRequest returns false", () => {
+      const killCb = vi.fn();
+      tracker.start(createActiveRequest({ id: "normal-1" }));
+      tracker.registerKillCallback("normal-1", killCb);
+
+      // Complete without killing
+      tracker.complete("normal-1", { status: "completed", statusCode: 200 });
+
+      // killCallback should have been cleaned up in complete()
+      const result = tracker.killRequest("normal-1");
+      expect(result).toBe(false);
+    });
+
+    it("kill then complete still moves to recentCompleted", () => {
+      const killCb = vi.fn();
+      tracker.start(createActiveRequest({ id: "kcr-1" }));
+      tracker.registerKillCallback("kcr-1", killCb);
+      tracker.killRequest("kcr-1");
+      tracker.complete("kcr-1", { status: "completed", statusCode: 200 });
+
+      const recent = tracker.getRecent();
+      expect(recent).toHaveLength(1);
+      expect(recent[0].status).toBe("failed");
+    });
+  });
+
+describe("getStats()", () => {
     it("delegates to statsAggregator", () => {
       const stats = tracker.getStats();
       expect(getStatsSpy).toHaveBeenCalled();

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -532,6 +532,8 @@ export const api = {
   getMonitorConcurrency: () =>
     request<ProviderConcurrencySnapshot[]>("get", API.MONITOR_CONCURRENCY),
   getMonitorRuntime: () => request<RuntimeMetrics>("get", API.MONITOR_RUNTIME),
+  killMonitorRequest: (id: string) =>
+    request<{ killed: boolean }>("delete", `${API.MONITOR_REQUEST}/${id}`),
 
   recommended: {
     getProviders: () =>

--- a/frontend/src/i18n/locales/en/monitor.json
+++ b/frontend/src/i18n/locales/en/monitor.json
@@ -47,6 +47,12 @@
     "activeRequests": "Active Requests",
     "eventLoopDelay": "Event Loop Delay"
   },
+  "kill": "Kill",
+  "killCancel": "Cancel",
+  "killConfirmTitle": "Confirm Kill Request",
+  "killConfirm": "Are you sure you want to kill the request for {model} ({provider})? This action cannot be undone.",
+  "killSuccess": "Request killed",
+  "killFailed": "Failed to kill request",
   "statusCodes": {
     "noData": "No status code data",
     "success": "2xx Success",

--- a/frontend/src/i18n/locales/zh-CN/monitor.json
+++ b/frontend/src/i18n/locales/zh-CN/monitor.json
@@ -47,6 +47,12 @@
     "activeRequests": "Active Requests",
     "eventLoopDelay": "Event Loop 延迟"
   },
+  "kill": "终止",
+  "killCancel": "取消",
+  "killConfirmTitle": "确认终止请求",
+  "killConfirm": "确定要终止 {model}（{provider}）的请求吗？此操作不可撤销。",
+  "killSuccess": "请求已终止",
+  "killFailed": "终止请求失败",
   "statusCodes": {
     "noData": "暂无状态码数据",
     "success": "2xx 成功",

--- a/frontend/src/views/Monitor.vue
+++ b/frontend/src/views/Monitor.vue
@@ -58,6 +58,16 @@
                   <TooltipContent>{{ t('monitor.copyId') }}</TooltipContent>
                 </Tooltip>
               </TooltipProvider>
+              <TooltipProvider :delay-duration="300">
+                <Tooltip>
+                  <TooltipTrigger as-child>
+                    <Button variant="ghost" size="icon-xs" class="shrink-0 text-destructive hover:text-destructive" @click.stop="openKillDialog(req.id)">
+                      <XIcon class="size-3" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>{{ t('monitor.kill') }}</TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
             </div>
           </ScrollArea>
         </CardContent>
@@ -98,6 +108,16 @@
                     </Button>
                   </TooltipTrigger>
                   <TooltipContent>{{ t('monitor.copyId') }}</TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+              <TooltipProvider :delay-duration="300">
+                <Tooltip>
+                  <TooltipTrigger as-child>
+                    <Button variant="ghost" size="icon-xs" class="shrink-0 text-destructive hover:text-destructive" @click.stop="openKillDialog(req.id)">
+                      <XIcon class="size-3" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>{{ t('monitor.kill') }}</TooltipContent>
                 </Tooltip>
               </TooltipProvider>
             </div>
@@ -197,18 +217,39 @@
       :stream-content="selectedRequest?.streamContent"
       :log-detail-data="logDetailData"
     />
+
+    <!-- Kill Confirmation Dialog -->
+    <AlertDialog v-model:open="killDialogOpen">
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{{ t('monitor.killConfirmTitle') }}</AlertDialogTitle>
+          <AlertDialogDescription v-if="killTarget">
+            {{ t('monitor.killConfirm', { model: killTarget.model, provider: killTarget.providerName }) }}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>{{ t('monitor.killCancel') }}</AlertDialogCancel>
+          <AlertDialogAction class="bg-destructive text-destructive-foreground hover:bg-destructive/90" @click="executeKill">
+            {{ t('monitor.kill') }}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
   </div>
 </template>
 
 <script setup lang="ts">
-import { onMounted, onUnmounted, ref } from 'vue'
+import { computed, onMounted, onUnmounted, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
-import { CheckIcon, CopyIcon } from 'lucide-vue-next'
+import { CheckIcon, CopyIcon, XIcon } from 'lucide-vue-next'
+import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from '@/components/ui/alert-dialog'
+import { api, getApiMessage } from '@/api/client'
+import { toast } from 'vue-sonner'
 import MonitorHeader from '@/components/monitor/MonitorHeader.vue'
 import ConcurrencyPanel from '@/components/monitor/ConcurrencyPanel.vue'
 import RuntimePanel from '@/components/monitor/RuntimePanel.vue'
@@ -260,6 +301,33 @@ const { connect } = useMonitorSSE(
 )
 
 const { copied, copy } = useClipboard()
+
+// --- Kill request ---
+const killDialogOpen = ref(false)
+const killTargetId = ref<string | null>(null)
+const killTarget = computed(() => {
+  if (!killTargetId.value) return null
+  return activeRequests.value.find(r => r.id === killTargetId.value) ?? null
+})
+
+function openKillDialog(id: string) {
+  killTargetId.value = id
+  killDialogOpen.value = true
+}
+
+async function executeKill() {
+  if (!killTargetId.value) return
+  try {
+    await api.killMonitorRequest(killTargetId.value)
+    // 立即从活跃列表移除，不等 SSE
+    activeRequests.value = activeRequests.value.filter(r => r.id !== killTargetId.value)
+    toast.success(t('monitor.killSuccess'))
+  } catch (e: unknown) {
+    console.error('Monitor.killRequest:', e)
+    toast.error(getApiMessage(e, t('monitor.killFailed')))
+  }
+  killDialogOpen.value = false
+}
 
 // --- Helper functions ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
     },
     "core": {
       "name": "@llm-router/core",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "devDependencies": {
         "@types/node": "^24.12.2",
         "typescript": "^5.8.3",
@@ -948,6 +948,7 @@
       "resolved": "https://registry.npmmirror.com/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -3123,6 +3124,7 @@
       "resolved": "https://registry.npmmirror.com/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
       "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -3204,6 +3206,7 @@
       "resolved": "https://registry.npmmirror.com/@noble/ciphers/-/ciphers-1.3.0.tgz",
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -3675,8 +3678,7 @@
       "optional": true,
       "os": [
         "android"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
       "version": "4.60.2",
@@ -3690,8 +3692,7 @@
       "optional": true,
       "os": [
         "android"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.60.2",
@@ -3705,8 +3706,7 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
       "version": "4.60.2",
@@ -3720,8 +3720,7 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
       "version": "4.60.2",
@@ -3735,8 +3734,7 @@
       "optional": true,
       "os": [
         "freebsd"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
       "version": "4.60.2",
@@ -3750,8 +3748,7 @@
       "optional": true,
       "os": [
         "freebsd"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
       "version": "4.60.2",
@@ -3765,8 +3762,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
       "version": "4.60.2",
@@ -3780,8 +3776,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
       "version": "4.60.2",
@@ -3795,8 +3790,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
       "version": "4.60.2",
@@ -3810,8 +3804,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
       "version": "4.60.2",
@@ -3825,8 +3818,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
       "version": "4.60.2",
@@ -3840,8 +3832,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
       "version": "4.60.2",
@@ -3855,8 +3846,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
       "version": "4.60.2",
@@ -3870,8 +3860,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
       "version": "4.60.2",
@@ -3885,8 +3874,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
       "version": "4.60.2",
@@ -3900,8 +3888,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
       "version": "4.60.2",
@@ -3915,8 +3902,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.60.2",
@@ -3930,8 +3916,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
       "version": "4.60.2",
@@ -3945,8 +3930,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
       "version": "4.60.2",
@@ -3960,8 +3944,7 @@
       "optional": true,
       "os": [
         "openbsd"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
       "version": "4.60.2",
@@ -3975,8 +3958,7 @@
       "optional": true,
       "os": [
         "openharmony"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
       "version": "4.60.2",
@@ -3990,8 +3972,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
       "version": "4.60.2",
@@ -4005,8 +3986,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
       "version": "4.60.2",
@@ -4020,8 +4000,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.60.2",
@@ -4035,8 +4014,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@silvia-odwyer/photon-node": {
       "version": "0.3.4",
@@ -4994,6 +4972,7 @@
       "integrity": "sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.1",
         "@typescript-eslint/types": "8.59.1",
@@ -5623,6 +5602,7 @@
       "resolved": "https://registry.npmmirror.com/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6118,6 +6098,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -6326,6 +6307,7 @@
       "resolved": "https://registry.npmmirror.com/chart.js/-/chart.js-4.5.1.tgz",
       "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@kurkle/color": "^0.3.0"
       },
@@ -7313,6 +7295,7 @@
       "resolved": "https://registry.npmmirror.com/eslint/-/eslint-10.3.0.tgz",
       "integrity": "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -8686,6 +8669,7 @@
       "resolved": "https://registry.npmmirror.com/hono/-/hono-4.12.16.tgz",
       "integrity": "sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -9110,6 +9094,7 @@
       "resolved": "https://registry.npmmirror.com/jiti/-/jiti-2.6.1.tgz",
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -9407,6 +9392,7 @@
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "dev": true,
       "license": "MPL-2.0",
+      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.3"
       },
@@ -10818,6 +10804,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -12504,6 +12491,7 @@
       "resolved": "https://registry.npmmirror.com/stylus/-/stylus-0.57.0.tgz",
       "integrity": "sha512-yOI6G8WYfr0q8v8rRvE91wbxFU+rJPo760Va4MF6K0I6BZjO4r+xSynkvyPBP9tV1CIEUeRsiidjIs2rzb1CnQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "css": "^3.0.0",
         "debug": "^4.3.2",
@@ -12750,6 +12738,7 @@
       "resolved": "https://registry.npmmirror.com/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -13138,7 +13127,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13156,7 +13144,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13174,7 +13161,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13192,7 +13178,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13210,7 +13195,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13228,7 +13212,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13246,7 +13229,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13264,7 +13246,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13282,7 +13263,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13300,7 +13280,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13318,7 +13297,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13336,7 +13314,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13354,7 +13331,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13372,7 +13348,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13390,7 +13365,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13408,7 +13382,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13426,7 +13399,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13444,7 +13416,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13462,7 +13433,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13480,7 +13450,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13498,7 +13467,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13516,7 +13484,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13534,7 +13501,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13552,7 +13518,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13570,7 +13535,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13588,7 +13552,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13698,6 +13661,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -13895,6 +13859,7 @@
       "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -15156,6 +15121,7 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -15237,6 +15203,7 @@
       "resolved": "https://registry.npmmirror.com/vue/-/vue-3.5.33.tgz",
       "integrity": "sha512-1AgChhx5w3ALgT4oK3acm2Es/7jyZhWSVUfs3rOBlGQC0rjEDkS7G4lWlJJGGNQD+BV3reCwbQrOe1mPNwKHBQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.33",
         "@vue/compiler-sfc": "3.5.33",
@@ -15646,6 +15613,7 @@
       "integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
       "devOptional": true,
       "license": "ISC",
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -15795,6 +15763,7 @@
       "resolved": "https://registry.npmmirror.com/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/router/src/admin/monitor.ts
+++ b/router/src/admin/monitor.ts
@@ -46,5 +46,14 @@ export const adminMonitorRoutes: FastifyPluginCallback<MonitorRoutesOptions> = (
     return req;
   });
 
+  app.delete("/admin/api/monitor/request/:id", async (request, reply) => {
+    const { id } = request.params as { id: string };
+    const killed = tracker.killRequest(id);
+    if (!killed) {
+      return reply.code(HTTP_NOT_FOUND).send(apiError(API_CODE.NOT_FOUND, "Request not found or already completed"));
+    }
+    return { killed: true };
+  });
+
   done();
 };

--- a/router/src/proxy/handler/failover-loop.ts
+++ b/router/src/proxy/handler/failover-loop.ts
@@ -176,6 +176,8 @@ export async function executeFailoverLoop(
   let failoverIteration = 0;
 
   while (true) {
+    // 请求被 kill 后 reply 已销毁，直接退出避免浪费 failover 迭代
+    if (reply.raw.destroyed) return reply;
     if (++failoverIteration > MAX_FAILOVER_ITERATIONS) {
       return reply.code(HTTP_SERVICE_UNAVAILABLE).send({
         error: { message: `Max failover iterations (${MAX_FAILOVER_ITERATIONS}) exceeded`, type: "server_error", code: "failover_limit_exceeded" },
@@ -475,6 +477,11 @@ export async function executeFailoverLoop(
         return rejectAndReply(reply, rCtx, errors.concurrencyTimeout(provider.id, (e as SemaphoreTimeoutError).timeoutMs),
           `Concurrency wait timeout for provider '${provider.id}' (${(e as SemaphoreTimeoutError).timeoutMs}ms)`, provider.id,
           flushCurrentErrors);
+      }
+
+      // 请求被主动 kill（abort + reply destroy），直接退出不写日志
+      if (e instanceof Error && e.name === "AbortError") {
+        return reply;
       }
 
       // 其他未知错误

--- a/router/src/proxy/orchestration/orchestrator.ts
+++ b/router/src/proxy/orchestration/orchestrator.ts
@@ -80,26 +80,40 @@ export class ProxyOrchestrator {
     ctx?: HandleContext,
   ): Promise<ResilienceResult> {
     const providerId = config.provider.id;
+    const controller = new AbortController();
+    // 客户端断连时自动 abort（保留原有行为）
+    request.raw.on("close", () => {
+      if (!request.raw.readableEnded) {
+        controller.abort();
+      }
+    });
     const trackerReq = this.buildActiveRequest(request, config, apiType);
     try {
       const result = await this.deps.trackerScope.track<ResilienceResult>(
         trackerReq,
-        () => this.deps.semaphoreScope.withSlot(
-          providerId,
-          this.createAbortSignal(request),
-          () => {
-            trackerReq.queued = true;
-            this.deps.trackerScope.markQueued(trackerReq.id, true);
-          },
-          () => {
-            if (trackerReq.queued) {
-              trackerReq.queued = false;
-              this.deps.trackerScope.markQueued(trackerReq.id, false);
-            }
-            return this.executeResilience(config, ctx);
-          },
-          config.concurrencyOverride,
-        ),
+        () => {
+          // kill 回调必须在 tracker.start() 之后注册，确保请求已在 activeMap 中
+          this.deps.trackerScope.registerKillCallback(trackerReq.id, () => {
+            controller.abort();
+            try { reply.raw.destroy(); } catch { /* reply may already be destroyed */ } // eslint-disable-line taste/no-silent-catch
+          });
+          return this.deps.semaphoreScope.withSlot(
+            providerId,
+            controller.signal,
+            () => {
+              trackerReq.queued = true;
+              this.deps.trackerScope.markQueued(trackerReq.id, true);
+            },
+            () => {
+              if (trackerReq.queued) {
+                trackerReq.queued = false;
+                this.deps.trackerScope.markQueued(trackerReq.id, false);
+              }
+              return this.executeResilience(config, ctx);
+            },
+            config.concurrencyOverride,
+          );
+        },
         (result) => this.extractTrackStatus(result),
         (result) => result.attempts.map(a => ({
           statusCode: a.statusCode,
@@ -150,16 +164,6 @@ export class ProxyOrchestrator {
       clientRequest: config.clientRequest,
       upstreamRequest: config.upstreamRequest,
     };
-  }
-
-  private createAbortSignal(request: FastifyRequest): AbortSignal {
-    const controller = new AbortController();
-    request.raw.on("close", () => {
-      if (!request.raw.readableEnded) {
-        controller.abort();
-      }
-    });
-    return controller.signal;
   }
 
   private async executeResilience(

--- a/router/src/proxy/orchestration/scope.ts
+++ b/router/src/proxy/orchestration/scope.ts
@@ -48,4 +48,9 @@ export class TrackerScope {
   markQueued(id: string, queued: boolean): void {
     this.tracker.update(id, { queued });
   }
+
+  /** 注册请求终止回调，代理到 RequestTracker */
+  registerKillCallback(id: string, callback: () => void): void {
+    this.tracker.registerKillCallback(id, callback);
+  }
 }

--- a/router/tests/admin-monitor.test.ts
+++ b/router/tests/admin-monitor.test.ts
@@ -155,4 +155,26 @@ describe("Admin Monitor API", () => {
     });
     expect(res.statusCode).toBe(404);
   });
+
+  describe("DELETE /admin/api/monitor/request/:id", () => {
+    it("returns 404 for non-existent request", async () => {
+      const res = await app.inject({
+        method: "DELETE",
+        url: "/admin/api/monitor/request/nonexistent-id",
+        headers: { cookie },
+      });
+      expect(res.statusCode).toBe(404);
+      const body = res.json();
+      expect(body.code).toBe(40401);
+      expect(body.data).toBeNull();
+    });
+
+    it("returns 401 without authentication", async () => {
+      const res = await app.inject({
+        method: "DELETE",
+        url: "/admin/api/monitor/request/some-id",
+      });
+      expect(res.statusCode).toBe(401);
+    });
+  });
 });

--- a/router/tests/orchestrator.test.ts
+++ b/router/tests/orchestrator.test.ts
@@ -9,7 +9,7 @@ import { ProviderSwitchNeeded } from "../src/proxy/types.js";
 function createMockDeps() {
   return {
     semaphoreScope: { withSlot: vi.fn() } as unknown as SemaphoreScope,
-    trackerScope: { track: vi.fn() } as unknown as TrackerScope,
+    trackerScope: { track: vi.fn(), registerKillCallback: vi.fn() } as unknown as TrackerScope,
     resilience: { execute: vi.fn() },
   };
 }


### PR DESCRIPTION
## 功能
在实时监控页面的活跃请求和排队请求列表中，增加一键杀死按钮。点击后经 AlertDialog 确认，立即中断请求。

## 变更
- **后端 core**: RequestTracker 新增 killCallbacks/killedRequests 机制，支持 registerKillCallback/killRequest
- **后端 router**: Orchestrator 在 tracker.start() 后注册 kill 回调（abort controller + destroy reply）；failover loop 增加 AbortError 识别和 reply.raw.destroyed 提前退出
- **后端 API**: DELETE /admin/api/monitor/request/:id
- **前端**: Monitor.vue 活跃/排队请求行增加 kill 按钮 + AlertDialog 确认弹窗；kill 成功后立即从活跃列表移除不等 SSE
- **i18n**: 中英文 kill 相关翻译

## 验证
- tsc: core + router + frontend 0 errors
- test: 965 passed
- lint: 0 warnings
- build: OK