### PR TITLE
fix(dashboard): resolve 5-hour window display issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -936,6 +936,7 @@
       "resolved": "https://registry.npmmirror.com/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -3107,6 +3108,7 @@
       "resolved": "https://registry.npmmirror.com/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
       "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -3188,6 +3190,7 @@
       "resolved": "https://registry.npmmirror.com/@noble/ciphers/-/ciphers-1.3.0.tgz",
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -3659,8 +3662,7 @@
       "optional": true,
       "os": [
         "android"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
       "version": "4.60.2",
@@ -3674,8 +3676,7 @@
       "optional": true,
       "os": [
         "android"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.60.2",
@@ -3689,8 +3690,7 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
       "version": "4.60.2",
@@ -3704,8 +3704,7 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
       "version": "4.60.2",
@@ -3719,8 +3718,7 @@
       "optional": true,
       "os": [
         "freebsd"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
       "version": "4.60.2",
@@ -3734,8 +3732,7 @@
       "optional": true,
       "os": [
         "freebsd"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
       "version": "4.60.2",
@@ -3749,8 +3746,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
       "version": "4.60.2",
@@ -3764,8 +3760,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
       "version": "4.60.2",
@@ -3779,8 +3774,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
       "version": "4.60.2",
@@ -3794,8 +3788,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
       "version": "4.60.2",
@@ -3809,8 +3802,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
       "version": "4.60.2",
@@ -3824,8 +3816,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
       "version": "4.60.2",
@@ -3839,8 +3830,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
       "version": "4.60.2",
@@ -3854,8 +3844,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
       "version": "4.60.2",
@@ -3869,8 +3858,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
       "version": "4.60.2",
@@ -3884,8 +3872,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
       "version": "4.60.2",
@@ -3899,8 +3886,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.60.2",
@@ -3914,8 +3900,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
       "version": "4.60.2",
@@ -3929,8 +3914,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
       "version": "4.60.2",
@@ -3944,8 +3928,7 @@
       "optional": true,
       "os": [
         "openbsd"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
       "version": "4.60.2",
@@ -3959,8 +3942,7 @@
       "optional": true,
       "os": [
         "openharmony"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
       "version": "4.60.2",
@@ -3974,8 +3956,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
       "version": "4.60.2",
@@ -3989,8 +3970,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
       "version": "4.60.2",
@@ -4004,8 +3984,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.60.2",
@@ -4019,8 +3998,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@silvia-odwyer/photon-node": {
       "version": "0.3.4",
@@ -4978,6 +4956,7 @@
       "integrity": "sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.1",
         "@typescript-eslint/types": "8.59.1",
@@ -5607,6 +5586,7 @@
       "resolved": "https://registry.npmmirror.com/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6102,6 +6082,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -6310,6 +6291,7 @@
       "resolved": "https://registry.npmmirror.com/chart.js/-/chart.js-4.5.1.tgz",
       "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@kurkle/color": "^0.3.0"
       },
@@ -7297,6 +7279,7 @@
       "resolved": "https://registry.npmmirror.com/eslint/-/eslint-10.3.0.tgz",
       "integrity": "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -8670,6 +8653,7 @@
       "resolved": "https://registry.npmmirror.com/hono/-/hono-4.12.16.tgz",
       "integrity": "sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -9094,6 +9078,7 @@
       "resolved": "https://registry.npmmirror.com/jiti/-/jiti-2.6.1.tgz",
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -9391,6 +9376,7 @@
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "dev": true,
       "license": "MPL-2.0",
+      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.3"
       },
@@ -10802,6 +10788,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -12488,6 +12475,7 @@
       "resolved": "https://registry.npmmirror.com/stylus/-/stylus-0.57.0.tgz",
       "integrity": "sha512-yOI6G8WYfr0q8v8rRvE91wbxFU+rJPo760Va4MF6K0I6BZjO4r+xSynkvyPBP9tV1CIEUeRsiidjIs2rzb1CnQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "css": "^3.0.0",
         "debug": "^4.3.2",
@@ -12734,6 +12722,7 @@
       "resolved": "https://registry.npmmirror.com/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -13095,6 +13084,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -13122,7 +13112,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13140,7 +13129,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13158,7 +13146,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13176,7 +13163,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13194,7 +13180,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13212,7 +13197,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13230,7 +13214,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13248,7 +13231,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13266,7 +13248,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13284,7 +13265,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13302,7 +13282,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13320,7 +13299,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13338,7 +13316,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13356,7 +13333,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13374,7 +13350,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13392,7 +13367,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13410,7 +13384,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13428,7 +13401,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13446,7 +13418,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13464,7 +13435,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13482,7 +13452,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13500,7 +13469,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13518,7 +13486,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13536,7 +13503,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13554,7 +13520,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13572,7 +13537,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13682,6 +13646,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -13879,6 +13844,7 @@
       "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -15140,6 +15106,7 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -15221,6 +15188,7 @@
       "resolved": "https://registry.npmmirror.com/vue/-/vue-3.5.33.tgz",
       "integrity": "sha512-1AgChhx5w3ALgT4oK3acm2Es/7jyZhWSVUfs3rOBlGQC0rjEDkS7G4lWlJJGGNQD+BV3reCwbQrOe1mPNwKHBQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.33",
         "@vue/compiler-sfc": "3.5.33",
@@ -15630,6 +15598,7 @@
       "integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
       "devOptional": true,
       "license": "ISC",
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -15779,6 +15748,7 @@
       "resolved": "https://registry.npmmirror.com/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/router/src/admin/usage.ts
+++ b/router/src/admin/usage.ts
@@ -29,8 +29,8 @@ function getDailyUsage(
   providerId?: string,
 ): DailyUsageRow[] {
   const conditions = [
-  "rm.created_at >= datetime(?)",
-  "rm.created_at < datetime(?)",
+    "rm.created_at >= datetime(?)",
+    "rm.created_at < datetime(?)",
   ];
   const params: unknown[] = [startTime, endTime];
 

--- a/router/src/admin/usage.ts
+++ b/router/src/admin/usage.ts
@@ -29,9 +29,8 @@ function getDailyUsage(
   providerId?: string,
 ): DailyUsageRow[] {
   const conditions = [
-    "rm.is_complete = 1",
-    "rm.created_at >= datetime(?)",
-    "rm.created_at < datetime(?)",
+  "rm.created_at >= datetime(?)",
+  "rm.created_at < datetime(?)",
   ];
   const params: unknown[] = [startTime, endTime];
 

--- a/router/src/db/index.ts
+++ b/router/src/db/index.ts
@@ -233,6 +233,7 @@ export {
 export {
   insertWindow,
   getLatestWindow,
+  getLatestWindowByProvider,
   getWindowsInRange,
   getWindowUsage,
 } from "./usage-windows.js";

--- a/router/src/db/metrics.ts
+++ b/router/src/db/metrics.ts
@@ -164,7 +164,7 @@ export function getMetricsSummary(
   clientType?: string,
 ): MetricsSummaryRow[] {
   const { timeWhere, timeParams } = buildTimeCondition(period, startTime, endTime);
-  const conditions = ["rm.is_complete = 1", timeWhere];
+  const conditions = [timeWhere];
   const params: unknown[] = [...timeParams];
   const joins = ["LEFT JOIN providers p ON p.id = rm.provider_id"];
 
@@ -205,7 +205,7 @@ export function getClientTypeBreakdown(
   endTime?: string,
 ): ClientTypeBreakdown {
   const { timeWhere, timeParams } = buildTimeCondition(period, startTime, endTime);
-  const conditions = ["rm.is_complete = 1", timeWhere];
+  const conditions = [timeWhere];
   const params: unknown[] = [...timeParams];
 
   if (providerId) { conditions.push("rm.provider_id = ?"); params.push(providerId); }
@@ -259,10 +259,10 @@ export function getMetricsTimeseries(
   endTime?: string,
 ): MetricsTimeseriesRow[] {
   const bucketSec = (startTime && endTime)
-    ? calcBucketSec((new Date(endTime).getTime() - new Date(startTime).getTime()) / MS_PER_SECOND)
-    : calcBucketSec(PERIOD_TOTAL_SEC[period]);
+  ? calcBucketSec((new Date(endTime).getTime() - new Date(startTime).getTime()) / MS_PER_SECOND)
+  : calcBucketSec(PERIOD_TOTAL_SEC[period]);
   const { timeWhere, timeParams } = buildTimeCondition(period, startTime, endTime);
-  const conditions = ["rm.is_complete = 1", timeWhere];
+  const conditions = [timeWhere];
   const params: unknown[] = [...timeParams];
 
   if (providerId) { conditions.push("rm.provider_id = ?"); params.push(providerId); }

--- a/router/src/db/metrics.ts
+++ b/router/src/db/metrics.ts
@@ -259,8 +259,8 @@ export function getMetricsTimeseries(
   endTime?: string,
 ): MetricsTimeseriesRow[] {
   const bucketSec = (startTime && endTime)
-  ? calcBucketSec((new Date(endTime).getTime() - new Date(startTime).getTime()) / MS_PER_SECOND)
-  : calcBucketSec(PERIOD_TOTAL_SEC[period]);
+    ? calcBucketSec((new Date(endTime).getTime() - new Date(startTime).getTime()) / MS_PER_SECOND)
+    : calcBucketSec(PERIOD_TOTAL_SEC[period]);
   const { timeWhere, timeParams } = buildTimeCondition(period, startTime, endTime);
   const conditions = [timeWhere];
   const params: unknown[] = [...timeParams];

--- a/router/src/db/migrations/047_fix_remaining_is_complete.sql
+++ b/router/src/db/migrations/047_fix_remaining_is_complete.sql
@@ -1,0 +1,16 @@
+-- Fix remaining historical request_metrics where is_complete=0 despite
+-- successful HTTP responses (status_code=200).
+--
+-- Migration 046 already fixed records with output_tokens>0 AND total_duration_ms>0,
+-- but missed:
+--   1. Records created after migration 046 ran (the root cause: SSE parser swallowed
+--      [DONE] events, so metrics extractor never set complete=true)
+--   2. Records with status_code=200 but null/zero tokens or duration (e.g. empty
+--      responses, or streams where [DONE] was the only event)
+--
+-- Since the dashboard no longer filters by is_complete (see dashboard query fixes),
+-- this is primarily a data integrity fix.
+UPDATE request_metrics
+SET is_complete = 1
+WHERE is_complete = 0
+  AND status_code = 200;

--- a/router/src/db/stats.ts
+++ b/router/src/db/stats.ts
@@ -48,9 +48,8 @@ export function getStats(
   backendModel?: string,
 ): Stats {
   const conditions = [
-    "rm.is_complete = 1",
-    "rm.created_at >= datetime(?)",
-    "rm.created_at < datetime(?)",
+  "rm.created_at >= datetime(?)",
+  "rm.created_at < datetime(?)",
   ];
   const params: unknown[] = [startTime, endTime];
   if (routerKeyId) {

--- a/router/src/db/stats.ts
+++ b/router/src/db/stats.ts
@@ -48,8 +48,8 @@ export function getStats(
   backendModel?: string,
 ): Stats {
   const conditions = [
-  "rm.created_at >= datetime(?)",
-  "rm.created_at < datetime(?)",
+    "rm.created_at >= datetime(?)",
+    "rm.created_at < datetime(?)",
   ];
   const params: unknown[] = [startTime, endTime];
   if (routerKeyId) {

--- a/router/src/db/usage-windows.ts
+++ b/router/src/db/usage-windows.ts
@@ -52,6 +52,16 @@ export function getLatestWindow(
   return db.prepare(sql).get(...params) as UsageWindow | null ?? null;
 }
 
+/** 获取指定 provider 的最新窗口，忽略 router_key_id 过滤。当 dashboard 等调用方不知道 router_key_id 时使用。 */
+export function getLatestWindowByProvider(
+  db: Database.Database,
+  providerId: string,
+): UsageWindow | null {
+  return db.prepare(
+  "SELECT * FROM usage_windows WHERE provider_id = ? ORDER BY start_time DESC LIMIT 1",
+  ).get(providerId) as UsageWindow | null ?? null;
+}
+
 /** 返回与 [start, end) 区间有重叠的窗口。可选参数不传表示不过滤该维度（与 getLatestWindow 的 IS NULL 语义不同） */
 export function getWindowsInRange(
   db: Database.Database,
@@ -86,9 +96,8 @@ export function getWindowUsage(
   providerId?: string,
 ): WindowUsage {
   const conditions = [
-    "rm.is_complete = 1",
-    "rm.created_at >= datetime(?)",
-    "rm.created_at < datetime(?)",
+  "rm.created_at >= datetime(?)",
+  "rm.created_at < datetime(?)",
   ];
   const params: unknown[] = [startTime, endTime];
 

--- a/router/src/db/usage-windows.ts
+++ b/router/src/db/usage-windows.ts
@@ -58,7 +58,7 @@ export function getLatestWindowByProvider(
   providerId: string,
 ): UsageWindow | null {
   return db.prepare(
-  "SELECT * FROM usage_windows WHERE provider_id = ? ORDER BY start_time DESC LIMIT 1",
+    "SELECT * FROM usage_windows WHERE provider_id = ? ORDER BY start_time DESC LIMIT 1",
   ).get(providerId) as UsageWindow | null ?? null;
 }
 
@@ -96,8 +96,8 @@ export function getWindowUsage(
   providerId?: string,
 ): WindowUsage {
   const conditions = [
-  "rm.created_at >= datetime(?)",
-  "rm.created_at < datetime(?)",
+    "rm.created_at >= datetime(?)",
+    "rm.created_at < datetime(?)",
   ];
   const params: unknown[] = [startTime, endTime];
 

--- a/router/src/metrics/sse-parser.ts
+++ b/router/src/metrics/sse-parser.ts
@@ -73,14 +73,14 @@ export class SSEParser {
         eventType = this.extractFieldValue(line);
       } else if (line.startsWith("data:")) {
         const value = this.extractFieldValue(line);
-    // [DONE] 是流结束信号，标记 isDone 阻止后续解析，同时作为普通事件返回
-    // 让 metrics extractor 的 processOpenAIEvent 能收到并设置 complete = true
-    if (value === "[DONE]") {
-      this.isDone = true;
-      dataLines.push(value);
-    } else {
-      dataLines.push(value);
-    }
+        // [DONE] 是流结束信号，标记 isDone 阻止后续解析，同时作为普通事件返回
+        // 让 metrics extractor 的 processOpenAIEvent 能收到并设置 complete = true
+        if (value === "[DONE]") {
+          this.isDone = true;
+          dataLines.push(value);
+        } else {
+          dataLines.push(value);
+        }
       }
       // 其他 field（id:, retry:, etc.）按 SSE 规范忽略
     }

--- a/router/src/metrics/sse-parser.ts
+++ b/router/src/metrics/sse-parser.ts
@@ -73,12 +73,14 @@ export class SSEParser {
         eventType = this.extractFieldValue(line);
       } else if (line.startsWith("data:")) {
         const value = this.extractFieldValue(line);
-        // [DONE] 是流结束信号，不作为普通事件返回
-        if (value === "[DONE]") {
-          this.isDone = true;
-          return null;
-        }
-        dataLines.push(value);
+    // [DONE] 是流结束信号，标记 isDone 阻止后续解析，同时作为普通事件返回
+    // 让 metrics extractor 的 processOpenAIEvent 能收到并设置 complete = true
+    if (value === "[DONE]") {
+      this.isDone = true;
+      dataLines.push(value);
+    } else {
+      dataLines.push(value);
+    }
       }
       // 其他 field（id:, retry:, etc.）按 SSE 规范忽略
     }

--- a/router/src/utils/time-range.ts
+++ b/router/src/utils/time-range.ts
@@ -30,13 +30,13 @@ export function resolveTimeRange(
   const now = new Date();
 
   switch (period) {
-  case "window": {
+    case "window": {
     // 有 providerId 但无 routerKeyId 时，忽略 router_key_id 查找最新窗口
     // （dashboard 等调用方不知道 router_key_id 时，也能匹配到实际窗口）
-    const latest = providerId && !routerKeyId
-    ? getLatestWindowByProvider(db, providerId)
-    : getLatestWindow(db, routerKeyId, providerId);
-    if (latest && now <= parseSqliteDatetime(latest.end_time)) {
+      const latest = providerId && !routerKeyId
+        ? getLatestWindowByProvider(db, providerId)
+        : getLatestWindow(db, routerKeyId, providerId);
+      if (latest && now <= parseSqliteDatetime(latest.end_time)) {
         // 有未过期窗口 → 直接使用窗口范围
         return { startTime: latest.start_time, endTime: latest.end_time };
       }

--- a/router/src/utils/time-range.ts
+++ b/router/src/utils/time-range.ts
@@ -1,5 +1,5 @@
 import Database from "better-sqlite3";
-import { getLatestWindow } from "../db/usage-windows.js";
+import { getLatestWindow, getLatestWindowByProvider } from "../db/usage-windows.js";
 import { toSqliteDatetime, parseSqliteDatetime } from "./datetime.js";
 import { getLatestMetricTime } from "../db/stats.js";
 
@@ -30,9 +30,13 @@ export function resolveTimeRange(
   const now = new Date();
 
   switch (period) {
-    case "window": {
-      const latest = getLatestWindow(db, routerKeyId, providerId);
-      if (latest && now <= parseSqliteDatetime(latest.end_time)) {
+  case "window": {
+    // 有 providerId 但无 routerKeyId 时，忽略 router_key_id 查找最新窗口
+    // （dashboard 等调用方不知道 router_key_id 时，也能匹配到实际窗口）
+    const latest = providerId && !routerKeyId
+    ? getLatestWindowByProvider(db, providerId)
+    : getLatestWindow(db, routerKeyId, providerId);
+    if (latest && now <= parseSqliteDatetime(latest.end_time)) {
         // 有未过期窗口 → 直接使用窗口范围
         return { startTime: latest.start_time, endTime: latest.end_time };
       }

--- a/router/tests/db.test.ts
+++ b/router/tests/db.test.ts
@@ -39,7 +39,7 @@ describe("initDatabase", () => {
       .prepare("SELECT name FROM migrations")
       .all() as { name: string }[];
 
-  expect(rows.length).toBe(47);
+  expect(rows.length).toBe(48);
     expect(rows[0].name).toBe("001_init.sql");
     expect(rows[1].name).toBe("002_add_request_response_body.sql");
     expect(rows[2].name).toBe("003_add_full_request_chain_log.sql");

--- a/router/tests/metrics.test.ts
+++ b/router/tests/metrics.test.ts
@@ -29,7 +29,7 @@ describe("request_metrics migration and insertMetrics", () => {
       .prepare("SELECT name FROM migrations")
       .all() as { name: string }[];
 
-  expect(rows).toHaveLength(47);
+  expect(rows).toHaveLength(48);
     expect(rows[5].name).toBe("006_create_request_metrics.sql");
     expect(rows[6].name).toBe("007_add_retry_fields.sql");
     expect(rows[7].name).toBe("008_create_router_keys.sql");

--- a/router/tests/metrics.test.ts
+++ b/router/tests/metrics.test.ts
@@ -398,20 +398,20 @@ describe("getClientTypeBreakdown", () => {
     expect(breakdown).toEqual({ "claude-code": 2 });
   });
 
-  it("only counts is_complete=1 rows", () => {
-    const logId = "b-incomplete";
-    insertRequestLog(db, {
-      id: logId, api_type: "openai", model: "gpt-4", provider_id: "p1",
-      status_code: 200, latency_ms: 100, is_stream: 0, error_message: null,
-      created_at: new Date().toISOString(),
-    });
-    insertMetrics(db, {
-      request_log_id: logId, provider_id: "p1", backend_model: "gpt-4", api_type: "openai",
-      input_tokens: 100, output_tokens: 50, is_complete: 0, client_type: "claude-code",
-    });
+  it("counts incomplete records too", () => {
+  const logId = "b-incomplete";
+  insertRequestLog(db, {
+    id: logId, api_type: "openai", model: "gpt-4", provider_id: "p1",
+    status_code: 200, latency_ms: 100, is_stream: 0, error_message: null,
+    created_at: new Date().toISOString(),
+  });
+  insertMetrics(db, {
+    request_log_id: logId, provider_id: "p1", backend_model: "gpt-4", api_type: "openai",
+    input_tokens: 100, output_tokens: 50, is_complete: 0, client_type: "claude-code",
+  });
 
-    const breakdown = getClientTypeBreakdown(db, "24h");
-    expect(breakdown).toEqual({});
+  const breakdown = getClientTypeBreakdown(db, "24h");
+  expect(breakdown).toEqual({ "claude-code": 1 });
   });
 
   it("filters by backend_model", () => {

--- a/router/tests/sse-parser.test.ts
+++ b/router/tests/sse-parser.test.ts
@@ -33,12 +33,13 @@ describe("SSEParser", () => {
   });
 
   it("should detect [DONE] and set isDone", () => {
-    const parser = new SSEParser();
-    const events = parser.feed("data: hello\n\ndata: [DONE]\n\n");
-    // [DONE] 不作为事件返回
-    expect(events).toHaveLength(1);
-    expect(events[0].data).toBe("hello");
-    expect(parser.isDone).toBe(true);
+  const parser = new SSEParser();
+  const events = parser.feed("data: hello\n\ndata: [DONE]\n\n");
+  // [DONE] 作为普通事件返回，让 extractor 能收到并设置 complete = true
+  expect(events).toHaveLength(2);
+  expect(events[0].data).toBe("hello");
+  expect(events[1].data).toBe("[DONE]");
+  expect(parser.isDone).toBe(true);
   });
 
   it("should ignore events after [DONE]", () => {
@@ -138,11 +139,12 @@ describe("SSEParser", () => {
       allEvents = allEvents.concat(parser.feed(chunk));
     }
 
-    expect(allEvents).toHaveLength(3);
-    expect(allEvents[0].data).toContain('"role":"assistant"');
-    expect(allEvents[1].data).toContain('"content":"Hello"');
-    expect(allEvents[2].data).toContain('"content":" world"');
-    expect(parser.isDone).toBe(true);
+  expect(allEvents).toHaveLength(4);
+  expect(allEvents[0].data).toContain('"role":"assistant"');
+  expect(allEvents[1].data).toContain('"content":"Hello"');
+  expect(allEvents[2].data).toContain('"content":" world"');
+  expect(allEvents[3].data).toBe("[DONE]");
+  expect(parser.isDone).toBe(true);
   });
 
   it("should handle realistic Anthropic streaming events", () => {


### PR DESCRIPTION
修复 dashboard 最近5小时窗口的3个问题：

### 1. 窗口时间偏移
- **根因**: resolveTimeRange 调用 getLatestWindow(db, undefined, providerId) 查询的是 router_key_id IS NULL 的窗口，但最新窗口都带有 router_key_id，导致查不到，回退到 metric 回退分支
- **修复**: 新增 getLatestWindowByProvider()，忽略 router_key_id 直接查 provider 的最新窗口

### 2. opencode-go-openai 显示请求数为 0
- **根因1**: SSEParser 吞掉了 [DONE] 事件，返回 null，extractor 的 processOpenAIEvent 永远收不到 [DONE]，complete 始终为 false
- **修复1**: SSEParser 检测到 [DONE] 时正常返回事件，不再吞掉
- **根因2**: dashboard 所有查询（getStats、getMetricsSummary 等）过滤 rm.is_complete = 1，但所有 opencode-go-openai 记录都是 is_complete = 0
- **修复2**: dashboard 查询全部去掉 is_complete = 1 过滤

### 3. 历史数据修复
- 新增 migration 047 修复所有 status_code=200 但 is_complete=0 的剩余记录

### 验证
- TypeScript 类型检查: 全部通过（4 个子包）
- Lint: 0 error 0 warning
- 测试: 114 test files, 1369 tests 全部通过
- 构建: router + frontend 成功