### PR TITLE
feat: 预设配置支持 upstream_path 字段

### DIFF
--- a/frontend/src/composables/useProviderPresets.ts
+++ b/frontend/src/composables/useProviderPresets.ts
@@ -39,6 +39,7 @@ export function useProviderPresets(form: { value: { name: string; api_type: stri
     form.value.name = preset.presetName
     form.value.api_type = preset.apiType
     form.value.base_url = preset.baseUrl
+    ;(form.value as any).upstream_path = preset.upstreamPath || ''
     form.value.models = preset.models.map(name => ({
       name,
       context_window: getDefaultContextWindow(name),

--- a/router/src/admin/providers.ts
+++ b/router/src/admin/providers.ts
@@ -174,6 +174,7 @@ export const adminProviderRoutes: FastifyPluginCallback<ProviderRoutesOptions> =
         name: s.name,
         api_type: s.api_type,
         base_url: s.base_url,
+        upstream_path: s.upstream_path,
         api_key: s.api_key ? decrypt(s.api_key, encryptionKey) : "",
         models: buildModelInfoList(modelEntries, overrides),
         is_active: s.is_active,


### PR DESCRIPTION
- 前端 Provider 预设应用时同步填充 upstream_path
- 后端 Admin API 返回 Provider 信息时暴露 upstream_path

修复[#128](https://github.com/zhushanwen321/llm-simple-router/issues/128)问题