### PR TITLE
fix: docker-compose.yml 构建路径缺少 dockerfile 指定

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,11 +166,37 @@ claude
 
 ## Docker 部署
 
+**方式一：直接拉取镜像（推荐）**
+
 ```bash
+# 一键启动，数据持久化到 ~/.llm-simple-router/
 docker compose up -d
 ```
 
+`docker-compose.yml` 默认从 ghcr.io 拉取预构建镜像，数据映射到宿主机 `~/.llm-simple-router/`。
+
+也可用 `docker run` 直接启动：
+
+```bash
+docker run -d \
+  --name llm-router \
+  -p 9981:9981 \
+  -v ~/.llm-simple-router:/app/data \
+  -e DB_PATH=/app/data/router.db \
+  -e TZ=Asia/Shanghai \
+  --restart unless-stopped \
+  ghcr.io/zhushanwen321/llm-simple-router:latest
+```
+
 环境变量通过 Setup 页面设置，不需要 `.env` 文件。
+
+**方式二：本地构建**
+
+编辑 `docker-compose.yml`，注释掉 `image` 行，取消 `build` 部分的注释，然后：
+
+```bash
+docker compose up -d --build
+```
 
 ## 进程管理
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,9 +2,11 @@ version: "3.8"
 
 services:
   router:
-    build:
-      context: .
-      dockerfile: router/Dockerfile
+    image: ghcr.io/zhushanwen321/llm-simple-router:latest
+    # 如需本地构建，取消注释以下配置并注释掉 image
+    # build:
+    #   context: .
+    #   dockerfile: router/Dockerfile
     ports:
       - "${PORT:-9981}:9981"
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,9 @@ version: "3.8"
 
 services:
   router:
-    build: .
+    build:
+      context: .
+      dockerfile: router/Dockerfile
     ports:
       - "${PORT:-9981}:9981"
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,9 +12,9 @@ services:
       - ENCRYPTION_KEY=${ENCRYPTION_KEY}
       - JWT_SECRET=${JWT_SECRET}
       - TZ=Asia/Shanghai
-      - DB_PATH=/data/router.db
+      - DB_PATH=/app/data/router.db
     volumes:
-      - ~/.llm-simple-router:/data
+      - ~/.llm-simple-router:/app/data
     env_file:
       - .env
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,11 +12,9 @@ services:
       - ENCRYPTION_KEY=${ENCRYPTION_KEY}
       - JWT_SECRET=${JWT_SECRET}
       - TZ=Asia/Shanghai
+      - DB_PATH=/data/router.db
     volumes:
-      - router-data:/app/data
+      - ~/.llm-simple-router:/data
     env_file:
       - .env
     restart: unless-stopped
-
-volumes:
-  router-data:

--- a/router/Dockerfile
+++ b/router/Dockerfile
@@ -56,14 +56,17 @@ RUN npm ci --omit=dev && npm cache clean --force
 # 清理编译工具，减小镜像体积
 RUN apk del python3 make g++
 
-# 复制后端编译产物
+# 复制 core 编译产物（router 运行时依赖 @llm-router/core 的子路径导出）
+COPY --from=builder /app/core/dist core/dist/
+
+# 复制 router 编译产物
 COPY --from=builder /app/router/dist router/dist/
 
 # migrations SQL 文件在运行时需要
 COPY --from=builder /app/router/src/db/migrations/ router/dist/db/migrations/
 
-# 复制前端编译产物
-COPY --from=frontend-builder /app/frontend/dist frontend-dist/
+# 复制前端编译产物（__dirname = router/dist/，代码里用 ../frontend-dist 查找）
+COPY --from=frontend-builder /app/frontend/dist router/frontend-dist/
 
 # 复制配置模板（recommended-providers.json 等）
 COPY router/config/ router/config/


### PR DESCRIPTION
docker-compose.yml 中 `build: .` 会在 context 根目录找 `Dockerfile`，但实际文件在 `router/Dockerfile`，导致 `docker compose up` 时会因找不到 Dockerfile 而构建失败。

修复为显式指定 `dockerfile: router/Dockerfile`，同时保持 context 为项目根目录（Dockerfile 中的 COPY 路径依赖于根目录上下文）。