### PR TITLE
fix: prevent EPIPE crash and improve robustness

### DIFF
--- a/router/src/admin/monitor.ts
+++ b/router/src/admin/monitor.ts
@@ -45,7 +45,9 @@ export const adminMonitorRoutes: FastifyPluginCallback<MonitorRoutesOptions> = (
         "Cache-Control": "no-cache",
         Connection: "keep-alive",
       });
-    } catch { /* 客户端在 hijack 和 writeHead 之间断连，安全忽略 */ } // eslint-disable-line taste/no-silent-catch
+    } catch {
+      request.log.debug("client disconnected before writeHead");
+    }
   });
 
   app.get("/admin/api/monitor/request/:id", async (request, reply) => {

--- a/router/src/admin/monitor.ts
+++ b/router/src/admin/monitor.ts
@@ -27,16 +27,25 @@ export const adminMonitorRoutes: FastifyPluginCallback<MonitorRoutesOptions> = (
   app.get("/admin/api/monitor/stream", (request, reply) => {
     // hijack() 让 Fastify 完全放弃响应管理，避免 onSend hook 向 SSE 流注入信封 JSON
     reply.hijack();
-    reply.raw.writeHead(HTTP_OK, {
-      "Content-Type": "text/event-stream",
-      "Cache-Control": "no-cache",
-      Connection: "keep-alive",
-    });
+
     const sseClient = adaptSSEClient(reply.raw);
     tracker.addClient(sseClient);
-    request.raw.on("close", () => {
+
+    // 在 writeHead 之前注册 close 处理器，避免竞态导致 tracker 泄漏
+    reply.raw.on("close", () => {
       tracker.removeClient(sseClient);
     });
+
+    // 客户端在 hijack 之前已断连，无需发送响应头
+    if (reply.raw.destroyed) return;
+
+    try {
+      reply.raw.writeHead(HTTP_OK, {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+        Connection: "keep-alive",
+      });
+    } catch { /* 客户端在 hijack 和 writeHead 之间断连，安全忽略 */ } // eslint-disable-line taste/no-silent-catch
   });
 
   app.get("/admin/api/monitor/request/:id", async (request, reply) => {

--- a/router/src/admin/providers.ts
+++ b/router/src/admin/providers.ts
@@ -107,8 +107,17 @@ function extractModelOverrides(models: ModelInput[]): {
   return { entries, overrides };
 }
 const API_KEY_PREVIEW_PREFIX_LEN = 4;
-
 const PROVIDER_NAME_RE = /^[a-zA-Z0-9_-]+$/;
+
+/** 校验 base_url 是否为合法的 HTTP(S) URL */
+function isValidHttpUrl(str: string): boolean {
+  try {
+    const url = new URL(str);
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
 
 const CreateProviderSchema = Type.Object({
   name: Type.String({ minLength: 1 }),
@@ -206,6 +215,9 @@ export const adminProviderRoutes: FastifyPluginCallback<ProviderRoutesOptions> =
     if (existing) {
       return reply.code(HTTP_CONFLICT).send(apiError(API_CODE.CONFLICT_NAME, `Provider 名称 '${body.name}' 已存在`));
     }
+    if (!isValidHttpUrl(body.base_url)) {
+      return reply.code(HTTP_BAD_REQUEST).send(apiError(API_CODE.VALIDATION_FAILED, "base_url 格式无效，必须是以 http:// 或 https:// 开头的合法 URL"));
+    }
     const encryptedKey = encrypt(body.api_key, getSetting(db, "encryption_key")!);
     const { entries: normalizedModels, overrides: contextOverrides } = extractModelOverrides((body.models ?? []) as ModelInput[]);
     const isAdaptiveEnabled = body.adaptive_enabled ?? 0;
@@ -273,7 +285,12 @@ export const adminProviderRoutes: FastifyPluginCallback<ProviderRoutesOptions> =
     const fields: Partial<Pick<Provider, 'name' | 'api_type' | 'base_url' | 'upstream_path' | 'api_key' | 'api_key_preview' | 'models' | 'is_active' | 'max_concurrency' | 'queue_timeout_ms' | 'max_queue_size' | 'adaptive_enabled' | 'proxy_type' | 'proxy_url' | 'proxy_username' | 'proxy_password'>> = {};
     if (body.name !== undefined) fields.name = body.name;
     if (body.api_type !== undefined) fields.api_type = body.api_type;
-    if (body.base_url !== undefined) fields.base_url = body.base_url;
+    if (body.base_url !== undefined) {
+      if (!isValidHttpUrl(body.base_url)) {
+        return reply.code(HTTP_BAD_REQUEST).send(apiError(API_CODE.VALIDATION_FAILED, "base_url 格式无效，必须是以 http:// 或 https:// 开头的合法 URL"));
+      }
+      fields.base_url = body.base_url;
+    }
     if (body.upstream_path !== undefined) fields.upstream_path = body.upstream_path || null;
     if (body.is_active !== undefined) fields.is_active = body.is_active;
     if (body.models !== undefined) {

--- a/router/src/index.ts
+++ b/router/src/index.ts
@@ -150,8 +150,22 @@ export async function buildApp(
   });
 
   // 记录请求到达时间，供全局错误处理计算延迟
-  app.addHook("onRequest", (request, _reply, done) => {
+  app.addHook("onRequest", (request, reply, done) => {
     (request as unknown as { receivedAt: number }).receivedAt = Date.now();
+
+    // 全局 EPIPE 防护：ServerResponse 的 write 异步完成失败时，
+    // 内部 socketErrorListener → response.destroy(err) → response.emit('error')。
+    // 若无 listener 则该 error 成为 uncaught exception。
+    // 代理路由在 create-proxy-handler.ts 中已有额外监听，此处覆盖所有路由。
+    reply.raw.on("error", (err: Error) => {
+      const code = (err as { code?: string }).code;
+      if (code === 'EPIPE') {
+        request.log.debug({ err }, "client disconnected (EPIPE)");
+      } else {
+        request.log.warn({ err }, "response stream error");
+      }
+    });
+
     done();
   });
 

--- a/router/src/proxy/handler/create-proxy-handler.ts
+++ b/router/src/proxy/handler/create-proxy-handler.ts
@@ -249,8 +249,24 @@ export function createProxyHandler(config: ProxyHandlerConfig) {
       // Socket error handling
       const socketErrorHandler = (err: Error) => request.log.debug({ err }, "client socket error");
       request.raw.socket.on("error", socketErrorHandler);
+
+      // reply.raw (ServerResponse) error handling
+      // Node.js 中，TCP socket write 异步完成失败时（如 EPIPE），
+      // 内部 socketErrorListener → response.destroy(err) → response.emit('error')。
+      // 若无 listener，该 error 成为 uncaught exception 导致进程退出。
+      const replyErrorHandler = (err: Error) => {
+        const code = (err as { code?: string }).code;
+        if (code === 'EPIPE') {
+          request.log.debug({ err }, "client disconnected (EPIPE)");
+        } else {
+          request.log.warn({ err }, "response stream error");
+        }
+      };
+      reply.raw.on("error", replyErrorHandler);
+
       reply.raw.on("close", () => {
         request.raw.socket.removeListener("error", socketErrorHandler);
+        reply.raw.removeListener("error", replyErrorHandler);
       });
 
       // 创建 pipeline context

--- a/router/src/proxy/transform/stream-oa2ant.ts
+++ b/router/src/proxy/transform/stream-oa2ant.ts
@@ -23,6 +23,9 @@ export class OpenAIToAnthropicTransform extends BaseSSETransform {
   private finishReasonReceived = false;
 
   protected processEvent(event: { event?: string; data?: string }): void {
+  // OpenAI SSE 标准结束信号 [DONE] 不是 JSON，跳过解析
+    if (event.data === '[DONE]') return;
+  
     let chunk: Record<string, unknown>;
     try { chunk = JSON.parse(event.data!); } catch (err) { this.emit("warning", err); return; }
 

--- a/router/src/proxy/transport/http.ts
+++ b/router/src/proxy/transport/http.ts
@@ -108,6 +108,9 @@ export function callNonStream(
           });
         }
       });
+      // 上游响应过程中连接中断时，IncomingMessage 发射 'error' 事件。
+      // 无 listener 会导致 uncaught exception 使进程退出。
+      res.on("error", (error) => resolve({ kind: "throw", error }));
     });
 
     req.on("error", (error) => resolve({ kind: "throw", error }));
@@ -148,6 +151,9 @@ export function callGet(
           headers: filterHeaders(res.headers as RawHeaders),
         });
       });
+      // 上游响应过程中连接中断时，IncomingMessage 发射 'error' 事件。
+      // 无 listener 会导致 uncaught exception 使进程退出。
+      res.on("error", (err) => reject(err));
     });
     req.on("error", (err) => reject(err));
     req.end();

--- a/router/src/proxy/transport/proxy-agent.ts
+++ b/router/src/proxy/transport/proxy-agent.ts
@@ -45,9 +45,14 @@ export class ProxyAgentFactory {
       this.cache.delete(provider.id);
     }
 
-    const agent = this.createAgent(provider.proxy_type, fullUrl);
-    this.cache.set(provider.id, { agent, proxyUrl: fullUrl });
-    return agent;
+    try {
+      const agent = this.createAgent(provider.proxy_type, fullUrl);
+      this.cache.set(provider.id, { agent, proxyUrl: fullUrl });
+      return agent;
+    } catch {
+    // proxy_url 格式无效时返回 undefined，由调用方回退到非代理的 keep-alive agent
+      return undefined;
+    }
   }
 
   invalidate(providerId: string): void {
@@ -92,10 +97,15 @@ export class ProxyAgentFactory {
     const password = provider.proxy_password;
 
     if (username) {
-      const parsed = new URL(url);
-      parsed.username = username;
-      if (password) parsed.password = password;
-      url = parsed.toString();
+      try {
+        const parsed = new URL(url);
+        parsed.username = username;
+        if (password) parsed.password = password;
+        url = parsed.toString();
+      } catch {
+        // proxy_url 格式无效时返回原始 URL，由上游请求层处理连接错误
+        return url;
+      }
     }
     return url;
   }

--- a/router/src/proxy/transport/stream.ts
+++ b/router/src/proxy/transport/stream.ts
@@ -171,7 +171,13 @@ class StreamProxy {
     }
     this.transition("STREAMING");
     this.headersSent = true;
-    this.reply.raw.writeHead(this.statusCode, this.sseHeaders);
+    try {
+      this.reply.raw.writeHead(this.statusCode, this.sseHeaders);
+    } catch {
+    // 客户端在 state transition 和 writeHead 之间断连，可安全忽略
+      this.terminal("stream_abort");
+      return;
+    }
     if (this.metricsTransform) {
       this.metricsTransform.pipe(this.formatTransform ?? this.passThrough, { end: true });
     }

--- a/router/src/proxy/transport/transport-fn.ts
+++ b/router/src/proxy/transport/transport-fn.ts
@@ -93,6 +93,17 @@ export function buildTransportFn(p: TransportFnParams): (target: Target) => Prom
         onChunk: (rawLine) => { p.tracker?.appendStreamChunk(p.logId, rawLine, p.apiType, STREAM_CONTENT_MAX_RAW, STREAM_CONTENT_MAX_TEXT); },
         onContentDelta: streamLoopGuard ? (text) => streamLoopGuard.feed(text) : undefined,
       });
+      // Transform stream 内部异常若无 listener 会触发 uncaught exception，
+      // 指标采集错误不影响业务数据流，仅记录 warn 日志。
+      metricsTransform.on("error", (err) => {
+        p.request.log.warn({ err, logId: p.logId }, "metricsTransform stream error");
+      });
+      if (p.formatTransform) {
+        // 格式转换异常会破坏管道，记录 warn 后由 StreamProxy 的空闲超时兜底清理。
+        p.formatTransform.on("error", (err) => {
+          p.request.log.warn({ err, logId: p.logId }, "formatTransform stream error");
+        });
+      }
       const checkEarlyError = p.matcher ? (data: string) => p.matcher!.test(UPSTREAM_SUCCESS, data) : undefined;
       const streamResult = await callStream(
         p.provider, p.apiKey, p.body, p.cliHdrs, p.reply, p.streamTimeoutMs,


### PR DESCRIPTION
## Root Cause

write EPIPE became an uncaught exception and crashed the process. When a TCP socket write fails asynchronously in Node.js, the error propagates through socketErrorListener -> response.destroy(err) -> response.emit(error). reply.raw (ServerResponse) had no error listener, making it an uncaught exception.

## Changes

### EPIPE Protection
- Global onRequest hook adds reply.raw.on(error) for all routes
- Proxy handler adds dedicated error listener with close-time cleanup
- Admin SSE endpoint: writeHead wrapped in try-catch, close handler registered before writeHead

### Upstream/Transform Error Handling
- callNonStream/callGet: add missing res.on(error) for upstream response stream
- SSEMetricsTransform/formatTransform: add error event listeners
- StreamProxy startStreaming(): writeHead wrapped in try-catch
- OpenAI-to-Anthropic transform: skip [DONE] SSE signal before JSON.parse

### Provider URL Validation
- Validate base_url format on provider create/update (isValidHttpUrl)
- ProxyAgentFactory: guard getAgent/buildProxyUrl against invalid proxy_url