### PR TITLE
refactor: frontend dedup, auth consolidation, backend bug fixes

### DIFF
--- a/.xyz-harness/2026-05-18-improvement/backend-impr.md
+++ b/.xyz-harness/2026-05-18-improvement/backend-impr.md
@@ -1,0 +1,385 @@
+# 后端架构审查报告（修订版）
+
+**日期:** 2026-05-18
+**范围:** `router/src/` 全部 172 个 TS 文件，约 20,352 行
+**方法:** 逐文件阅读关键模块，对照插件化架构设计意图逐条验证
+
+---
+
+## 第一部分：插件化架构违规
+
+项目设计了一套 Pipeline + Hook + Plugin 三层可扩展架构，但大量代码绕过这套架构直接内联实现。以下是所有违规点。
+
+### V1. 9 个内置 Hook 中 8 个是死代码（828 行）
+
+**背景：** `registerBuiltinHooks()` 在启动时将 9 个 hook 同时注册到 `proxyPipeline`（执行用）和 `hookRegistry`（Admin API 查询用）。但整个请求处理路径中，**只有 `create-proxy-handler.ts:279` 调用了 `proxyPipeline.emit("pre_route", ctx)`**，其余 5 个阶段（`post_route`、`pre_transport`、`post_response`、`on_error`、`on_stream_event`）从未被 emit。
+
+**验证过程：**
+
+```
+grep -rn 'proxyPipeline\.emit' router/src/ → 只有一处调用
+grep -rn 'emit(' proxy/pipeline/pipeline.ts → emit 方法本身存在但无其他调用者
+```
+
+**实际执行状态：**
+
+| Hook | Phase | 是否被 emit | 是否实际执行 | 原因 |
+|------|-------|-------------|-------------|------|
+| `builtin:client-detection` | `pre_route` | 是 | **是** | emit 前已设置 `ctx.metadata.set("db", db)` |
+| `builtin:enhancement-preprocess` | `pre_route` | 是 | **否** | 需要 `container`，但 emit 前只设置了 `db`，没有设置 `container` → early return |
+| `builtin:allowed-models` | `post_route` | 否 | **否** | `post_route` 阶段从未被 emit |
+| `builtin:overflow-redirect` | `post_route` | 否 | **否** | 同上 |
+| `builtin:plugin-request` | `pre_transport` | 否 | **否** | `pre_transport` 阶段从未被 emit |
+| `builtin:provider-patches` | `pre_transport` | 否 | **否** | 同上 |
+| `builtin:cache-estimation` | `post_response` | 否 | **否** | `post_response` 阶段从未被 emit |
+| `builtin:request-logging` | `post_response` | 否 | **否** | 同上 |
+| `builtin:error-logging` | `on_error` | 否 | **否** | `on_error` 阶段从未被 emit |
+
+**死代码统计：**
+
+| 文件 | 行数 | 说明 |
+|------|------|------|
+| `proxy/hooks/builtin/` (8 个文件) | 589 行 | 有完整实现但永不执行 |
+| `proxy/hooks/plugin-bridge.ts` | 126 行 | `bridgePlugin()` 将 `TransformPlugin` 桥接为 `PipelineHook[]`，从未被调用 |
+| `proxy/hooks/sse-event-transform.ts` | 70 行 | `SSEEventTransform` 流式 SSE 事件拦截器，从未被使用 |
+| `proxy/pipeline/hook-registry.ts` | 43 行 | 独立于 `proxyPipeline` 的查询注册表，`proxyPipeline.getHookChain()` 已有此功能 |
+| **合计** | **828 行** | |
+
+**影响：** 新增横切功能（如新的 provider patch、新的日志字段）时，开发者不知道应该写在 hook 里还是内联在 failover-loop 里。hook 代码写了、测了、注册了，但线上不执行 — 极度混淆。
+
+---
+
+### V2. `enhancement-preprocess` Hook 注册了但因缺少依赖而静默跳过
+
+**位置:** `proxy/hooks/builtin/enhancement-preprocess.ts` + `proxy/handler/create-proxy-handler.ts:279-285`
+
+**详细过程：**
+
+1. `create-proxy-handler.ts:275` — `ctx.metadata.set("db", db)` 注入 DB
+2. `create-proxy-handler.ts:279` — `proxyPipeline.emit("pre_route", ctx)` 触发 hooks
+3. `enhancement-preprocess` hook 被触发，但 `ctx.metadata.get("container")` 返回 `undefined`
+4. Hook 第一行 `if (!db || !container) return;` — **静默退出，不执行任何逻辑**
+5. `create-proxy-handler.ts:285` — `applyEnhancementPreprocess(request, reply, ctx, db, container)` 执行内联版本
+
+**根因：** emit 前只设置了 `db`，没设置 `container`。而 `enhancement-preprocess` hook 需要 `container` 来 resolve `SessionTracker`。
+
+**影响：** Hook 的代码（91 行）写得完全正确，但因为依赖注入遗漏而从未执行。同样的逻辑在 `create-proxy-handler.ts:136-190` 有一个完全独立的内联实现（55 行），这才是实际运行的代码。
+
+**对比（两份实现完全相同的功能）：**
+
+```
+proxy/hooks/builtin/enhancement-preprocess.ts (91 行, Hook 版, 未执行)
+  ↓ 等价于
+proxy/handler/create-proxy-handler.ts:136-190 (55 行, 内联版, 实际运行)
+```
+
+---
+
+### V3. `plugin-bridge.ts` 将 TransformPlugin 桥接为 PipelineHook，但从未被调用
+
+**位置:** `proxy/hooks/plugin-bridge.ts`
+
+**设计意图：** 外部 `.js` 插件和 DB 声明式规则都注册为 `TransformPlugin`。`bridgePlugin()` 函数可以将它们转换为 `PipelineHook[]` 并注册到 `proxyPipeline`，让插件系统与 Pipeline 系统打通。
+
+**实际情况：** `bridgePlugin()` 导出了但零调用者。外部插件只通过 `failover-loop.ts:105-106` 的内联 `pluginRegistry.applyBeforeRequest/AfterRequest` 调用生效，不经过 Pipeline。
+
+**影响：** 插件系统的 `onStreamEvent` 和 `onError` 回调永远无法触发 — 因为只有 Pipeline emit 时才会调用对应的 hook，而 Pipeline 没有桥接插件。插件的能力被限制在 `beforeRequest/afterRequest` 和 `beforeResponse/afterResponse` 四个方法上，`onStreamEvent` 和 `onError` 是死接口。
+
+---
+
+### V4. Hook 版本与 Failover-Loop 内联版本的语义差异
+
+Hook 是为"单次请求、单个 resolved target"的场景设计的，但 failover-loop 处理的是"多 target 列表 + 跨迭代累积"场景。两者的语义差距导致 hook 无法直接替代内联实现：
+
+**V4a. `overflow-redirect` 差异**
+
+| | Hook 版本 | 内联版本 |
+|---|---------|---------|
+| 函数 | `applyOverflowRedirect(target, db, body)` | `expandOverflowTargets(allTargets, db, body)` |
+| 输入 | 单个 `Target` | `Target[]` 列表 |
+| 输出 | 单个重定向结果或 null | 扩展后的列表 + `overflowIndices` 追踪集合 |
+| 语义 | "当前 target 溢出 → 替换 resolved" | "为每个 target 预计算溢出目标，prepend 到列表" |
+
+内联版本需要追踪哪些 index 是 overflow 产生的（`overflowIndices`），用于后续 failover 日志中标记 `mappingReason: "overflow_redirect"`。Hook 版本没有这个概念。
+
+**V4b. `allowed-models` 差异**
+
+| | Hook 版本 | 内联版本 |
+|---|---------|---------|
+| 函数 | 检查 `resolved.backend_model` 是否在白名单 | 过滤整个 `allTargets` 列表 |
+| 行为 | 不匹配 → `PipelineAbort(403)` 直接拒绝 | 移除不允许的 target，保留允许的，同时重建 `overflowIndices` |
+| 语义 | "reject" — 单 target 场景 | "filter and continue" — 多 target 场景 |
+
+内联版本的 filter 语义允许：如果首选 target 不在白名单，但备选 target 在白名单，可以自动选择备选。Hook 版本直接 abort，丢失了这个能力。
+
+**V4c. 日志传递路径差异**
+
+| | Hook 版本 | 内联版本 |
+|---|---------|---------|
+| 依赖获取 | `ctx.metadata.get("resilienceResult") as ...` （10+ 次 unsafe `as` 断言） | 闭包变量直接引用（`resilienceResult`, `startTime` 等） |
+| 类型安全 | `metadata.get()` 返回 `unknown`，每次需要 `as` 断言 | 变量有具体类型，编译器检查 |
+
+**影响：** Hook 设计假设"单次执行"模型，无法表达 failover 循环中的列表级操作。要让 Pipeline 真正接管这些逻辑，需要扩展 `PipelineContext` 的数据模型（如增加 `allTargets`、`overflowIndices` 字段），而不能只传递 `resolved: Target | null`。
+
+---
+
+### V5. `patch` 层不通过插件系统接入
+
+**位置:** `proxy/patch/index.ts` + `proxy/patch/deepseek/`
+
+`applyProviderPatches()` 是一个硬编码的分发函数，根据 provider 的 `base_url` 和 `api_type` 决定应用哪些补丁（DeepSeek developer_role 转换等）。它：
+- 不通过 `TransformPlugin` 接口注册
+- 不通过 `FormatAdapter` 机制扩展
+- 在 `failover-loop.ts:341` 和 `hooks/builtin/provider-patches.ts:24` 都有调用（但只有 failover-loop 的调用生效）
+
+Provider patches 应该是 `TransformPlugin` 的典型使用场景（按 provider 匹配 + 修改 request body），但当前是硬编码在 `patch/index.ts` 中的 if-else 链。
+
+---
+
+### V6. Enhancement 配置检查散落在三个位置
+
+**涉及文件：**
+
+1. `proxy/hooks/builtin/enhancement-preprocess.ts` — Hook 版本（未执行，因缺少 container）
+2. `proxy/handler/create-proxy-handler.ts:136-190` — `applyEnhancementPreprocess()` 内联版本（实际运行）
+3. `proxy/handler/failover-loop.ts:155-262` — `enhancementConfig` 的 `tool_error_logging_enabled`、`stream_loop_enabled`
+
+配置 `enhancementConfig` 在 failover-loop 中被读取两次（`tool_error_logging_enabled` 和 `stream_loop_enabled`），在 create-proxy-handler 中被读取一次。三处都独立调用 `loadEnhancementConfig(db)`，不共享缓存。
+
+---
+
+### V7. `SSEEventTransform` 已实现但从未接入流式管道
+
+**位置:** `proxy/hooks/sse-event-transform.ts`
+
+`SSEEventTransform` 是一个 Transform stream，设计用于插入 SSE 流式管道中，解析每个 SSE 事件后调用 `on_stream_event` hook。它是 `TransformPlugin.onStreamEvent` 回调的接入点。
+
+**问题：**
+- 从未被任何代码实例化
+- `StreamProxy`（`proxy/transport/stream.ts`）中的流式管道不包含这个 transform
+- 因此 `TransformPlugin.onStreamEvent` 是一个永远无法触发的死接口
+
+---
+
+### V8. `HookRegistry` 与 `ProxyPipeline` 双注册导致混淆
+
+**位置:** `proxy/pipeline/register-hooks.ts` + `proxy/pipeline/hook-registry.ts`
+
+`registerBuiltinHooks()` 将每个 hook 同时注册到两个独立的数据结构：
+
+```ts
+for (const hook of ALL_HOOKS) {
+  hookRegistry.register(hook);   // Admin API 查询用
+  proxyPipeline.register(hook);  // 实际执行用
+}
+```
+
+但 `hookRegistry` 和 `proxyPipeline` 的注册逻辑是独立的 — `hookRegistry` 不检查幂等（允许同名重复注册），`proxyPipeline` 检查幂等（同名跳过）。Admin API 的 `/admin/api/pipeline/hooks` 查询的是 `hookRegistry`，它反映的"已注册 hook"与 `proxyPipeline` 的实际执行列表不一致。
+
+---
+
+## 第二部分：真实存在的 Bug
+
+### B1. `resilience.ts` errMsg 三元表达式重复
+
+**位置:** `proxy/orchestration/resilience.ts:241`
+
+```ts
+const errMsg = err instanceof Error ? err.message : err instanceof Error ? err.message : JSON.stringify(err);
+```
+
+第二个 `err instanceof Error` 永远不会执行（第一个条件已覆盖）。应改为：
+
+```ts
+const errMsg = err instanceof Error ? err.message : JSON.stringify(err);
+```
+
+### B2. `enhancement-preprocess` Hook 因依赖注入遗漏而从未执行
+
+**位置:** `proxy/handler/create-proxy-handler.ts:275-285`
+
+详见 V2。`emit("pre_route")` 前只设置了 `ctx.metadata.set("db", db)`，没有设置 `container`。导致 hook 静默退出。修复只需在 emit 前加一行：
+
+```ts
+ctx.metadata.set("container", container);
+```
+
+---
+
+## 第三部分：架构层面的合理问题
+
+### A1. `failover-loop.ts` (592行) 过度膨胀
+
+**位置:** `proxy/handler/failover-loop.ts`
+
+**问题分析：** 这个文件是 V1-V8 所有违规的共同症状。因为它绕过了 Pipeline 架构内联了所有逻辑，导致：
+
+- 46 个 import（项目最多）
+- 单函数 `executeFailoverLoop()` 约 400 行
+- 同时处理路由、格式转换、加密解密、插件调用、日志记录、流式内容采集、failover 循环控制
+
+**膨胀来源对照表：**
+
+| 内联逻辑 | 行数 | 对应的死 Hook |
+|---------|------|-------------|
+| resolveMapping + modality redirect + overflow | ~70 | `overflow-redirect` hook |
+| allowed_models 过滤 | ~20 | `allowed-models` hook |
+| applyPluginAdjustments | ~15 | `plugin-request` hook |
+| applyProviderPatches | ~5 | `provider-patches` hook |
+| logResilienceResult + collectTransportMetrics | ~25 | `request-logging` hook |
+| insertRejectedLog / insertRequestLog (error) | ~30 | `error-logging` hook |
+| tool error logging | ~15 | `request-logging` hook |
+| **合计可迁移** | **~180** | |
+
+如果 Pipeline 架构被激活，failover-loop 可缩减到约 400 行，只保留循环控制 + 有状态依赖管理。
+
+### A2. 双层日志系统
+
+**问题：** 日志相关逻辑分散在 6 个文件中，且 `logResilienceResult()` 内部有 4 条路径（stream_error / error / 非200 / 成功），每条都是大段重复的 `insertRequestLog()` 调用。
+
+**涉及文件：**
+
+| 文件 | 职责 | 行数 |
+|------|------|------|
+| `proxy/log-helpers.ts` | `insertSuccessLog()` + `insertRejectedLog()` | 103 |
+| `proxy/proxy-logging.ts` | `logResilienceResult()` + `collectTransportMetrics()` | 233 |
+| `proxy/handler/failover-loop.ts` | 内联 `insertRequestLog()` 调用（error/catch 场景） | ~40 |
+| `proxy/hooks/builtin/error-logging.ts` | Pipeline hook 版本（未执行） | 113 |
+| `proxy/hooks/builtin/request-logging.ts` | Pipeline hook 版本（未执行） | 124 |
+| `index.ts` | 全局 errorHandler 中内联 `insertRequestLog()` | ~20 |
+
+**重复模式：** 每个路径都手动构造一个 ~15 字段的 `RequestLogInsert` 对象。改一个字段（如新增 `pipeline_snapshot`）需要改所有路径。Hook 版本的日志代码（113 + 124 = 237 行）是死代码，与内联版本做同样的事。
+
+**建议：** 统一为 `RequestLogWriter` 类，提供 `logSuccess()` / `logError()` / `logRejected()` / `logResilienceResult()` 方法。
+
+### A3. `ErrorKind` 类型在两个文件中独立定义
+
+**位置:**
+- `proxy/proxy-core.ts` — `ErrorKind` union type，被 `createErrorFormatter()` 使用
+- `proxy/format/types.ts` — 同名 union type，被 `FormatAdapter.errorMeta` 使用
+
+两个定义值完全相同，但没有共享。如果新增一种错误类型，需要同时改两个文件。
+
+---
+
+## 第四部分：代码品味问题
+
+### T1. `getConfig()` 废弃函数仍有调用者
+
+**位置:** `config/index.ts` + `proxy/handler/failover-loop.ts:153`
+
+`getConfig()` 标记为 `@deprecated`，建议用 `getBaseConfig()`，但 `failover-loop.ts` 仍在使用。
+
+### T2. `tokens_per_second` 废弃字段未清理
+
+**位置:** `core/types.ts:67`
+
+```ts
+/** @deprecated Use total_tps instead */
+tokens_per_second: number | null;
+```
+
+仍在 `toStreamMetrics()` 中被映射、在 `LOG_LIST_SELECT` 中被查询。废弃字段在 API/DB/前端三处都有消费者，清理需要协调。
+
+### T3. `JSON.parse(JSON.stringify())` 做深拷贝
+
+**位置:** `core/loop-prevention/tool-loop-guard.ts:46`
+
+```ts
+const cloned = JSON.parse(JSON.stringify(body));
+```
+
+项目品味规范要求 `structuredClone()`。另外两处（`proxy/pipeline/context.ts`、`proxy/patch/index.ts`）已改用 `structuredClone()`，这里遗漏了。
+
+### T4. Target key 构造散落 4 处
+
+```
+provider_id:backend_model
+```
+
+这个字符串拼接在以下位置各自独立实现：
+- `proxy/routing/mapping-resolver.ts` — `filterExcluded()`
+- `proxy/orchestration/resilience.ts` — `execute()` 内联
+- `proxy/handler/failover-loop.ts` — 调用 `filterExcluded()` 但也有独立的 target key 构造
+- `proxy/transport/transport-fn.ts` — 不构造但消费 target
+
+应提取为 `Target.toKey()` 或在 `Target` 类型上定义 `equals()` 方法。
+
+### T5. `console.warn` / `console.error` 替代 logger
+
+**位置:**
+- `proxy/routing/mapping-resolver.ts:166` — `console.warn`
+- `proxy/routing/modality-redirect.ts:241` — `console.error`
+- `proxy/routing/overflow.ts:89` — `console.error`
+- `db/index.ts` — `console.error`
+- `proxy/transform/plugin-registry.ts` — `console.error`
+
+在 Fastify 上下文中这些应该用 `request.log` 或 `app.log`，保证日志格式和级别统一。
+
+### T6. Hook 通过 `metadata.get()` 传依赖的不安全模式
+
+**位置:** 所有 `proxy/hooks/builtin/*.ts`
+
+Hook 通过 `ctx.metadata.get("db") as Database.Database` 获取依赖。每次调用都需要 `as` 类型断言，编译器无法检查 key 是否正确、值类型是否匹配。`request-logging.ts` 有 10 处这样的断言，`error-logging.ts` 有 9 处。
+
+应该改为通过 PipelineContext 的显式字段或 DI 容器注入。
+
+### T7. `modality-redirect.ts` snapshot 记录高度重复
+
+**位置:** `proxy/routing/modality-redirect.ts`
+
+`computeModalityRedirectTargets()` 中有 7 处 `snapshot.add({...satisfies StageRecord})`，每处都重复填写 `stage`、`triggered`、`original_model`、`redirect_to`、`redirect_provider`、`reason` 六个字段。应提取一个闭包 helper。
+
+### T8. `admin/providers.ts` (502行) 混合了 HTTP 处理和业务逻辑
+
+**位置:** `admin/providers.ts`
+
+`cascadeProviderDisable()` 和 `extractModelOverrides()` 是纯业务逻辑函数，不依赖 Fastify request/reply，但放在了 HTTP handler 文件中。应移到 `db/` 或 `core/` 层。
+
+---
+
+## 第五部分：之前审查中修正的误判
+
+### M1. `index.ts` 不是 God File — 是合理的 Composition Root
+
+`buildApp()` 本质上是 DI 组装点。26 行 Fastify 配置 + 85 行全局 hooks + 56 行 DI 注册 + 43 行路由注册，线性可读。拆成 4 个文件反而增加跳转成本。
+
+### M2. `TransportResult` 6 个 variant 不过大
+
+6 个 variant（success / stream_success / stream_error / stream_abort / error / throw）是对代理请求所有可能结局的完整枚举，每个都有独立且必要的数据结构。拆分会增加类型转换代码。
+
+### M3. `SemaphoreScope` / `TrackerScope` 不是多余的间接层
+
+它们是 RAII guard，保证 acquire/release 和 start/complete 的配对时序。内联到 orchestrator 会暴露底层协议给调用者。
+
+---
+
+## 优先级矩阵
+
+| 优先级 | 编号 | 问题 | 类型 | 预估修复量 |
+|--------|------|------|------|-----------|
+| **P0** | V1 | 828 行 Hook 死代码 | 架构违规 | 大（需要激活 Pipeline emit） |
+| **P0** | V2 | enhancement-preprocess 因依赖注入遗漏未执行 | Bug | 小（加 1 行 metadata.set） |
+| **P0** | B1 | resilience.ts errMsg 重复三元 | Bug | 小（改 1 行） |
+| **P1** | V3 | plugin-bridge 从未被调用 | 架构违规 | 中（桥接到 Pipeline 或删除） |
+| **P1** | V4 | Hook 与内联版本语义差异 | 架构设计 | 大（扩展 PipelineContext） |
+| **P1** | V5 | Patch 层不通过插件系统接入 | 架构违规 | 中（改为 TransformPlugin） |
+| **P1** | A2 | 双层日志系统 | 架构 | 中（统一为 RequestLogWriter） |
+| **P1** | A1 | failover-loop 592 行膨胀 | 架构 | 依赖 V1 解决后自动缓解 |
+| **P2** | V6 | Enhancement 配置散落 3 处 | 违规 | 小 |
+| **P2** | V7 | SSEEventTransform 未接入 | 架构违规 | 中（插入 StreamProxy 管道） |
+| **P2** | V8 | 双注册 HookRegistry | 架构违规 | 小（删除 hookRegistry） |
+| **P2** | A3 | ErrorKind 双定义 | DRY | 小 |
+| **P2** | T1-T8 | 代码品味问题 | 品味 | 各小 |
+
+---
+
+## 决策记录
+
+### D1. Pipeline 死代码 — 选项 C: 标记 + 文档
+
+**决策日期**: 2026-05-18
+**选定选项**: C（标记 + 文档）
+**理由**: 当前分支 scope 为 bug 修复和小重构，不适合做大范围架构改动（选项 A 需 ~2-3 周、高风险核心路径重构；选项 B 需单独 spec/plan）。选项 C 零风险，减少未来开发者的困惑。
+**下一步**: 在下一个迭代中评估选项 B（删除 828 行死代码）。选项 A（激活 Pipeline）需要单独的 spec + plan。
+**涉及问题**: V1, V3, V7, V8, A1

--- a/.xyz-harness/2026-05-18-improvement/changes/evidence/test_execution.json
+++ b/.xyz-harness/2026-05-18-improvement/changes/evidence/test_execution.json
@@ -1,0 +1,142 @@
+{
+  "test_execution": [
+    {
+      "caseId": "TC-1-01",
+      "round": 1,
+      "passed": true,
+      "execute_steps": [
+        "审查 Monitor.vue 源码：确认 copiedId 为 ref<string | null>(null)，每行通过 copiedId === req.id 独立判断",
+        "确认 copyId(id) 函数调用 copy(id) 后设置 copiedId.value = id，2s 后自动清除",
+        "模板中 3 处 v-if/click 已改为 copiedId/copyId，不再依赖全局 copied 状态"
+      ],
+      "evidence": "源码审查通过，grep confirmed 3 处 copiedId === req.id 判断点"
+    },
+    {
+      "caseId": "TC-2-01",
+      "round": 1,
+      "passed": true,
+      "execute_steps": [
+        "审查 router/index.ts guard 逻辑：未登录访问受保护页面时 isAuthenticated.value = false + next('/login')",
+        "确认 App.vue v-if='isAuthenticated' 使用 router 导入的 ref",
+        "确认 setup 未初始化时访问非 setup 页面会重定向到 /setup"
+      ],
+      "evidence": "源码审查通过，router guard 6 处 isAuthenticated 赋值正确"
+    },
+    {
+      "caseId": "TC-2-02",
+      "round": 1,
+      "passed": true,
+      "execute_steps": [
+        "审查 router guard：登录成功后 guard 置 isAuthenticated.value = true，next() 放行",
+        "页面切换时 guard 检查 api.getStats()，成功后 isAuthenticated = true 不变",
+        "App.vue 导入 isAuthenticated from '@/router'，Sidebar 通过 v-if 绑定"
+      ],
+      "evidence": "单一状态源设计，App.vue 不再有独立的 checkAuth/watch 逻辑"
+    },
+    {
+      "caseId": "TC-2-03",
+      "round": 1,
+      "passed": true,
+      "execute_steps": [
+        "审查 router guard：to.path === '/setup' 且 setup 未初始化 → next()（正常显示）",
+        "to.path === '/setup' 且 setup 已初始化 → next('/login')（重定向）",
+        "tests/auth.test.ts 覆盖认证中间件基本场景（已通过）"
+      ],
+      "evidence": "源码审查通过，guard 逻辑覆盖 setup 未初始化/已初始化两条路径"
+    },
+    {
+      "caseId": "TC-3-01",
+      "round": 1,
+      "passed": true,
+      "execute_steps": [
+        "运行 python3 .githooks/vue_rules_checker.py PatchChips.vue → 无报错",
+        "grep 确认文件中使用 Button 组件（import from '@/components/ui/button'），无原生 <button>",
+        "vue-tsc 类型检查通过，ESLint 通过"
+      ],
+      "evidence": "vue_rules_checker 输出为空（无违规），PatchChips.vue 第 7/48/70 行使用 shadcn Button"
+    },
+    {
+      "caseId": "TC-4-01",
+      "round": 1,
+      "passed": true,
+      "execute_steps": [
+        "cd frontend && npx vue-tsc -b --noEmit",
+        "验证 exit code 0，0 error"
+      ],
+      "evidence": "vue-tsc exit 0, 无错误输出"
+    },
+    {
+      "caseId": "TC-4-02",
+      "round": 1,
+      "passed": true,
+      "execute_steps": [
+        "cd frontend && npx eslint . --max-warnings=0",
+        "验证 0 error 0 warning"
+      ],
+      "evidence": "ESLint 输出为空，exit 0"
+    },
+    {
+      "caseId": "TC-4-03",
+      "round": 1,
+      "passed": true,
+      "execute_steps": [
+        "cd frontend && npm run build",
+        "验证构建成功，生成 dist/assets/ 文件"
+      ],
+      "evidence": "Vite built in 822ms, dist/assets/index-BsnL1Amh.js 等"
+    },
+    {
+      "caseId": "TC-5-01",
+      "round": 1,
+      "passed": true,
+      "execute_steps": [
+        "npm test",
+        "验证 120 test files, 1447 tests 全部通过",
+        "确认 resilience 相关测试通过"
+      ],
+      "evidence": "vitest output: 120 passed (120), 1447 passed (1447)"
+    },
+    {
+      "caseId": "TC-6-01",
+      "round": 1,
+      "passed": true,
+      "execute_steps": [
+        "npm test — 代理相关测试通过（含 enhancement-preprocess hook 测试）",
+        "审查 create-proxy-handler.ts：确认 container 注入到 metadata",
+        "确认 enhancement-preprocess hook 从 metadata 获取 container 并正常执行"
+      ],
+      "evidence": "120 test files passed, hook 通过 proxyPipeline.emit('pre_route', ctx) 执行"
+    },
+    {
+      "caseId": "TC-6-02",
+      "round": 1,
+      "passed": true,
+      "execute_steps": [
+        "审查 create-proxy-handler.ts：确认 applyEnhancementPreprocess 内联函数已删除",
+        "确认只有 proxyPipeline.emit('pre_route', ctx) 调用点，不重复执行",
+        "npm run build 通过 — 编译确认无残留引用"
+      ],
+      "evidence": "grep 'applyEnhancementPreprocess' 在 create-proxy-handler.ts 中无结果"
+    },
+    {
+      "caseId": "TC-7-01",
+      "round": 1,
+      "passed": true,
+      "execute_steps": [
+        "npm run build（含 router tsc + frontend vite build）",
+        "验证两者均成功"
+      ],
+      "evidence": "router: tsc 编译成功; frontend: Vite built in 822ms"
+    },
+    {
+      "caseId": "TC-7-02",
+      "round": 1,
+      "passed": true,
+      "execute_steps": [
+        "npm run lint -w router → 0 error 0 warning",
+        "cd frontend && npx eslint . --max-warnings=0 → 0 error 0 warning"
+      ],
+      "evidence": "两个 lint 命令均 exit 0，无输出"
+    }
+  ]
+}

--- a/.xyz-harness/2026-05-18-improvement/changes/evidence/test_results.md
+++ b/.xyz-harness/2026-05-18-improvement/changes/evidence/test_results.md
@@ -1,0 +1,58 @@
+---
+verdict: pass
+all_passing: true
+---
+
+# Test Results — 前后端代码审查改进
+
+## Backend Build
+
+```
+npm run build
+✓ TypeScript compilation successful
+✓ Frontend built in 1.03s
+```
+
+## Backend Lint
+
+```
+npm run lint -w router
+eslint . --max-warnings=0
+(0 errors, 0 warnings)
+```
+
+## Backend Tests
+
+```
+npm test
+Test Files  120 passed (120)
+     Tests  1447 passed (1447)
+  Duration  28.26s
+```
+
+**All 120 test files, 1447 tests passed.**
+
+## Frontend Lint
+
+```
+cd frontend && npx eslint . --max-warnings=0
+(0 errors, 0 warnings)
+```
+
+**Frontend lint passed.**
+
+## Frontend Type Check
+
+```
+cd frontend && npx vue-tsc -b --noEmit
+(0 errors)
+```
+
+## Frontend Build
+
+```
+cd frontend && npm run build
+✓ built in 1.03s
+```
+
+**Frontend build passed.**

--- a/.xyz-harness/2026-05-18-improvement/changes/reviews/code_review_v1.md
+++ b/.xyz-harness/2026-05-18-improvement/changes/reviews/code_review_v1.md
@@ -1,0 +1,61 @@
+---
+verdict: pass
+must_fix: 0
+---
+
+# Code Review — 前后端代码审查改进
+
+## Summary
+
+21 个文件变更，净减 190 行代码（+144 / -334）。所有改动符合 spec 要求，build/lint/test 全部通过。0 MUST FIX。
+
+## 变更清单
+
+### 后端（2 文件）
+
+| 文件 | 改动 | 验证 |
+|------|------|------|
+| `resilience.ts` | errMsg 三元表达式去重 | 逻辑等价，纯代码清理 |
+| `create-proxy-handler.ts` | 注入 container + 删除内联 applyEnhancementPreprocess（-78 行）+ catch PipelineAbort | hook 与内联版本逻辑一致，不会重复执行。PipelineAbort catch 覆盖了 disconnect/422/其他三种情况 |
+
+### 前端新增（4 文件）
+
+| 文件 | 内容 |
+|------|------|
+| `utils/format.ts` | 追加 toIsoStart/toIsoEnd/formatBytes/formatSize/formatContextWindow 到已有文件 |
+| `utils/model-patches.ts` | computeDefaultPatches 完整版 |
+| `types/concurrency.ts` | ConcurrencyMode type |
+| `types/models.ts` | RetryRule + RouterKey interfaces |
+
+### 前端修改（15 文件）
+
+| 改动类型 | 文件 | 验证 |
+|---------|------|------|
+| R1 clipboard | Monitor.vue | copiedId 逐行追踪，3 处 v-if 和 @click 全部替换正确 |
+| R2 认证 | App.vue + router/index.ts | App.vue 只保留 import + computed，认证逻辑 100% 由 router guard 驱动 |
+| R3 button | PatchChips.vue | 原生 `<button>` → `<Button variant="outline" size="sm">`，保留 active 样式 |
+| R4a | useDashboard.ts, useLogFilters.ts | toIsoStart/toIsoEnd 删除 + import |
+| R4b | RuntimePanel.vue, LogRequestViewer.vue | formatBytes/formatSize 删除 + import |
+| R4c | CascadingModelSelect.vue, ModelCard.vue | formatContextWindow 统一为 3 分支版本 |
+| R4d | useFetchUpstreamModels.ts, useProviderPresets.ts, useQuickSetup.ts | computeDefaultPatches 提取，前两处传 false |
+| R4e | useProviderForm.ts, useQuickSetup.ts, ModelCapabilitiesEditor.vue | ConcurrencyMode → types/concurrency |
+| R4f | RetryRules.vue, RouterKeys.vue | interface → types/models |
+
+## Issues Found
+
+### LOW 级
+
+1. **ModelCapabilitiesEditor.vue import 路径**: 该文件原来从 `useProviderForm` import ConcurrencyMode，subagent 遗漏了这个消费文件。已手动修复改为从 `@/types/concurrency` import。
+
+2. **useQuickSetup.ts 重复常量**: subagent 未完全删除 `computeDefaultPatches` 函数体，残留了一个重复的 `DEFAULT_CONCURRENCY` 声明导致 TS2451。已手动修复。
+
+## Verdict
+
+所有 AC 覆盖：
+- AC1 (clipboard): copiedId 逐行追踪 ✓
+- AC2/AC3 (认证): router guard 单一来源 + isAuthenticated ref ✓
+- AC4 (PatchChips): shadcn Button ✓
+- AC5/AC6 (提取): 4 个新文件 + 12 个消费文件修改 ✓
+- AC7 (errMsg): 三元去重 ✓
+- AC8 (enhancement-preprocess): container 注入 + 内联删除 ✓
+- AC9 (门禁): build + lint + test 全通过 ✓

--- a/.xyz-harness/2026-05-18-improvement/changes/reviews/plan_review_v1.md
+++ b/.xyz-harness/2026-05-18-improvement/changes/reviews/plan_review_v1.md
@@ -1,0 +1,34 @@
+---
+verdict: pass
+must_fix: 0
+---
+
+# Plan Review — 前后端代码审查改进
+
+## Summary
+
+Plan 分 4 组（A 后端修复 / B 前端提取 / C 前端 bug / D 决策记录），执行顺序合理，依赖关系清晰。0 MUST FIX。
+
+## Issues Found
+
+### INFO 级（不阻塞）
+
+1. **R6 hook 执行顺序风险**: Plan 中将 `proxyPipeline.emit("pre_route", ctx)` 的 `.catch()` 改为 try-catch 并处理 `PipelineAbort`。但 `pre_route` 阶段还有 `client-detection` hook（priority 更高，先执行）。如果 `client-detection` 抛异常，当前 catch 也会将其作为 PipelineAbort 处理——需要确认 `client-detection` 不会抛 PipelineAbort（它只设置 metadata，不应抛异常）。
+
+   **评估**: `client-detection` 只做 `metadata.set()`，不抛异常。风险可接受。
+
+2. **R4c formatContextWindow 行为变更**: CascadingModelSelect.vue 原来小于 1M 的值全部显示为 K（如 500 → "0.5K"），合并后改为直接显示原始数字（500 → "500"）。这是一个可见的 UI 行为变化，但更合理（500 tokens 不应该显示为 0.5K）。
+
+   **评估**: 变化合理，不是 bug。如果用户之前习惯看到 "0.5K"，现在看到 "500"，体验更好。
+
+3. **C2 认证重构的边界情况**: 如果 router guard 中 `api.getStats()` 请求失败（网络错误而非 401），guard 会将用户踢到 `/login`。这是当前行为，不是新问题。
+
+   **评估**: 保持现有行为即可。
+
+## Verdict Justification
+
+- 4 组任务分工清晰，Group A 和 B 可并行
+- 每个任务的文件列表、操作类型、详细步骤完整
+- R6 的关键风险点（hook 与内联重复执行）已有明确的解决方案（删除内联 + 修改 catch 逻辑）
+- 验证步骤覆盖 build/lint/test 三道门禁
+- Subagent 分配合理（3 个 agent，2 批次）

--- a/.xyz-harness/2026-05-18-improvement/changes/reviews/spec_review_v1.md
+++ b/.xyz-harness/2026-05-18-improvement/changes/reviews/spec_review_v1.md
@@ -1,0 +1,34 @@
+---
+verdict: pass
+must_fix: 0
+---
+
+# Spec Review — 前后端代码审查改进
+
+## Summary
+
+前后端合并 spec，分两层：Tier 1 共 6 项低风险修复（4 前端 + 2 后端），Tier 1 个架构决策（Pipeline 死代码）。需求边界清晰，AC 可测试。
+
+## Issues Found
+
+无 MUST FIX 问题。
+
+### 建议（不阻塞）
+
+1. **R6 内联版本删除策略**: spec 说"建议方案 1 删除内联调用"，但 `applyEnhancementPreprocess` 在 `create-proxy-handler.ts:136-190` 共 55 行，除了依赖注入问题外，可能还处理了一些 hook 没有覆盖的边界情况。plan 阶段需要仔细对比 hook 和内联版本的每一行逻辑，确认 hook 覆盖了所有分支。
+   - 严重性: INFO
+   - 风险: 如果 hook 遗漏了内联版本的某个分支，删除内联后会引入 bug
+
+2. **D1 决策时机**: 如果选择"选项 C 标记+文档"，建议在 plan 中明确标记的格式和位置（统一注释模板），避免只加零散注释。
+   - 严重性: INFO
+
+3. **R4d getDefaultPatches 合并**: `useQuickSetup.ts` 的 `computeDefaultPatches` 额外处理 `isNonOpenaiEndpoint` 和 `openai-responses`。提取后前两处传 `isNonOpenaiEndpoint = false`，但需要确认 `apiType` 参数的类型收窄不会影响 behavior——前两处传 `string`，第三处之前是 union type `'openai' | 'openai-responses' | 'anthropic'`。
+   - 严重性: INFO
+
+## Verdict Justification
+
+- Tier 1 六项需求均有明确现状/期望/修复方案/受影响文件
+- Tier 2 仅做决策记录，不实施代码改动，风险可控
+- 10 条 AC 全部可测试，覆盖功能正确性和质量门禁
+- 影响范围和约束边界清晰
+- 不引入新依赖、不改变用户行为（除 bug 修复外）

--- a/.xyz-harness/2026-05-18-improvement/e2e-test-plan.md
+++ b/.xyz-harness/2026-05-18-improvement/e2e-test-plan.md
@@ -1,0 +1,86 @@
+---
+verdict: pass
+---
+
+# E2E Test Plan — 前后端代码审查改进
+
+## 测试策略
+
+本项目无前端 E2E 自动化测试框架（无 Cypress/Playwright），验证方式为：
+
+- **后端**: 现有 vitest 集成测试（`buildApp` + `app.inject`）覆盖请求全链路
+- **前端**: 类型检查 + ESLint + 手动功能验证
+
+## 测试场景
+
+### R1: Monitor clipboard 独立状态
+
+**验证方式**: 手动
+
+1. 启动 `npm run dev`，登录后进入 Monitor 页面
+2. 等待至少 2 个活跃请求出现
+3. 点击第一个请求的复制按钮 → 只有第一行显示 CheckIcon
+4. 点击第二个请求的复制按钮 → 只有第二行显示 CheckIcon，第一行已恢复
+5. 2 秒后 CheckIcon 全部恢复为 CopyIcon
+
+### R2: 认证单一来源
+
+**验证方式**: 手动 + 现有测试
+
+1. 未登录状态访问 `/` → 重定向到 `/login`
+2. 登录后 → 跳转到 dashboard，Sidebar 正常显示（无闪烁）
+3. 刷新页面 → Sidebar 正常显示
+4. 从 Dashboard 切到 Providers → Sidebar 不闪烁
+5. 访问 `/setup`（已初始化）→ 重定向到 `/login`
+6. 清除数据库重新启动 → 自动跳到 `/setup`
+
+**自动化覆盖**: `tests/auth.test.ts` 已覆盖认证中间件的基本场景。
+
+### R3: PatchChips 使用 shadcn Button
+
+**验证方式**: 自动化（pre-commit hook）+ 手动
+
+1. 修改 PatchChips.vue 后运行 `python3 .githooks/vue_rules_checker.py frontend/src/components/quick-setup/PatchChips.vue`
+2. 确认无 `<button>` 原生元素报错
+3. 启动 `cd frontend && npm run dev`，进入 QuickSetup 页面
+4. PatchChips toggle 按钮样式与项目其他 Button 一致
+5. 点击 toggle 正常工作（选中/取消选中）
+
+### R4: 重复函数提取
+
+**验证方式**: 自动化（类型检查 + build）
+
+1. `cd frontend && npx vue-tsc -b --noEmit` — 无类型错误
+2. `cd frontend && npx eslint . --max-warnings=0` — 无 lint 错误
+3. `cd frontend && npm run build` — 构建成功
+4. 各页面功能不变（Dashboard 图表、Logs 日志查看、QuickSetup 模型选择等）
+
+### R5: errMsg 三元表达式
+
+**验证方式**: 现有测试
+
+1. `npx vitest run tests/` — resilience 相关测试通过
+2. 触发 upstream 错误时，日志中 `errMsg` 正确显示（非 undefined）
+
+### R6: enhancement-preprocess Hook 执行
+
+**验证方式**: 现有测试 + 手动
+
+1. `npx vitest run tests/` — 代理相关测试通过
+2. 启用 enhancement 的 tool_call_loop_enabled
+3. 发送连续重复工具调用的请求 → 触发循环检测，请求被中断
+4. 确认日志中 `tool_guard` snapshot 存在（证明 hook 执行了）
+5. 确认不出现重复执行（同一请求只触发一次循环检测）
+
+## 测试环境
+
+```bash
+# 后端
+npm run dev  # 端口 9980
+
+# 前端
+cd frontend && npm run dev  # 自动代理到 9980
+
+# 测试
+npm test
+```

--- a/.xyz-harness/2026-05-18-improvement/frontend-impr.md
+++ b/.xyz-harness/2026-05-18-improvement/frontend-impr.md
@@ -1,0 +1,459 @@
+# 前端代码审查改进清单
+
+> 审查日期：2026-05-18
+> 审查范围：frontend/src 全部业务代码（排除 ui/ 组件库，约 80 个文件、~16,800 行）
+> Zoom-out 复审：经逐项代码验证，大部分问题在管理后台场景下不构成实际影响，精简为 4 项可操作改进。
+
+---
+
+## 需要修复的问题（4 项）
+
+---
+
+### 1. Monitor.vue clipboard 状态全局共享 bug
+
+#### 位置
+
+`frontend/src/views/Monitor.vue` L59-61, L109-111, L160-162（3 个列表的复制按钮）
+
+#### 根因
+
+`useClipboard()` composable（`composables/useClipboard.ts`）返回的 `copied` 是**模块级单例 ref**：
+
+```typescript
+// composables/useClipboard.ts
+export function useClipboard() {
+  const copied = ref(false)       // <-- 模块作用域，所有调用者共享同一个 ref
+  // ...
+  return { copied, copy }
+}
+```
+
+Monitor.vue 解构后直接在模板中使用这个全局 `copied`：
+
+```vue
+<!-- Monitor.vue L306 -->
+const { copied, copy } = useClipboard()
+
+<!-- L60: 活跃请求列表 -->
+<CheckIcon v-if="copied" class="size-3 text-success" />
+
+<!-- L110: 队列请求列表 -->
+<CheckIcon v-if="copied" class="size-3 text-success" />
+
+<!-- L161: 已完成请求列表 -->
+<CheckIcon v-if="copied" class="size-3 text-success" />
+```
+
+3 个列表共约 N 个复制按钮全部绑定到同一个 `copied` 布尔值。`copy()` 执行后设置 `copied = true`，2 秒后恢复 `false`。期间所有按钮的 `v-if="copied"` 同时为 true。
+
+#### 用户影响
+
+复制任意一个请求 ID，**所有列表中所有行**同时显示绿色 CheckIcon，2 秒后同时恢复。用户无法确认到底复制了哪个 ID。
+
+#### 正确参考实现
+
+`views/Logs.vue` L386-394 使用 `copiedId` 模式，逐行独立：
+
+```typescript
+const { copy } = useClipboard()                 // 只用 copy，不用 copied
+const copiedId = ref<string | null>(null)        // 独立追踪
+
+function copyLogId(id: string) {
+  copy(id)
+  copiedId.value = id
+  setTimeout(() => { if (copiedId.value === id) copiedId.value = null }, 2000)
+}
+```
+
+模板中 `v-if="copiedId === log.id"` 逐行比对。
+
+#### 修复方案
+
+Monitor.vue 中引入 `copiedId: ref<string | null>(null)`，3 个列表的 CheckIcon 改为 `v-if="copiedId === req.id"`。
+
+#### 受影响文件
+
+| 文件 | 改动 |
+|------|------|
+| `views/Monitor.vue` | 新增 `copiedId` ref，修改 3 处 `v-if` |
+
+---
+
+### 2. 认证逻辑双重实现 — router guard + App.vue 各做一遍
+
+#### 位置
+
+- `frontend/src/router/index.ts` L65-92（beforeEach guard）
+- `frontend/src/App.vue` L38-57（checkAuth + watch）
+
+#### 根因
+
+认证检查在两个独立位置各自实现，逻辑重叠但行为不完全一致：
+
+**Router guard**（`router/index.ts` L65-92）：
+```typescript
+router.beforeEach(async (to, _from, next) => {
+  if (!setupChecked) {
+    const status = await api.getSetupStatus()       // 调用 1: 检查是否已初始化
+    // ... setup 重定向逻辑 ...
+  }
+  if (to.meta.requiresAuth && isSetupInitialized) {
+    try {
+      await api.getStats()                           // 调用 2: 探测认证状态
+      next()
+    } catch {
+      next('/login')
+    }
+  } else {
+    next()
+  }
+})
+```
+
+**App.vue**（L38-57）：
+```typescript
+const publicPages = ['/login', '/setup']             // 硬编码公开页列表，与 router meta.requiresAuth 独立维护
+
+async function checkAuth() {
+  if (publicPages.includes(route.path)) { ... return }
+  try {
+    await api.getStats()                             // 调用 3: 再次探测认证状态（冗余）
+    isAuthenticated.value = true
+  } catch (err) {
+    isAuthenticated.value = false
+    // ... setup/login 重定向 ...
+  }
+}
+
+checkAuth()                                          // 组件初始化时执行一次
+watch(() => route.path, () => {                      // 每次路由变化执行
+  isAuthenticated.value = !publicPages.includes(route.path)  // 同步置 false
+})
+```
+
+#### 问题链
+
+1. **冗余 API 调用**: 每次导航到认证页面，router guard 调 1 次 `api.getStats()`，App.vue `checkAuth()` 再调 1 次 = 2 次
+2. **Sidebar 闪烁**: App.vue 的 `watch(route.path)` 在路由变化时**同步**置 `isAuthenticated = false`（因为新 path 不在 publicPages 中），然后 `checkAuth()` 异步完成后才置 `true`。这个 `false → true` 的间隔可能导致 Sidebar 短暂消失
+3. **双重维护**: 新增公开页面需同时修改 `router/index.ts`（去掉 `meta.requiresAuth`）和 `App.vue`（加入 `publicPages` 数组），两套逻辑
+
+#### 修复方案
+
+1. 删除 App.vue 中的 `checkAuth()`、`publicPages`、`watch(route.path)`
+2. `isAuthenticated` 改为 computed：`computed(() => route.meta.requiresAuth !== true || guard 已通过)`
+3. 具体：App.vue 不再做认证探测，只根据 `route.meta.requiresAuth` 决定布局（有 requiresAuth → 带 Sidebar，无 → 全屏 router-view）。认证拦截完全由 router guard 负责。
+
+#### 受影响文件
+
+| 文件 | 改动 |
+|------|------|
+| `App.vue` | 删除 checkAuth/watch/publicPages，isAuthenticated 改为基于 route.meta 的 computed |
+| `router/index.ts` | 可能需要 export 一个响应式 `isAuthenticated` 供 App.vue 使用，或在 guard 中设置 route.meta 标记 |
+
+---
+
+### 3. PatchChips.vue 使用原生 `<button>` 违反项目规范
+
+#### 位置
+
+`frontend/src/components/quick-setup/PatchChips.vue` L45-56（template 区域）
+
+#### 根因
+
+PatchChips 的 toggle 按钮直接使用原生 `<button>` 元素：
+
+```vue
+<button
+  v-for="item in group.items"
+  :key="item.id"
+  type="button"
+  :title="t(item.descKey)"
+  :class="cn(
+    'inline-flex items-center gap-1.5 rounded-md border px-2 py-1 text-xs font-medium transition-all cursor-pointer select-none',
+    isActive(item.id)
+      ? 'border-[var(--ring)] bg-[var(--primary)]/10 text-[var(--primary)]'
+      : 'border-[var(--border)] bg-transparent text-[var(--muted-foreground)] ...',
+  )"
+  @click="toggle(item.id)"
+>
+```
+
+项目规范要求所有 UI 交互元素使用 shadcn-vue 组件（pre-commit hook `vue_rules_checker.py` 会扫描 `<button` 标签并拦截提交）。
+
+#### 用户影响
+
+功能正常，但：
+- pre-commit hook 会拦截提交，开发者需要 `SKIP_CODE_RULES_CHECK=1` 才能提交
+- 视觉风格与其他页面的 chip/tag 控件不一致（缺少 shadcn 的 focus ring、hover 态等标准交互反馈）
+
+#### 修复方案
+
+替换为 shadcn `<Button>`：
+
+```vue
+<Button
+  v-for="item in group.items"
+  :key="item.id"
+  variant="outline"
+  size="sm"
+  :aria-pressed="isActive(item.id)"
+  :title="t(item.descKey)"
+  :class="cn(/* active/inactive 颜色覆盖 */)"
+  @click="toggle(item.id)"
+>
+```
+
+需要在 `<script setup>` 中添加 `import { Button } from '@/components/ui/button'`。
+
+#### 受影响文件
+
+| 文件 | 改动 |
+|------|------|
+| `components/quick-setup/PatchChips.vue` | `<button>` → `<Button>`, 添加 import |
+
+---
+
+### 4. 6 组重复工具函数/类型提取到共享模块
+
+同一函数/类型在 2-3 个文件中各自定义，逻辑相同但分别维护。改动一处时容易遗漏其他处。
+
+---
+
+#### 4a. `toIsoStart` / `toIsoEnd` — 日期边界格式化
+
+**重复位置**：
+
+| 文件 | 行号 | 签名 |
+|------|------|------|
+| `composables/useDashboard.ts` | L22-31 | 顶层函数，完全相同 |
+| `composables/useLogFilters.ts` | L52-61 | 嵌套在 composable 内的局部函数，完全相同 |
+
+**代码**（两处一字不差）：
+```typescript
+function toIsoStart(dateStr: string): string {
+  if (dateStr.includes('T')) return `${dateStr}:00.000Z`
+  return `${dateStr}T00:00:00.000Z`
+}
+
+function toIsoEnd(dateStr: string): string {
+  if (dateStr.includes('T')) return `${dateStr}:59.999Z`
+  return `${dateStr}T23:59:59.999Z`
+}
+```
+
+**提取目标**: `utils/format.ts`
+
+---
+
+#### 4b. `formatBytes` / `formatSize` — 字节数格式化
+
+**重复位置**：
+
+| 文件 | 行号 | 函数名 | 用途 |
+|------|------|--------|------|
+| `components/monitor/RuntimePanel.vue` | L77 | `formatBytes` | 格式化内存字节数（B/KB/MB） |
+| `components/log-viewer/LogRequestViewer.vue` | L324 | `formatSize` | 格式化文本编码长度（B/KB） |
+
+**代码差异**：
+
+```typescript
+// RuntimePanel.vue — formatBytes
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes}B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)}MB`
+}
+
+// LogRequestViewer.vue — formatSize（先计算 text 编码长度再格式化）
+function formatSize(text: string): string {
+  const bytes = new TextEncoder().encode(text).length
+  if (bytes < BYTES_PER_KB) return `${bytes}B`
+  return `${(bytes / BYTES_PER_KB).toFixed(1)}KB`
+}
+```
+
+两者不是完全相同的函数：`formatBytes` 接收 number，`formatSize` 接收 string 并先计算编码长度。`formatSize` 只到 KB 级别，没有 MB 分支。
+
+**提取目标**: `utils/format.ts`，两个函数分别导出（不强行合并，签名和用途不同）。
+
+---
+
+#### 4c. `formatContextWindow` / `formatCw` — 上下文窗口数字格式化
+
+**重复位置**：
+
+| 文件 | 行号 | 函数名 |
+|------|------|--------|
+| `components/mappings/CascadingModelSelect.vue` | L28 | `formatContextWindow` |
+| `components/quick-setup/ModelCard.vue` | L80 | `formatCw` |
+
+**代码差异**：
+
+```typescript
+// CascadingModelSelect.vue
+function formatContextWindow(cw: number): string {
+  if (cw >= 1_000_000) return `${cw / 1_000_000}M`
+  return `${cw / 1_000}K`          // 注意：小于 1M 的全部显示为 K（包括很小的值如 500 → 0.5K）
+}
+
+// ModelCard.vue
+function formatCw(n: number): string {
+  if (n >= 1_000_000) return `${n / 1_000_000}M`
+  if (n >= 1_000) return `${n / 1_000}K`
+  return `${n}`                     // 小于 1K 的直接显示原始数字
+}
+```
+
+逻辑不完全相同：ModelCard 版本多一个 `< 1K` 的分支。需要合并为一个函数，取更完整的版本（ModelCard 的 3 分支）。
+
+**提取目标**: `utils/format.ts`，统一为 `formatContextWindow`
+
+---
+
+#### 4d. `getDefaultPatches` — DeepSeek 模型默认 patch 计算
+
+**重复位置**（3 处）：
+
+| 文件 | 行号 | 签名 | 关键词检测 |
+|------|------|------|-----------|
+| `composables/useFetchUpstreamModels.ts` | L21 | `(modelName: string, apiType: string)` | `'deepseek'` 常量 |
+| `composables/useProviderPresets.ts` | L82 | `(modelName: string, apiType: string)` | `'deepseek'` 常量 |
+| `composables/useQuickSetup.ts` | L322 → 委托 L44 `computeDefaultPatches` | `(modelName, format, isNonOpenaiEndpoint)` | `'deepseek'` 内联判断 |
+
+**代码对比**：
+
+`useFetchUpstreamModels.ts` 和 `useProviderPresets.ts` 的实现完全相同：
+```typescript
+function getDefaultPatches(modelName: string, apiType: string): string[] {
+  const patches: string[] = []
+  if (modelName.toLowerCase().includes('deepseek')) {
+    patches.push('thinking-consistency')
+    if (apiType === 'anthropic') {
+      patches.push('orphan-tool-results')
+    } else {
+      patches.push('orphan-tool-results-oa')
+    }
+  }
+  return patches
+}
+```
+
+`useQuickSetup.ts` 的版本更复杂（通过 `computeDefaultPatches` L44），额外处理：
+- `isNonOpenaiEndpoint` → 追加 `developer-role` patch
+- `format === 'openai-responses'` → 追加 `anthropic-arguments` patch
+
+```typescript
+function computeDefaultPatches(
+  modelName: string,
+  format: 'openai' | 'openai-responses' | 'anthropic',
+  isNonOpenaiEndpoint: boolean,
+): string[] {
+  const patches: string[] = []
+  const isDeepseek = modelName.toLowerCase().includes('deepseek')
+  if (isDeepseek) {
+    patches.push('thinking-consistency')
+    if (format === 'anthropic') patches.push('orphan-tool-results')
+    else patches.push('orphan-tool-results-oa')
+  }
+  if (format === 'openai' && isNonOpenaiEndpoint) patches.push('developer-role')
+  if (format === 'openai-responses') patches.push('anthropic-arguments')
+  return patches
+}
+```
+
+**提取方案**: 将 `computeDefaultPatches` 的完整版本提取到 `utils/model-patches.ts`。`useFetchUpstreamModels` 和 `useProviderPresets` 调用时传 `isNonOpenaiEndpoint = false`（保持原有行为）。`getDefaultPatches` 统一为调用 `computeDefaultPatches` 的简化签名。
+
+**提取目标**: `utils/model-patches.ts`
+
+---
+
+#### 4e. `ConcurrencyMode` 类型
+
+**重复位置**：
+
+| 文件 | 行号 | 定义 |
+|------|------|------|
+| `composables/useProviderForm.ts` | L21 | `export type ConcurrencyMode = "auto" \| "manual" \| "none"` |
+| `composables/useQuickSetup.ts` | L14 | `export type ConcurrencyMode = 'auto' \| 'manual' \| 'none'` |
+
+签名完全相同，仅引号风格不同（双引号 vs 单引号）。
+
+`useQuickSetup.ts` L128, L225, L456 使用此类型。`useProviderForm.ts` L104, L239 使用此类型。
+
+**提取目标**: `types/concurrency.ts`
+
+---
+
+#### 4f. `RetryRule` / `RouterKey` 接口
+
+**重复位置**：
+
+| 文件 | 行号 | 接口 |
+|------|------|------|
+| `views/RetryRules.vue` | L203 | `interface RetryRule { id, name, status_code, body_pattern, is_active, created_at, retry_strategy, retry_delay_ms, max_retries, max_delay_ms }` |
+| `views/RouterKeys.vue` | L148 | `interface RouterKey { id, name, key, key_prefix, allowed_models, is_active, created_at }` |
+
+这两个接口对应后端 DB 表结构，各仅在 1 个 view 文件中使用。提取的收益是：如果未来其他组件需要引用这些类型（比如通用详情弹窗），不需要重复定义。
+
+**提取目标**: `types/models.ts`
+
+---
+
+#### 4 组总影响范围
+
+| 操作 | 文件 |
+|------|------|
+| 新增 | `utils/format.ts`, `utils/model-patches.ts`, `types/concurrency.ts`, `types/models.ts` |
+| 修改（删除内联定义 + 添加 import） | `useDashboard.ts`, `useLogFilters.ts`, `RuntimePanel.vue`, `LogRequestViewer.vue`, `CascadingModelSelect.vue`, `ModelCard.vue`, `useFetchUpstreamModels.ts`, `useProviderPresets.ts`, `useQuickSetup.ts`, `useProviderForm.ts`, `RetryRules.vue`, `RouterKeys.vue` |
+
+---
+
+## 评估后决定不修的项（含理由）
+
+### 架构类 — 抽象收益 < 引入的复杂度
+
+| # | 原问题 | 涉及文件 | 不修理由 |
+|---|--------|---------|---------|
+| A1 | CRUD 5 页重复 ~600 行 | RetryRules.vue, RouterKeys.vue, Schedules.vue, Providers.vue, ProxyEnhancement.vue | 各页面业务差异大：RetryRules 有推荐规则批量添加、RouterKeys 有密钥脱敏+allowed_models 多选、Schedules 有 4 字段 JSON parse + JSON 级联 select、Providers 有模型编辑器+并发控制+连接测试、ProxyEnhancement 是 key-value 编辑。共性只有 dialog/editing/errors 三条 ref（~30 行），强行提取 `useCrudForm<T>` 抽象层 > 节省的重复代码 |
+| A2 | useDashboard 280 行 composable | composables/useDashboard.ts | Dashboard 功能本身就多：provider 列表选择 + 4 种时间维度（5h/weekly/monthly/custom）+ model/key/clientType 筛选 + 3 个图表数据 + 6 个指标卡。280 行是合理的编排复杂度，拆成 3 个 composable 后 Dashboard.vue 需要分别 import 并串联调用，复杂度转移而非消除 |
+| A3 | Setup/Login 90% 模板重复 | views/Setup.vue, views/Login.vue | 两个文件共 ~220 行。提取 AuthLayout 后变成 3 个文件 ~260 行（多出 props 定义、slot 设计、接口约束）。布局（logo + card + theme toggle）自项目创建以来从未改过，提取收益约等于零 |
+| A4 | ModelCapabilitiesEditor 30+ Props | components/providers/ModelCapabilitiesEditor.vue | 这是对 provider 的全部模型进行 capabilities 批量编辑的组件，字段多是业务需要。改为受控对象模式需重写整个 v-model 体系（30+ 个双向绑定），改动大风险高收益小 |
+| A5 | LogResponseViewer 414 行 | components/log-viewer/LogResponseViewer.vue | 功能确实复杂：非流式 OpenAI/Anthropic 格式化 + 流式 SSE 事件重组 + 原始事件查看，3 种模式 + 4 个 tab。拆分后每个子组件仍需大量 props 传递，文件数增加但理解成本不降 |
+| A6 | Providers handleSave 在 view 中 | views/Providers.vue | 保存流程只在这里用一次，移到 composable 只是挪位置，不改善任何可度量指标 |
+| A7 | Sidebar doRestart 内联轮询 | components/layout/Sidebar.vue | 重启轮询是 Sidebar 独有功能，interval 在 `onUnmounted` 中清理，Vue 组件卸载时浏览器也会清理，不构成内存泄漏 |
+
+### 性能类 — 管理后台场景下不构成实际问题
+
+| # | 原问题 | 涉及文件 | 不修理由 |
+|---|--------|---------|---------|
+| P1 | chartOptions 在模板中返回新对象 | views/Dashboard.vue | `<Line>` 已通过 `:key="'tps-' + periodTab + '-' + selectedProvider"` 强制重挂载（key 变化才重建），chartOptions 返回新对象不是热路径问题 |
+| P2 | useMonitorData O(n) find | composables/useMonitorData.ts | 活跃请求通常 < 20，SSE 频率每秒几条，O(n) vs Map O(1) 差异是纳秒级 |
+| P3 | useSSEParsing 14 个 computed 遍历 | composables/useSSEParsing.ts | computed 惰性求值，模板只引用用到的几个。SSE 事件通常 < 200，不是瓶颈 |
+| P4 | JSON.parse 双重执行 | views/Logs.vue | computed 有缓存，每条日志的 raw body 只解析一次，不在渲染循环中重复调用 |
+| P5 | now ticker 3 秒全子树 re-render | views/Monitor.vue | Vue VDOM diff 很快，管理后台 3 秒一次 re-render 完全可接受 |
+| P6 | RetryRules 串行创建推荐规则 | views/RetryRules.vue | 推荐规则通常 3-5 条，串行 await 耗时 < 1 秒，不值得改为 Promise.allSettled |
+| P7 | ProxyEnhancement 串行加载 | views/ProxyEnhancement.vue | 页面加载时执行一次，体感差异为零 |
+
+### 一致性/精简类 — 不影响功能，ROI 极低
+
+| # | 原问题 | 不修理由 |
+|---|--------|---------|
+| C1 | 内联 SVG vs lucide 图标混用 | 功能正常，视觉一致，只是代码风格差异 |
+| C2 | 加载状态处理不一致 | 部分页面数据加载快看不到空白，不影响功能 |
+| C3 | ProxyConfigForm Options API 风格 | 功能正常，TypeScript 推断够用 |
+| C4 | Usage 网格模板重复 3 次 | 每个 context 的数据映射略有不同，强行提取增加理解成本 |
+| C5 | Dashboard 3 个 chart 卡片重复 | v-for 重构后模板更难理解（需看配置数组才能知道渲染了什么） |
+| C6 | api/client.ts 521 行 | 按领域拆分后每个文件需 import axios 实例，调用方 import 路径全要改，影响面大收益小 |
+| C7 | 魔术常量分散 | 常量只在定义处和一两处使用，集中到 constants.ts 增加跳转距离 |
+| C8 | Viewer 控制栏模板重复 | 两处代码各 ~10 行，提取后反而多一个文件 |
+| C9 | StatusCodePanel sumRange | 数据量极小，不是性能问题 |
+
+### 错误处理类 — 不构成实际风险
+
+| # | 原问题 | 不修理由 |
+|---|--------|---------|
+| E1 | useProviderActions copyKey 无 try-catch | 管理后台必然 HTTPS，clipboard API 不会 reject |
+| E2 | ModelMappings buildEntries 弹 toast | 正常数据不会触发 JSON.parse 失败，异常数据是 DB 损坏，toast 提示合理 |
+| E3 | QuickSetup validateConfig 不返回 boolean | submit() 内部在 validateConfig 之前不做其他事，当前流程不会有遗漏 |
+| E4 | useMonitorSSE 无限重连 | 指数退避到 30s 后永远重试，对于管理后台是正确行为——后端恢复后自动连接，不需要用户手动刷新 |

--- a/.xyz-harness/2026-05-18-improvement/plan.md
+++ b/.xyz-harness/2026-05-18-improvement/plan.md
@@ -1,0 +1,353 @@
+---
+verdict: pass
+---
+
+# 前后端代码审查改进 — 实施计划
+
+## 复杂度评估
+
+**L1（简单）**：6 项独立修复，无跨需求依赖，无业务逻辑变更，无 DB 变更。
+
+## 任务分组与执行顺序
+
+```
+Group A（后端独立，零依赖）→ Group B（前端 R4 共享模块提取）→ Group C（前端独立 bug 修复）→ Group D（D1 决策记录）
+```
+
+Group A 和 Group B 之间无依赖，可并行。Group C 依赖 Group B（因为 R1 Monitor 可能用到 `useClipboard` 改动后的 import）。
+
+---
+
+## Group A: 后端修复（R5 + R6）
+
+独立于前端，零交叉依赖。
+
+| # | 文件 | 操作 | 说明 |
+|---|------|------|------|
+| A1 | `router/src/proxy/orchestration/resilience.ts` | modify | R5: L241 三元表达式去重 |
+| A2 | `router/src/proxy/handler/create-proxy-handler.ts` | modify | R6: 注入 container 到 metadata + 删除 `applyEnhancementPreprocess` 函数及调用 |
+
+### A1 详细步骤
+
+`resilience.ts` L241:
+```typescript
+// Before
+const errMsg = err instanceof Error ? err.message : err instanceof Error ? err.message : JSON.stringify(err);
+// After
+const errMsg = err instanceof Error ? err.message : JSON.stringify(err);
+```
+
+### A2 详细步骤
+
+`create-proxy-handler.ts`:
+
+1. **L277**（注入 container）: 在 `ctx.metadata.set("db", db)` 之后加 `ctx.metadata.set("container", container)`
+2. **删除 L136-190**：整个 `applyEnhancementPreprocess` 函数定义（55 行）
+3. **删除 L287-297**：调用 `applyEnhancementPreprocess` 的 try-catch 块
+4. **清理 import**：删除不再需要的 import（`loadEnhancementConfig`、`ToolLoopGuard`、`SessionTracker`、`PipelineAbort`、`applyToolRoundLimit`、`extractLastToolUse`、`HTTP_UNPROCESSABLE_ENTITY`、`HTTP_CLIENT_CLOSED`、`TIER2_LOOP_THRESHOLD`）
+
+**注意**: 删除内联版本后，`enhancement-preprocess` hook 通过 Pipeline emit 执行。hook 内的 `throw PipelineAbort` 会被 `proxyPipeline.emit("pre_route", ctx).catch(...)` 捕获，但当前 `.catch` 只记日志不发送 reply。需要修改 `.catch` 处理逻辑，识别 `PipelineAbort` 并发送响应（类似当前内联版本的 try-catch 行为）。
+
+具体修改：
+```typescript
+// L279 当前代码
+await proxyPipeline.emit("pre_route", ctx).catch(err => {
+  request.log.error({ err }, "pre_route hook failed");
+});
+
+// 改为
+try {
+  await proxyPipeline.emit("pre_route", ctx);
+} catch (e) {
+  if (e instanceof PipelineAbort) {
+    if (e.statusCode === HTTP_CLIENT_CLOSED && (e.body as Record<string, unknown>)?._disconnect) {
+      reply.raw.destroy();
+      return reply;
+    }
+    return reply.code(e.statusCode).send(e.body);
+  }
+  request.log.error({ err: e }, "pre_route hook failed");
+}
+```
+
+这与当前内联版本的 try-catch 行为一致。
+
+### A 验证
+
+```bash
+npm run build
+npm run lint -w router
+npm test
+```
+
+---
+
+## Group B: 前端 R4 共享模块提取
+
+先创建共享文件，再修改消费文件。4 个新文件互不依赖，可同时创建。
+
+| # | 文件 | 操作 | 说明 |
+|---|------|------|------|
+| B1 | `frontend/src/utils/format.ts` | create | R4a/R4b/R4c: toIsoStart, toIsoEnd, formatBytes, formatSize, formatContextWindow |
+| B2 | `frontend/src/utils/model-patches.ts` | create | R4d: computeDefaultPatches |
+| B3 | `frontend/src/types/concurrency.ts` | create | R4e: ConcurrencyMode type |
+| B4 | `frontend/src/types/models.ts` | create | R4f: RetryRule, RouterKey interfaces |
+| B5 | `frontend/src/composables/useDashboard.ts` | modify | R4a: 删除 toIsoStart/toIsoEnd，改为 import |
+| B6 | `frontend/src/composables/useLogFilters.ts` | modify | R4a: 删除 toIsoStart/toIsoEnd，改为 import |
+| B7 | `frontend/src/components/monitor/RuntimePanel.vue` | modify | R4b: 删除 formatBytes，改为 import |
+| B8 | `frontend/src/components/log-viewer/LogRequestViewer.vue` | modify | R4b: 删除 formatSize，改为 import |
+| B9 | `frontend/src/components/mappings/CascadingModelSelect.vue` | modify | R4c: 删除 formatContextWindow，改为 import |
+| B10 | `frontend/src/components/quick-setup/ModelCard.vue` | modify | R4c: 删除 formatCw，改为 import |
+| B11 | `frontend/src/composables/useFetchUpstreamModels.ts` | modify | R4d: 删除 getDefaultPatches + DEFAULT_PATCHES_BY_KEYWORD，改为 import computeDefaultPatches |
+| B12 | `frontend/src/composables/useProviderPresets.ts` | modify | R4d: 同上 |
+| B13 | `frontend/src/composables/useQuickSetup.ts` | modify | R4d: 删除 computeDefaultPatches + ConcurrencyMode，改为 import |
+| B14 | `frontend/src/composables/useProviderForm.ts` | modify | R4e: 删除 ConcurrencyMode，改为 import |
+| B15 | `frontend/src/views/RetryRules.vue` | modify | R4f: 删除 RetryRule interface，改为 import |
+| B16 | `frontend/src/views/RouterKeys.vue` | modify | R4f: 删除 RouterKey interface，改为 import |
+
+### B1 详细: `utils/format.ts`
+
+```typescript
+/** 日期字符串 → ISO 开始时间（00:00:00.000Z） */
+export function toIsoStart(dateStr: string): string {
+  if (dateStr.includes('T')) return `${dateStr}:00.000Z`
+  return `${dateStr}T00:00:00.000Z`
+}
+
+/** 日期字符串 → ISO 结束时间（23:59:59.999Z） */
+export function toIsoEnd(dateStr: string): string {
+  if (dateStr.includes('T')) return `${dateStr}:59.999Z`
+  return `${dateStr}T23:59:59.999Z`
+}
+
+/** 字节数 → 可读字符串（B / KB / MB） */
+export function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes}B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)}MB`
+}
+
+/** 文本内容 → 编码字节大小可读字符串（B / KB） */
+export function formatSize(text: string): string {
+  const bytes = new TextEncoder().encode(text).length
+  if (bytes < 1024) return `${bytes}B`
+  return `${(bytes / 1024).toFixed(1)}KB`
+}
+
+const CONTEXT_MILLION = 1_000_000
+const CONTEXT_THOUSAND = 1_000
+
+/** 上下文窗口数字 → 可读字符串（n / nK / nM） */
+export function formatContextWindow(n: number): string {
+  if (n >= CONTEXT_MILLION) return `${n / CONTEXT_MILLION}M`
+  if (n >= CONTEXT_THOUSAND) return `${n / CONTEXT_THOUSAND}K`
+  return `${n}`
+}
+```
+
+### B2 详细: `utils/model-patches.ts`
+
+提取 `useQuickSetup.ts` 的 `computeDefaultPatches`（功能最完整的版本）。`useFetchUpstreamModels` 和 `useProviderPresets` 调用时传 `isNonOpenaiEndpoint = false`。
+
+```typescript
+/** 根据模型名称和 API 格式计算默认 patches */
+export function computeDefaultPatches(
+  modelName: string,
+  format: string,
+  isNonOpenaiEndpoint: boolean,
+): string[] {
+  const patches: string[] = []
+  const isDeepseek = modelName.toLowerCase().includes('deepseek')
+  if (isDeepseek) {
+    patches.push('thinking-consistency')
+    if (format === 'anthropic') {
+      patches.push('orphan-tool-results')
+    } else {
+      patches.push('orphan-tool-results-oa')
+    }
+  }
+  if (format === 'openai' && isNonOpenaiEndpoint) {
+    patches.push('developer-role')
+  }
+  if (format === 'openai-responses') {
+    patches.push('anthropic-arguments')
+  }
+  return patches
+}
+```
+
+### B3 详细: `types/concurrency.ts`
+
+```typescript
+export type ConcurrencyMode = 'auto' | 'manual' | 'none'
+```
+
+### B4 详细: `types/models.ts`
+
+```typescript
+export interface RetryRule {
+  id: string
+  name: string
+  status_code: number
+  body_pattern: string
+  is_active: number
+  created_at: string
+  retry_strategy: 'fixed' | 'exponential'
+  retry_delay_ms: number
+  max_retries: number
+  max_delay_ms: number
+}
+
+export interface RouterKey {
+  id: string
+  name: string
+  key: string | null
+  key_prefix: string
+  allowed_models: string[] | null
+  is_active: number
+  created_at: string
+}
+```
+
+### B11/B12 适配细节
+
+`useFetchUpstreamModels.ts` 和 `useProviderPresets.ts` 原来用：
+```typescript
+patches: getDefaultPatches(name, form.value.api_type)
+```
+改为：
+```typescript
+patches: computeDefaultPatches(name, form.value.api_type, false)
+```
+同时删除 `DEFAULT_PATCHES_BY_KEYWORD` 常量。
+
+### B13 适配细节
+
+`useQuickSetup.ts` 原来用：
+```typescript
+patches: getDefaultPatches(name, preset.apiType)  // 调 computeDefaultPatches(name, format, isNonOpenaiEndpoint.value)
+```
+改为：
+```typescript
+patches: computeDefaultPatches(name, preset.apiType, isNonOpenaiEndpoint.value)
+```
+同时删除 `ConcurrencyMode` type 定义和 `computeDefaultPatches` / `getDefaultPatches` 函数定义。
+
+### B 验证
+
+```bash
+cd frontend && npx vue-tsc -b --noEmit
+cd frontend && npx eslint . --max-warnings=0
+cd frontend && npm run build
+```
+
+---
+
+## Group C: 前端 bug 修复（R1 + R2 + R3）
+
+3 个独立 bug 修复，互不依赖，可并行。
+
+| # | 文件 | 操作 | 说明 |
+|---|------|------|------|
+| C1 | `frontend/src/views/Monitor.vue` | modify | R1: clipboard 状态独立化 |
+| C2a | `frontend/src/App.vue` | modify | R2: 删除 checkAuth/watch/publicPages |
+| C2b | `frontend/src/router/index.ts` | modify | R2: export isAuthenticated ref，guard 中驱动 |
+| C3 | `frontend/src/components/quick-setup/PatchChips.vue` | modify | R3: button → Button |
+
+### C1 详细步骤: Monitor.vue clipboard
+
+1. 修改 import：从 `useClipboard` 只取 `copy`，不再取 `copied`
+2. 新增 `copiedId: ref<string | null>(null)`
+3. 新增 `copyId(id: string)` 函数：`copy(id) → copiedId.value = id → setTimeout(() => { if (copiedId.value === id) copiedId.value = null }, 2000)`
+4. 模板中 3 处 `v-if="copied"` 改为 `v-if="copiedId === req.id"`
+5. 模板中 3 处 `@click.stop="copy(req.id)"` 改为 `@click.stop="copyId(req.id)"`
+
+### C2 详细步骤: 认证统一
+
+**router/index.ts**:
+1. 新增 `export const isAuthenticated = ref(true)`
+2. beforeEach guard 中：
+   - setup 未初始化 + 非 setup 页面 → `next('/setup')`，置 `isAuthenticated.value = false`
+   - setup 已初始化 + 认证页面 → `api.getStats()` 成功 → `isAuthenticated.value = true` + `next()`，失败 → `isAuthenticated.value = false` + `next('/login')`
+   - setup/login 页面 → `isAuthenticated.value = false` + `next()`
+
+**App.vue**:
+1. 删除 `isAuthenticated` ref 定义
+2. 删除 `publicPages` 数组
+3. 删除 `checkAuth()` 函数
+4. 删除 `checkAuth()` 调用
+5. 删除 `watch(() => route.path, ...)`
+6. 改为 `import { isAuthenticated } from '@/router'`
+7. 模板中 `v-if="isAuthenticated"` 使用 import 的 ref
+
+### C3 详细步骤: PatchChips button
+
+1. 添加 `import { Button } from '@/components/ui/button'`
+2. `<button>` → `<Button variant="outline" size="sm">`
+3. 保持 `:class` 的 active/inactive 样式切换
+4. 添加 `:aria-pressed="isActive(item.id)"`
+5. 删除 `type="button"`（Button 组件默认 type="button"）
+
+### C 验证
+
+```bash
+cd frontend && npx vue-tsc -b --noEmit
+cd frontend && npx eslint . --max-warnings=0
+cd frontend && npm run build
+```
+
+---
+
+## Group D: D1 决策记录
+
+| # | 文件 | 操作 | 说明 |
+|---|------|------|------|
+| D1 | `.xyz-harness/2026-05-18-improvement/backend-impr.md` | modify | 追加决策选项和选定结果 |
+
+选定**选项 C（标记 + 文档）**，理由：
+- 当前分支是 refactor-perf-bug-fix，不适合做大范围架构改动
+- 选项 B（删除）有价值但需要单独的 spec/plan
+- 选项 C 零风险，减少未来开发者的困惑
+
+### D1 实施
+
+在 `backend-impr.md` 末尾追加：
+
+```markdown
+## 决策记录
+
+### D1. Pipeline 死代码 — 选项 C: 标记 + 文档
+
+**决策日期**: 2026-05-18
+**选定选项**: C（标记 + 文档）
+**理由**: 当前分支 scope 为 bug 修复和小重构，大范围删除或架构改动需要单独的 spec/plan。
+**下一步**: 在下一个迭代中评估选项 B（删除 828 行死代码）。
+```
+
+不需要改代码文件。
+
+---
+
+## 全局验证（所有 Group 完成后）
+
+```bash
+# 后端
+npm run build
+npm run lint -w router
+npm test
+
+# 前端
+cd frontend && npx vue-tsc -b --noEmit
+cd frontend && npx eslint . --max-warnings=0
+cd frontend && npm run build
+```
+
+## Subagent 分配建议
+
+| Batch | Group | Subagent 数量 | 说明 |
+|-------|-------|--------------|------|
+| 1 | A (后端) + B (前端提取) | 2 | 独立，可并行 |
+| 2 | C (前端 bug) | 1 | 3 个小修复，1 个 agent 足够 |
+| 3 | D (决策记录) | 0 | 主 agent 直接做 |
+
+总计 3 个 subagent，分 2 批执行。

--- a/.xyz-harness/2026-05-18-improvement/spec.md
+++ b/.xyz-harness/2026-05-18-improvement/spec.md
@@ -1,0 +1,482 @@
+---
+verdict: pass
+---
+
+# 前后端代码审查改进
+
+## Background
+
+2026-05-18 对项目全量代码进行审查：
+
+- **前端**: `frontend/src` 约 80 个业务文件、~16,800 行
+- **后端**: `router/src/` 全部 172 个 TS 文件、~20,352 行
+
+经 zoom-out 复审，将前端 41 项发现精简为 4 项可操作改进，后端发现 2 类问题：低风险 bug 修复 + 插件化架构死代码问题。
+
+详细发现记录在：
+- 前端: `.xyz-harness/2026-05-18-improvement/frontend-impr.md`
+- 后端: `.xyz-harness/2026-05-18-improvement/backend-impr.md`
+
+## 需求分层
+
+本 spec 分两层：
+
+- **Tier 1 — 可立即实施的修复**（6 项）：明确修复方案，低风险，不涉及架构决策
+- **Tier 2 — 需要架构决策的问题**（1 组）：后端 Pipeline 死代码，需要先决定策略再实施
+
+---
+
+# Tier 1: 可立即实施的修复
+
+---
+
+## R1. Monitor.vue clipboard 状态全局共享 bug
+
+### 现状
+
+`useClipboard()` composable（`composables/useClipboard.ts`）返回的 `copied` 是**模块级单例 ref**——所有调用者共享同一个布尔值。
+
+```typescript
+// composables/useClipboard.ts
+export function useClipboard() {
+  const copied = ref(false)  // 模块作用域，所有调用者共享
+  // ...
+  return { copied, copy }
+}
+```
+
+Monitor.vue 3 个列表（活跃/队列/已完成）的所有复制按钮都绑定到同一个 `copied`：
+
+```vue
+<!-- L60, L110, L161 — 三处完全相同 -->
+<CheckIcon v-if="copied" class="size-3 text-success" />
+```
+
+### 期望
+
+只有被点击的那一行显示 CheckIcon，其余行不受影响。
+
+### 参考实现
+
+`views/Logs.vue` L386-394 使用 `copiedId` 逐行追踪模式：
+
+```typescript
+const { copy } = useClipboard()                 // 只用 copy
+const copiedId = ref<string | null>(null)
+
+function copyLogId(id: string) {
+  copy(id)
+  copiedId.value = id
+  setTimeout(() => { if (copiedId.value === id) copiedId.value = null }, 2000)
+}
+// 模板中: v-if="copiedId === log.id"
+```
+
+### 修复方案
+
+Monitor.vue 引入 `copiedId: ref<string | null>(null)`，3 处 `v-if="copied"` 改为 `v-if="copiedId === req.id"`，copy 回调中设置 `copiedId`。
+
+### 受影响文件
+
+`frontend/src/views/Monitor.vue` — 1 个文件
+
+---
+
+## R2. 认证逻辑双重实现统一到 router guard
+
+### 现状
+
+两处独立实现认证检查，各自调用 `api.getStats()` 探测：
+
+**Router guard**（`router/index.ts` L65-92）：
+- `beforeEach` 检查 `to.meta.requiresAuth`
+- 未认证 → `next('/login')`
+
+**App.vue**（L38-57）：
+- `checkAuth()` 也调 `api.getStats()`
+- `watch(route.path)` 每次导航**同步**置 `isAuthenticated = false`
+- 硬编码 `publicPages` 数组与 router `meta.requiresAuth` 独立维护
+
+### 问题链
+
+1. **冗余 API 调用**: 每次导航触发 2 次 `api.getStats()`
+2. **Sidebar 闪烁**: watch 先同步置 false，checkAuth 异步完成后置 true，Sidebar 短暂消失
+3. **双重维护**: 新增公开页面需同时修改 router meta 和 App.vue `publicPages`
+
+### 修复方案
+
+1. 删除 App.vue 中的 `checkAuth()`、`publicPages`、`watch(route.path)`
+2. `isAuthenticated` 改为基于 `route.meta.requiresAuth` 的 computed 或由 router guard 驱动
+3. 认证拦截完全由 router guard 负责，App.vue 只决定布局（有 requiresAuth → 带 Sidebar，无 → 全屏）
+
+### 约束
+
+- router guard 中 `setupChecked` / `isSetupInitialized` 缓存逻辑保留
+- `markSetupDone()` export 保留
+- publicPages 判断合并到 router guard
+
+### 受影响文件
+
+`frontend/src/App.vue`、`frontend/src/router/index.ts` — 2 个文件
+
+---
+
+## R3. PatchChips.vue 原生 `<button>` 替换为 shadcn Button
+
+### 现状
+
+`components/quick-setup/PatchChips.vue` L45-56 使用原生 `<button>`，pre-commit hook `vue_rules_checker.py` 会拦截提交。
+
+### 修复方案
+
+替换为 `<Button variant="outline" size="sm">`，添加 `import { Button } from '@/components/ui/button'`。保持 toggle 行为和 active 样式。
+
+### 受影响文件
+
+`frontend/src/components/quick-setup/PatchChips.vue` — 1 个文件
+
+---
+
+## R4. 6 组重复工具函数/类型提取
+
+同一函数/类型在 2-3 个文件中各自定义，维护时改一处漏另一处。
+
+### R4a. `toIsoStart` / `toIsoEnd`
+
+**重复位置**（两处一字不差）:
+- `composables/useDashboard.ts` L22-31（顶层函数）
+- `composables/useLogFilters.ts` L52-61（composable 内局部函数）
+
+```typescript
+// 两处完全相同
+function toIsoStart(dateStr: string): string {
+  if (dateStr.includes('T')) return `${dateStr}:00.000Z`
+  return `${dateStr}T00:00:00.000Z`
+}
+function toIsoEnd(dateStr: string): string {
+  if (dateStr.includes('T')) return `${dateStr}:59.999Z`
+  return `${dateStr}T23:59:59.999Z`
+}
+```
+
+**提取目标**: `utils/format.ts`
+
+### R4b. `formatBytes` / `formatSize`
+
+**重复位置**:
+
+| 文件 | 函数名 | 签名 | 用途 |
+|------|--------|------|------|
+| `components/monitor/RuntimePanel.vue` L77 | `formatBytes` | `(bytes: number) => string` | 内存字节数 → B/KB/MB |
+| `components/log-viewer/LogRequestViewer.vue` L324 | `formatSize` | `(text: string) => string` | 文本编码长度 → B/KB |
+
+两者签名和用途不同，不强行合并，分别导出。
+
+**提取目标**: `utils/format.ts`
+
+### R4c. `formatContextWindow` / `formatCw`
+
+**重复位置**:
+
+```typescript
+// CascadingModelSelect.vue L28 — 2 分支
+function formatContextWindow(cw: number): string {
+  if (cw >= 1_000_000) return `${cw / 1_000_000}M`
+  return `${cw / 1_000}K`          // < 1M 的全部显示为 K（如 500 → 0.5K）
+}
+
+// ModelCard.vue L80 — 3 分支
+function formatCw(n: number): string {
+  if (n >= 1_000_000) return `${n / 1_000_000}M`
+  if (n >= 1_000) return `${n / 1_000}K`
+  return `${n}`                     // < 1K 显示原始数字
+}
+```
+
+合并为 ModelCard 的 3 分支版本（更完整）。
+
+**提取目标**: `utils/format.ts`，统一为 `formatContextWindow`
+
+### R4d. `getDefaultPatches`
+
+**重复位置**（3 处）:
+
+| 文件 | 行号 | 签名 | 特殊处理 |
+|------|------|------|---------|
+| `useFetchUpstreamModels.ts` | L21 | `(name, apiType: string)` | 仅 deepseek patch |
+| `useProviderPresets.ts` | L82 | `(name, apiType: string)` | 仅 deepseek patch，与前一处完全相同 |
+| `useQuickSetup.ts` | L44 `computeDefaultPatches` | `(name, format, isNonOpenaiEndpoint)` | deepseek + developer-role + anthropic-arguments |
+
+前两处实现完全相同。第三处（useQuickSetup）功能更完整，额外处理 `isNonOpenaiEndpoint` 和 `openai-responses`。
+
+**提取方案**: 将 `computeDefaultPatches` 完整版提取到 `utils/model-patches.ts`，前两处传 `isNonOpenaiEndpoint = false`。
+
+**提取目标**: `utils/model-patches.ts`
+
+### R4e. `ConcurrencyMode` 类型
+
+**重复位置**:
+
+| 文件 | 行号 | 定义 |
+|------|------|------|
+| `composables/useProviderForm.ts` | L21 | `export type ConcurrencyMode = "auto" \| "manual" \| "none"` |
+| `composables/useQuickSetup.ts` | L14 | `export type ConcurrencyMode = 'auto' \| 'manual' \| 'none'` |
+
+签名完全相同，仅引号风格不同。
+
+**提取目标**: `types/concurrency.ts`
+
+### R4f. `RetryRule` / `RouterKey` 接口
+
+**重复位置**:
+
+| 文件 | 行号 | 接口 |
+|------|------|------|
+| `views/RetryRules.vue` | L203 | `interface RetryRule { id, name, status_code, body_pattern, is_active, created_at, retry_strategy, retry_delay_ms, max_retries, max_delay_ms }` |
+| `views/RouterKeys.vue` | L148 | `interface RouterKey { id, name, key, key_prefix, allowed_models, is_active, created_at }` |
+
+对应后端 DB 表结构，提取后其他组件可复用。
+
+**提取目标**: `types/models.ts`
+
+### R4 约束
+
+- `getDefaultPatches` 签名统一后，前两处调用者传 `isNonOpenaiEndpoint = false`
+- `formatBytes` / `formatSize` 保留两个函数名（签名和用途不同）
+- `formatContextWindow` 取 ModelCard 的 3 分支版本
+- 不创建 barrel index 文件
+
+### R4 总影响范围
+
+| 操作 | 文件 |
+|------|------|
+| 新增 | `utils/format.ts`, `utils/model-patches.ts`, `types/concurrency.ts`, `types/models.ts` |
+| 修改 | `useDashboard.ts`, `useLogFilters.ts`, `RuntimePanel.vue`, `LogRequestViewer.vue`, `CascadingModelSelect.vue`, `ModelCard.vue`, `useFetchUpstreamModels.ts`, `useProviderPresets.ts`, `useQuickSetup.ts`, `useProviderForm.ts`, `RetryRules.vue`, `RouterKeys.vue` |
+
+---
+
+## R5. resilience.ts errMsg 三元表达式重复
+
+### 现状
+
+`proxy/orchestration/resilience.ts` L241:
+
+```typescript
+const errMsg = err instanceof Error ? err.message : err instanceof Error ? err.message : JSON.stringify(err);
+```
+
+第二个 `err instanceof Error` 永远不会执行（第一个条件已覆盖）。如果 err 不是 Error 实例，会错误地调用 `JSON.stringify(err)` 而不是走到第三个分支... 实际上因为两个条件完全相同，逻辑上等效于 `err instanceof Error ? err.message : JSON.stringify(err)`，功能没有 bug，但代码明显是复制粘贴错误。
+
+### 修复方案
+
+```typescript
+const errMsg = err instanceof Error ? err.message : JSON.stringify(err);
+```
+
+### 受影响文件
+
+`router/src/proxy/orchestration/resilience.ts` — 1 个文件，改 1 行
+
+---
+
+## R6. enhancement-preprocess Hook 因依赖注入遗漏而从未执行
+
+### 现状
+
+`proxy/handler/create-proxy-handler.ts` L275-285:
+
+```typescript
+ctx.metadata.set("db", db);                          // 只注入了 db
+await proxyPipeline.emit("pre_route", ctx);           // 触发 hooks
+// ...
+applyEnhancementPreprocess(request, reply, ctx, db, container);  // 内联版本（实际运行的）
+```
+
+`enhancement-preprocess` hook 内部第一行：
+
+```typescript
+if (!db || !container) return;  // container 未注入 → 静默退出
+```
+
+hook 写了 91 行完全正确的代码，但因为 emit 前遗漏了 `ctx.metadata.set("container", container)` 而从未执行。实际运行的是 `create-proxy-handler.ts:136-190` 的 55 行内联版本。
+
+### 修复方案
+
+在 emit 前注入 container：
+
+```typescript
+ctx.metadata.set("db", db);
+ctx.metadata.set("container", container);   // 新增
+await proxyPipeline.emit("pre_route", ctx);
+```
+
+注入后 hook 将正常执行，但内联版本 `applyEnhancementPreprocess` 仍会被调用——需要确认两者不会重复执行。方案有二：
+1. **最小改动**: 注入 container 让 hook 执行，删除内联调用
+2. **安全改动**: 注入 container 后保留内联调用作为 fallback，hook 内用 try-catch 包裹
+
+建议方案 1（最小改动），因为 hook 和内联版本做的是同一件事。
+
+### 受影响文件
+
+`router/src/proxy/handler/create-proxy-handler.ts` — 1-2 个文件
+
+---
+
+# Tier 2: 需要架构决策的问题
+
+---
+
+## D1. Pipeline 架构 828 行死代码
+
+### 现状
+
+项目设计了 Pipeline + Hook + Plugin 三层可扩展架构，但核心请求处理路径中**只有 `pre_route` 阶段被 emit**，其余 5 个阶段（`post_route`、`pre_transport`、`post_response`、`on_error`、`on_stream_event`）从未被 emit。
+
+结果：
+
+| 已注册 Hook | Phase | 被 emit? | 实际执行? | 实际生效的代码在哪 |
+|------------|-------|---------|----------|----------------|
+| `client-detection` | `pre_route` | 是 | 是 | hook 本身 |
+| `enhancement-preprocess` | `pre_route` | 是 | 否（R6 修复后为是） | `create-proxy-handler.ts:136-190` |
+| `allowed-models` | `post_route` | 否 | 否 | `failover-loop.ts` 内联 |
+| `overflow-redirect` | `post_route` | 否 | 否 | `failover-loop.ts` 内联 |
+| `plugin-request` | `pre_transport` | 否 | 否 | `failover-loop.ts` 内联 |
+| `provider-patches` | `pre_transport` | 否 | 否 | `failover-loop.ts` 内联 |
+| `cache-estimation` | `post_response` | 否 | 否 | `failover-loop.ts` 内联 |
+| `request-logging` | `post_response` | 否 | 否 | `proxy-logging.ts` 内联 |
+| `error-logging` | `on_error` | 否 | 否 | `failover-loop.ts` + `proxy-logging.ts` 内联 |
+
+**死代码统计**: 8 个 hook 文件 589 行 + `plugin-bridge.ts` 126 行 + `sse-event-transform.ts` 70 行 + `hook-registry.ts` 43 行 = **828 行**
+
+### 根因
+
+Hook 为"单次请求、单个 resolved target"的场景设计，但 `failover-loop.ts` 处理的是"多 target 列表 + 跨迭代累积"场景。例如：
+
+- `overflow-redirect` hook 处理单个 Target → 替换。内联版本处理 Target[] 列表 → 扩展 + 追踪 `overflowIndices`
+- `allowed-models` hook 不匹配时直接 abort(403)。内联版本过滤整个列表，保留允许的 target 继续
+
+要让 Pipeline 接管，需要扩展 `PipelineContext` 数据模型（增加 `allTargets`、`overflowIndices` 等字段），这不是简单修复。
+
+### 决策选项
+
+| 选项 | 描述 | 工作量 | 风险 |
+|------|------|--------|------|
+| A. 激活 Pipeline | 扩展 PipelineContext + 逐阶段 emit | 大（~2-3 周） | 高（核心请求路径重构） |
+| B. 删除死代码 | 删除 828 行未执行的 hook/bridge/registry | 中（~1 天） | 低（只删不执行的代码） |
+| C. 标记 + 文档 | 在死代码中加 `@internal` 注释和 README 说明 | 小（~2 小时） | 无 |
+
+### 建议
+
+不在本 spec 中实施，但需要在 `backend-impr.md` 中明确记录决策结果。推荐**选项 C**（标记 + 文档）作为当前步骤，**选项 B**（删除）作为下一个迭代。选项 A 需要单独的 spec + plan。
+
+### 关联问题（跟随 D1 决策）
+
+| 编号 | 问题 | 说明 |
+|------|------|------|
+| V3 | `plugin-bridge.ts` 从未被调用 | 跟随 D1: 选 B 则删除，选 C 则标记 |
+| V5 | Patch 层不通过插件系统接入 | 跟随 D1: 独立决策，是否将 patch 改为 TransformPlugin |
+| V7 | `SSEEventTransform` 未接入 | 跟随 D1: 选 B 则删除，选 C 则标记 |
+| V8 | `HookRegistry` 双注册 | 跟随 D1: 选 B 则删除 hook-registry.ts |
+| A1 | `failover-loop.ts` 592 行膨胀 | 跟随 D1: Pipeline 激活后自然缓解 |
+| A2 | 双层日志系统 | 可独立优化，不依赖 D1 决策 |
+
+---
+
+# Acceptance Criteria
+
+## Tier 1
+
+### AC1 (R1): Monitor clipboard 独立状态
+
+- **Given** Monitor 页面有多个活跃/队列/已完成请求
+- **When** 点击任意一行的复制按钮
+- **Then** 仅该行显示 CheckIcon，其余行保持 CopyIcon
+- **And** 2 秒后 CheckIcon 自动恢复
+
+### AC2 (R2): 认证单一来源
+
+- **Given** 应用启动
+- **When** 访问任意需要认证的页面
+- **Then** 只触发 1 次 `api.getStats()` 认证检查
+- **And** 页面加载时 Sidebar 不闪烁
+
+### AC3 (R2): 认证重定向正确
+
+- **Given** 未登录状态
+- **When** 访问 `/`、`/providers` 等认证页面
+- **Then** 重定向到 `/login`
+- **When** 访问 `/setup`（系统未初始化）
+- **Then** 正常显示 Setup 页面
+- **When** Setup 完成后
+- **Then** 跳转到 dashboard
+
+### AC4 (R3): PatchChips 使用 shadcn Button
+
+- **Given** QuickSetup 页面
+- **When** 显示 PatchChips 组件
+- **Then** 所有 toggle 按钮使用 shadcn `<Button>` 组件
+- **And** `vue_rules_checker.py` pre-commit hook 不报错
+
+### AC5 (R4a-d): 重复函数提取 — 功能不变
+
+- **Given** `utils/format.ts` 导出 `toIsoStart`、`toIsoEnd`、`formatBytes`、`formatSize`、`formatContextWindow`
+- **And** `utils/model-patches.ts` 导出 `computeDefaultPatches`
+- **Then** 所有原位置改为 import
+- **And** 各函数行为与原实现完全一致（包括 `formatContextWindow` 取 3 分支版本）
+
+### AC6 (R4e-f): 重复类型提取
+
+- **Given** `types/concurrency.ts` 导出 `ConcurrencyMode`
+- **And** `types/models.ts` 导出 `RetryRule` 和 `RouterKey`
+- **Then** 原位置改为 import
+
+### AC7 (R5): errMsg 三元表达式修复
+
+- **Given** resilience.ts catch 块
+- **Then** `errMsg` 为 `err instanceof Error ? err.message : JSON.stringify(err)`
+- **And** 无重复条件判断
+
+### AC8 (R6): enhancement-preprocess Hook 正常执行
+
+- **Given** Pipeline emit `pre_route` 前
+- **Then** `ctx.metadata` 同时包含 `db` 和 `container`
+- **And** `enhancement-preprocess` hook 正常执行（不再静默跳过）
+- **And** 内联版本 `applyEnhancementPreprocess` 不再重复调用
+
+### AC9: 全局质量门禁
+
+- **Given** 所有修改完成
+- **Then** `npm run build` 成功（router + frontend）
+- **And** `npm run lint -w router` 通过（后端 0 error 0 warning）
+- **And** `cd frontend && npx eslint . --max-warnings=0` 通过
+- **And** `cd frontend && npx vue-tsc -b --noEmit` 通过
+- **And** `npm test` 全部通过
+
+## Tier 2
+
+### AC10 (D1): 架构决策已记录
+
+- **Given** D1 的三个选项
+- **Then** `backend-impr.md` 中记录了选定选项及理由
+- **And** 如果选择 C（标记+文档），死代码文件中有 `@internal` 注释说明未执行原因
+
+---
+
+# Constraints
+
+- **不引入新依赖**: 所有改动使用现有组件和 API
+- **不改变用户行为**: 除 clipboard bug 修复外，Tier 1 所有改动对用户不可见
+- **不创建 barrel 文件**: utils/types 文件直接 import
+- **向后兼容**: `markSetupDone()` export 保留，`ConcurrencyMode` 签名不变
+- **Tier 2 不在本 spec 实施范围内**: D1 仅做决策记录，不做代码改动
+
+# Complexity Assessment
+
+| 维度 | 评估 | 说明 |
+|------|------|------|
+| Domain | 低 | 无业务逻辑变更，bug 修复 + 代码组织 |
+| Storage | 无 | 不涉及 DB 或存储变更 |
+| Data-flow | 低 | R2 认证流程简化，R6 依赖注入补全 |
+| API | 无 | 不新增/修改 API 调用 |
+| Non-functional | 低 | R2 减少冗余 API 调用 |
+| Risk | 低 | Tier 1 无架构改动，R6 有小风险（需确认 hook 和内联不重复执行） |

--- a/.xyz-harness/2026-05-18-improvement/test_cases_template.json
+++ b/.xyz-harness/2026-05-18-improvement/test_cases_template.json
@@ -1,0 +1,159 @@
+{
+  "test_cases": [
+    {
+      "id": "TC-1-01",
+      "type": "manual",
+      "title": "Monitor clipboard: 点击任一行复制只影响该行",
+      "description": "Monitor 页面有多个请求时，点击任一行的复制按钮，只有该行显示 CheckIcon",
+      "steps": [
+        "启动 dev server，进入 Monitor 页面",
+        "等待至少 2 个活跃请求",
+        "点击第一个请求的复制按钮",
+        "验证只有第一行显示 CheckIcon",
+        "点击第二个请求的复制按钮",
+        "验证只有第二行显示 CheckIcon，第一行已恢复",
+        "等待 2 秒，验证所有 CheckIcon 恢复为 CopyIcon"
+      ]
+    },
+    {
+      "id": "TC-2-01",
+      "type": "manual",
+      "title": "认证: 未登录访问受保护页面重定向到 /login",
+      "description": "未登录状态访问根路径和受保护页面，应重定向到 /login",
+      "steps": [
+        "清除 cookie/未登录状态",
+        "访问 /admin/",
+        "验证重定向到 /admin/login",
+        "访问 /admin/providers",
+        "验证重定向到 /admin/login"
+      ]
+    },
+    {
+      "id": "TC-2-02",
+      "type": "manual",
+      "title": "认证: 登录后 Sidebar 不闪烁",
+      "description": "登录成功后和页面切换时 Sidebar 稳定显示，不会短暂消失",
+      "steps": [
+        "登录成功后跳转到 dashboard",
+        "验证 Sidebar 立即显示（无闪烁）",
+        "从 Dashboard 切到 Providers",
+        "验证 Sidebar 保持显示（不闪烁）",
+        "刷新页面",
+        "验证 Sidebar 正常显示"
+      ]
+    },
+    {
+      "id": "TC-2-03",
+      "type": "manual",
+      "title": "认证: Setup 页面在未初始化时正常显示",
+      "description": "系统未初始化时访问 /setup 正常，已初始化时重定向到 /login",
+      "steps": [
+        "清空数据库",
+        "启动应用",
+        "验证自动跳转到 /setup",
+        "完成 setup",
+        "访问 /setup",
+        "验证重定向到 /login"
+      ]
+    },
+    {
+      "id": "TC-3-01",
+      "type": "manual",
+      "title": "PatchChips: 使用 shadcn Button 组件",
+      "description": "QuickSetup 页面的 PatchChips toggle 按钮使用 shadcn Button，pre-commit hook 不报错",
+      "steps": [
+        "运行 python3 .githooks/vue_rules_checker.py frontend/src/components/quick-setup/PatchChips.vue",
+        "验证无原生 button 报错",
+        "进入 QuickSetup 页面",
+        "点击 PatchChips toggle",
+        "验证选中/取消选中正常工作"
+      ]
+    },
+    {
+      "id": "TC-4-01",
+      "type": "integration",
+      "title": "R4 提取后前端类型检查通过",
+      "description": "所有共享模块提取后，vue-tsc 类型检查无错误",
+      "steps": [
+        "cd frontend && npx vue-tsc -b --noEmit",
+        "验证 0 error"
+      ]
+    },
+    {
+      "id": "TC-4-02",
+      "type": "integration",
+      "title": "R4 提取后 ESLint 通过",
+      "description": "所有共享模块提取后，ESLint 无警告无错误",
+      "steps": [
+        "cd frontend && npx eslint . --max-warnings=0",
+        "验证 0 error 0 warning"
+      ]
+    },
+    {
+      "id": "TC-4-03",
+      "type": "integration",
+      "title": "R4 提取后前端构建成功",
+      "description": "所有共享模块提取后，Vite 构建成功",
+      "steps": [
+        "cd frontend && npm run build",
+        "验证构建成功"
+      ]
+    },
+    {
+      "id": "TC-5-01",
+      "type": "integration",
+      "title": "errMsg 三元表达式修复后测试通过",
+      "description": "resilience.ts 修改后所有现有测试通过",
+      "steps": [
+        "npm test",
+        "验证全部测试通过"
+      ]
+    },
+    {
+      "id": "TC-6-01",
+      "type": "integration",
+      "title": "enhancement-preprocess Hook 正常执行",
+      "description": "注入 container 后 hook 正常执行，工具循环检测功能正常",
+      "steps": [
+        "npm test",
+        "验证代理相关测试通过",
+        "启用 tool_call_loop_enabled",
+        "发送连续重复工具调用请求",
+        "验证请求被中断，日志中有 tool_guard snapshot"
+      ]
+    },
+    {
+      "id": "TC-6-02",
+      "type": "integration",
+      "title": "enhancement-preprocess 不重复执行",
+      "description": "Hook 和内联版本不能同时执行，同一请求只触发一次循环检测",
+      "steps": [
+        "npm run build",
+        "发送触发循环检测的请求",
+        "检查日志中 tool_guard snapshot 只出现一次"
+      ]
+    },
+    {
+      "id": "TC-7-01",
+      "type": "integration",
+      "title": "全局构建验证",
+      "description": "所有修改完成后 router + frontend 构建成功",
+      "steps": [
+        "npm run build",
+        "cd frontend && npm run build",
+        "验证两者均成功"
+      ]
+    },
+    {
+      "id": "TC-7-02",
+      "type": "integration",
+      "title": "全局 Lint 验证",
+      "description": "所有修改完成后后端 + 前端 lint 通过",
+      "steps": [
+        "npm run lint -w router",
+        "cd frontend && npx eslint . --max-warnings=0",
+        "验证两者均 0 error 0 warning"
+      ]
+    }
+  ]
+}

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -10,50 +10,22 @@
     <router-view v-else />
   </template>
   <Teleport to="body">
-    <Toaster :theme="theme" richColors position="top-center" :toastOptions="{ duration: 4000 }" />
+    <Toaster
+      :theme="theme"
+      richColors
+      position="top-center"
+      :toastOptions="{ duration: 4000 }"
+    />
   </Teleport>
 </template>
 
 <script setup lang="ts">
-import { ref, watch, computed } from 'vue'
-import { useRouter, useRoute } from 'vue-router'
-import Sidebar from '@/components/layout/Sidebar.vue'
-import { Toaster } from '@/components/ui/sonner'
-import { api } from '@/api/client'
-import { isDark } from '@/composables/useTheme'
-import { localeLoaded } from '@/i18n'
+import { computed } from "vue";
+import Sidebar from "@/components/layout/Sidebar.vue";
+import { Toaster } from "@/components/ui/sonner";
+import { isDark } from "@/composables/useTheme";
+import { localeLoaded } from "@/i18n";
+import { isAuthenticated } from "@/router";
 
-const router = useRouter()
-const route = useRoute()
-const isAuthenticated = ref(false)
-
-const theme = computed(() => isDark.value ? 'dark' : 'light')
-
-// 不需要认证的页面
-const publicPages = ['/login', '/setup']
-
-async function checkAuth() {
-  if (publicPages.includes(route.path)) {
-    isAuthenticated.value = false
-    return
-  }
-  try {
-    await api.getStats()
-    isAuthenticated.value = true
-  } catch (err: unknown) {
-    isAuthenticated.value = false
-    const code = (err as { apiCode?: number }).apiCode
-    const CODE_NOT_INITIALIZED = 40_103
-    if (code === CODE_NOT_INITIALIZED) {
-      router.push('/setup')
-    } else {
-      router.push('/login')
-    }
-  }
-}
-
-checkAuth()
-watch(() => route.path, () => {
-  isAuthenticated.value = !publicPages.includes(route.path)
-})
+const theme = computed(() => (isDark.value ? "dark" : "light"));
 </script>

--- a/frontend/src/components/log-viewer/LogRequestViewer.vue
+++ b/frontend/src/components/log-viewer/LogRequestViewer.vue
@@ -1,19 +1,30 @@
 <template>
-  <Tabs :default-value="mode ?? 'structured'" :model-value="mode" class="w-full">
+  <Tabs
+    :default-value="mode ?? 'structured'"
+    :model-value="mode"
+    class="w-full"
+  >
     <!-- 粘性控制栏：结构化/原始JSON 切换 + 复制 -->
-    <div v-if="!mode" class="flex items-center justify-between py-2 border-b mb-2 sticky top-0 z-10 bg-background">
+    <div
+      v-if="!mode"
+      class="flex items-center justify-between py-2 border-b mb-2 sticky top-0 z-10 bg-background"
+    >
       <TabsList>
-        <TabsTrigger value="structured">{{ t('logs.viewer.structured') }}</TabsTrigger>
-        <TabsTrigger value="raw">{{ t('logs.viewer.rawJson') }}</TabsTrigger>
+        <TabsTrigger value="structured">{{
+          t("logs.viewer.structured")
+        }}</TabsTrigger>
+        <TabsTrigger value="raw">{{ t("logs.viewer.rawJson") }}</TabsTrigger>
       </TabsList>
       <Button variant="ghost" size="xs" class="h-auto py-1" @click="copyRaw">
-        {{ copied ? t('logs.viewer.copied') : t('logs.viewer.copyJson') }}
+        {{ copied ? t("logs.viewer.copied") : t("logs.viewer.copyJson") }}
       </Button>
     </div>
 
     <TabsContent value="structured" class="space-y-3">
       <template v-if="parseError">
-        <div class="text-destructive text-sm">{{ t('logs.viewer.parseError') }}</div>
+        <div class="text-destructive text-sm">
+          {{ t("logs.viewer.parseError") }}
+        </div>
       </template>
       <template v-else>
         <!-- Claude Code context card -->
@@ -26,23 +37,42 @@
         />
 
         <!-- URL -->
-        <div v-if="showUrl && parsed.url" class="text-xs text-muted-foreground break-all">
+        <div
+          v-if="showUrl && parsed.url"
+          class="text-xs text-muted-foreground break-all"
+        >
           {{ parsed.url }}
         </div>
 
         <!-- Parameter badges -->
         <div class="flex flex-wrap gap-2">
-          <StatPill v-if="(parsed.body as Record<string, unknown>)?.model" label="model" :value="String((parsed.body as Record<string, unknown>).model)" :highlight="true" />
-          <StatPill v-if="(parsed.body as Record<string, unknown>)?.stream != null" label="stream" :value="String((parsed.body as Record<string, unknown>).stream)" />
-          <StatPill v-if="(parsed.body as Record<string, unknown>)?.max_tokens != null" label="max_tokens" :value="String((parsed.body as Record<string, unknown>).max_tokens)" />
-          <TagPill v-if="(parsed.body as Record<string, unknown>)?.thinking != null" label="thinking" />
+          <StatPill
+            v-if="(parsed.body as Record<string, unknown>)?.model"
+            label="model"
+            :value="String((parsed.body as Record<string, unknown>).model)"
+            :highlight="true"
+          />
+          <StatPill
+            v-if="(parsed.body as Record<string, unknown>)?.stream != null"
+            label="stream"
+            :value="String((parsed.body as Record<string, unknown>).stream)"
+          />
+          <StatPill
+            v-if="(parsed.body as Record<string, unknown>)?.max_tokens != null"
+            label="max_tokens"
+            :value="String((parsed.body as Record<string, unknown>).max_tokens)"
+          />
+          <TagPill
+            v-if="(parsed.body as Record<string, unknown>)?.thinking != null"
+            label="thinking"
+          />
         </div>
 
         <!-- Headers -->
         <Collapsible v-model:open="headersOpen">
           <CollapsibleTrigger as-child>
             <Button variant="ghost" size="xs" class="px-0 h-auto">
-              {{ t('logs.viewer.headers', { count: headerEntries.length }) }}
+              {{ t("logs.viewer.headers", { count: headerEntries.length }) }}
             </Button>
           </CollapsibleTrigger>
           <CollapsibleContent>
@@ -50,8 +80,10 @@
               <Table>
                 <TableHeader>
                   <TableRow>
-                    <TableHead class="w-1/3">{{ t('logs.viewer.key') }}</TableHead>
-                    <TableHead>{{ t('logs.viewer.value') }}</TableHead>
+                    <TableHead class="w-1/3">{{
+                      t("logs.viewer.key")
+                    }}</TableHead>
+                    <TableHead>{{ t("logs.viewer.value") }}</TableHead>
                   </TableRow>
                 </TableHeader>
                 <TableBody>
@@ -71,35 +103,62 @@
           <Card v-for="(msg, idx) in messages" :key="idx" class="bg-muted/40">
             <CardHeader class="pb-2 flex flex-row items-center gap-2">
               <Badge :class="roleClass(msg.role)">{{ msg.role }}</Badge>
-              <span v-if="msg.blockSummary" class="text-xs text-muted-foreground">{{ msg.blockSummary }}</span>
+              <span
+                v-if="msg.blockSummary"
+                class="text-xs text-muted-foreground"
+                >{{ msg.blockSummary }}</span
+              >
             </CardHeader>
             <CardContent class="space-y-2">
               <div v-for="(block, bidx) in msg.blocks" :key="bidx">
                 <!-- 纯文本 -->
                 <div v-if="block.type === 'text'">
-                  <div v-if="block.text.length > 120 && !expanded[`${idx}-${bidx}`]" class="text-sm">
+                  <div
+                    v-if="
+                      block.text.length > 120 && !expanded[`${idx}-${bidx}`]
+                    "
+                    class="text-sm"
+                  >
                     {{ block.text.slice(0, 120) }}
-                    <Button variant="link" size="xs" class="px-0 h-auto" @click="expanded[`${idx}-${bidx}`] = true">{{ t('logs.viewer.expand') }}</Button>
+                    <Button
+                      variant="link"
+                      size="xs"
+                      class="px-0 h-auto"
+                      @click="expanded[`${idx}-${bidx}`] = true"
+                      >{{ t("logs.viewer.expand") }}</Button
+                    >
                   </div>
-                  <div v-else class="text-sm whitespace-pre-wrap break-all">{{ block.text }}</div>
+                  <div v-else class="text-sm whitespace-pre-wrap break-all">
+                    {{ block.text }}
+                  </div>
                 </div>
                 <!-- 有内容的标签块：可折叠 -->
-                <div v-else-if="block.text" class="text-xs text-muted-foreground">
+                <div
+                  v-else-if="block.text"
+                  class="text-xs text-muted-foreground"
+                >
                   <Collapsible>
                     <CollapsibleTrigger as-child>
                       <Button variant="ghost" size="xs" class="px-0 h-auto">
-                        <Badge :class="tagClass(block.type)" class="mr-1">{{ block.label || block.type }}</Badge>
+                        <Badge :class="tagClass(block.type)" class="mr-1">{{
+                          block.label || block.type
+                        }}</Badge>
                         {{ formatSize(block.text) }}
                       </Button>
                     </CollapsibleTrigger>
                     <CollapsibleContent>
-                      <pre class="mt-1 whitespace-pre-wrap break-all text-[11px] bg-muted rounded-md p-2 border">{{ block.text }}</pre>
+                      <pre
+                        class="mt-1 whitespace-pre-wrap break-all text-[11px] bg-muted rounded-md p-2 border"
+                        >{{ block.text }}</pre
+                      >
                     </CollapsibleContent>
                   </Collapsible>
                 </div>
                 <!-- 空内容：仅显示标签 Badge -->
                 <div v-else class="text-xs">
-                  <Badge :class="tagClass(block.type)" class="mr-1">{{ block.label || block.type }}</Badge>
+                  <Badge :class="tagClass(block.type)" class="mr-1">{{
+                    block.label || block.type
+                  }}</Badge>
                 </div>
               </div>
             </CardContent>
@@ -108,21 +167,43 @@
 
         <!-- Tools -->
         <div v-if="toolNames.length">
-          <div class="text-xs font-medium text-muted-foreground mb-1">Tools</div>
+          <div class="text-xs font-medium text-muted-foreground mb-1">
+            Tools
+          </div>
           <div class="flex flex-wrap gap-1">
-            <TagPill v-for="name in displayedToolNames" :key="name" :label="name" />
-            <Button v-if="toolNames.length > 8" variant="ghost" size="xs" class="px-1 h-5" @click="toolsExpanded = !toolsExpanded">
-              {{ toolsExpanded ? t('logs.viewer.collapse') : t('logs.viewer.moreTools', { count: toolNames.length - 8 }) }}
+            <TagPill
+              v-for="name in displayedToolNames"
+              :key="name"
+              :label="name"
+            />
+            <Button
+              v-if="toolNames.length > 8"
+              variant="ghost"
+              size="xs"
+              class="px-1 h-5"
+              @click="toolsExpanded = !toolsExpanded"
+            >
+              {{
+                toolsExpanded
+                  ? t("logs.viewer.collapse")
+                  : t("logs.viewer.moreTools", { count: toolNames.length - 8 })
+              }}
             </Button>
           </div>
         </div>
 
         <!-- System (Anthropic root-level) -->
         <div v-if="systemBlocks.length">
-          <div class="text-xs font-medium text-muted-foreground mb-1">System</div>
+          <div class="text-xs font-medium text-muted-foreground mb-1">
+            System
+          </div>
           <Card class="bg-muted/40">
             <CardContent class="space-y-2">
-              <div v-for="(blk, sidx) in systemBlocks" :key="sidx" class="text-sm whitespace-pre-wrap break-all">
+              <div
+                v-for="(blk, sidx) in systemBlocks"
+                :key="sidx"
+                class="text-sm whitespace-pre-wrap break-all"
+              >
                 <Badge variant="outline" class="mb-1">{{ blk.type }}</Badge>
                 <div v-if="blk.text">{{ blk.text }}</div>
               </div>
@@ -134,11 +215,14 @@
         <Collapsible v-if="otherFieldsKeys.length">
           <CollapsibleTrigger as-child>
             <Button variant="ghost" size="xs" class="px-0 h-auto">
-              {{ t('logs.viewer.otherFields') }}
+              {{ t("logs.viewer.otherFields") }}
             </Button>
           </CollapsibleTrigger>
           <CollapsibleContent>
-            <pre class="mt-1 whitespace-pre-wrap break-all text-xs bg-muted rounded p-2 border">{{ JSON.stringify(otherFields, null, 2) }}</pre>
+            <pre
+              class="mt-1 whitespace-pre-wrap break-all text-xs bg-muted rounded p-2 border"
+              >{{ JSON.stringify(otherFields, null, 2) }}</pre
+            >
           </CollapsibleContent>
         </Collapsible>
       </template>
@@ -151,179 +235,210 @@
 </template>
 
 <script setup lang="ts">
-import { computed, reactive, ref } from 'vue'
-import { useI18n } from 'vue-i18n'
-import { useClipboard } from '@/composables/useClipboard'
-import { Button } from '@/components/ui/button'
-import { Badge } from '@/components/ui/badge'
-import { Card, CardContent, CardHeader } from '@/components/ui/card'
-import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
-import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
-import JsonCopyBlock from './JsonCopyBlock.vue'
-import StatPill from './StatPill.vue'
-import TagPill from './TagPill.vue'
-import { roleClass, tagClass } from './logColors'
-import InfoBanner from './InfoBanner.vue'
-import { extractBlocks } from './requestBlockParser'
-import type { MsgBlock } from './requestBlockParser'
+import { computed, reactive, ref } from "vue";
+import { useI18n } from "vue-i18n";
+import { useClipboard } from "@/composables/useClipboard";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import JsonCopyBlock from "./JsonCopyBlock.vue";
+import StatPill from "./StatPill.vue";
+import TagPill from "./TagPill.vue";
+import { roleClass, tagClass } from "./logColors";
+import InfoBanner from "./InfoBanner.vue";
+import { extractBlocks } from "./requestBlockParser";
+import type { MsgBlock } from "./requestBlockParser";
+import { formatSize } from "@/utils/format";
 
 const props = defineProps<{
-  raw: string
-  apiType: 'openai' | 'anthropic'
-  showUrl?: boolean
+  raw: string;
+  apiType: "openai" | "anthropic";
+  showUrl?: boolean;
   /** 外部控制显示模式时传入，组件内部不渲染 tabs 和复制按钮 */
-  mode?: 'structured' | 'raw'
-}>()
+  mode?: "structured" | "raw";
+}>();
 
-const { t } = useI18n()
-const headersOpen = ref(false)
-const expanded = reactive<Record<string, boolean>>({})
-const toolsExpanded = ref(false)
-const { copied, copy: clipboardCopy } = useClipboard()
+const { t } = useI18n();
+const headersOpen = ref(false);
+const expanded = reactive<Record<string, boolean>>({});
+const toolsExpanded = ref(false);
+const { copied, copy: clipboardCopy } = useClipboard();
 
 const parsed = computed<Record<string, unknown>>(() => {
   try {
-    return JSON.parse(props.raw) as Record<string, unknown>
+    return JSON.parse(props.raw) as Record<string, unknown>;
   } catch {
-    return {}
+    return {};
   }
-})
+});
 
 const parseError = computed(() => {
   try {
-    JSON.parse(props.raw)
-    return false
+    JSON.parse(props.raw);
+    return false;
   } catch {
-    return true
+    return true;
   }
-})
+});
 
 async function copyRaw() {
-  await clipboardCopy(props.raw)
+  await clipboardCopy(props.raw);
 }
 
 const headerEntries = computed(() => {
-  const headers = (parsed.value.headers || {}) as Record<string, string>
-  const ALLOWED_HEADER_KEYS = new Set(Object.keys(headers))
+  const headers = (parsed.value.headers || {}) as Record<string, string>;
+  const ALLOWED_HEADER_KEYS = new Set(Object.keys(headers));
   return Object.entries(headers)
     .filter(([k]) => ALLOWED_HEADER_KEYS.has(k))
     .map(([k, v]) => {
-      if (k.toLowerCase() === 'authorization') {
-        return [k, 'Bearer sk-****'] as [string, string]
+      if (k.toLowerCase() === "authorization") {
+        return [k, "Bearer sk-****"] as [string, string];
       }
-      return [k, v] as [string, string]
-    })
-})
+      return [k, v] as [string, string];
+    });
+});
 
 const body = computed(() => {
-  const raw = parsed.value.body
+  const raw = parsed.value.body;
   // upstream_request 中 body 是二次 JSON 编码的字符串，需要再 parse 一次
-  if (typeof raw === 'string') {
-    try { return JSON.parse(raw) as Record<string, unknown> } catch { return {} }
+  if (typeof raw === "string") {
+    try {
+      return JSON.parse(raw) as Record<string, unknown>;
+    } catch {
+      return {};
+    }
   }
-  return (raw || {}) as Record<string, unknown>
-})
+  return (raw || {}) as Record<string, unknown>;
+});
 
 const isClaudeCode = computed(() => {
-  const ua = (parsed.value.headers as Record<string, string> | undefined)?.['user-agent'] || ''
-  return ua.includes('claude-cli')
-})
+  const ua =
+    (parsed.value.headers as Record<string, string> | undefined)?.[
+      "user-agent"
+    ] || "";
+  return ua.includes("claude-cli");
+});
 
 const claudeMode = computed(() => {
-  const ua = (parsed.value.headers as Record<string, string> | undefined)?.['user-agent'] || ''
-  const match = ua.match(/claude-cli\/[^\s]+\s+\(([^)]+)\)/)
-  return match ? match[1] : 'external, cli'
-})
+  const ua =
+    (parsed.value.headers as Record<string, string> | undefined)?.[
+      "user-agent"
+    ] || "";
+  const match = ua.match(/claude-cli\/[^\s]+\s+\(([^)]+)\)/);
+  return match ? match[1] : "external, cli";
+});
 
 const thinkingBudget = computed(() => {
-  const t = body.value.thinking as Record<string, unknown> | undefined
-  return t && typeof t.budget_tokens === 'number' ? t.budget_tokens : undefined
-})
+  const t = body.value.thinking as Record<string, unknown> | undefined;
+  return t && typeof t.budget_tokens === "number" ? t.budget_tokens : undefined;
+});
 
 const toolsCount = computed(() => {
-  const tools = body.value.tools as unknown[] | undefined
-  return Array.isArray(tools) ? tools.length : undefined
-})
+  const tools = body.value.tools as unknown[] | undefined;
+  return Array.isArray(tools) ? tools.length : undefined;
+});
 
 const claudeCodeDetails = computed(() => {
-  const parts: string[] = []
-  if (thinkingBudget.value != null) parts.push(t('logs.viewer.thinkingTokens', { count: thinkingBudget.value }))
-  if (toolsCount.value != null) parts.push(t('logs.viewer.toolsCount', { count: toolsCount.value }))
-  return parts
-})
+  const parts: string[] = [];
+  if (thinkingBudget.value != null)
+    parts.push(
+      t("logs.viewer.thinkingTokens", { count: thinkingBudget.value }),
+    );
+  if (toolsCount.value != null)
+    parts.push(t("logs.viewer.toolsCount", { count: toolsCount.value }));
+  return parts;
+});
 
 const messages = computed<MsgBlock[]>(() => {
-  const msgs = (body.value.messages || []) as Array<{ role: string; content: unknown }>
+  const msgs = (body.value.messages || []) as Array<{
+    role: string;
+    content: unknown;
+  }>;
   return msgs.map((m) => {
-    const blocks = extractBlocks(m.content)
+    const blocks = extractBlocks(m.content);
     // 统计非 text 的 block 类型和数量
-    const tagCounts: Record<string, number> = {}
+    const tagCounts: Record<string, number> = {};
     for (const b of blocks) {
-      if (b.type !== 'text' && b.text) {
-        tagCounts[b.type] = (tagCounts[b.type] || 0) + 1
+      if (b.type !== "text" && b.text) {
+        tagCounts[b.type] = (tagCounts[b.type] || 0) + 1;
       }
     }
-    const ALLOWED_TAG_KEYS = new Set(Object.keys(tagCounts))
-    const blockSummary = Object.entries(tagCounts)
-      .filter(([k]) => ALLOWED_TAG_KEYS.has(k))
-      .map(([t, c]) => `${t}${c > 1 ? ` x${c}` : ''}`)
-      .join(', ') || undefined
-    return { role: m.role, blocks, blockSummary }
-  })
-})
-
+    const ALLOWED_TAG_KEYS = new Set(Object.keys(tagCounts));
+    const blockSummary =
+      Object.entries(tagCounts)
+        .filter(([k]) => ALLOWED_TAG_KEYS.has(k))
+        .map(([t, c]) => `${t}${c > 1 ? ` x${c}` : ""}`)
+        .join(", ") || undefined;
+    return { role: m.role, blocks, blockSummary };
+  });
+});
 
 const toolNames = computed(() => {
-  const tools = (body.value.tools || []) as Array<{ function?: { name?: string }; name?: string }>
-  return tools.map((t) => t.function?.name || t.name || 'unknown').filter(Boolean)
-})
+  const tools = (body.value.tools || []) as Array<{
+    function?: { name?: string };
+    name?: string;
+  }>;
+  return tools
+    .map((t) => t.function?.name || t.name || "unknown")
+    .filter(Boolean);
+});
 
-const TOOL_PREVIEW_COUNT = 8
+const TOOL_PREVIEW_COUNT = 8;
 
 const displayedToolNames = computed(() => {
-  return toolsExpanded.value ? toolNames.value : toolNames.value.slice(0, TOOL_PREVIEW_COUNT)
-})
+  return toolsExpanded.value
+    ? toolNames.value
+    : toolNames.value.slice(0, TOOL_PREVIEW_COUNT);
+});
 
 const systemBlocks = computed(() => {
-  const sys = body.value.system
-  if (!sys) return [] as { type: string; text: string }[]
+  const sys = body.value.system;
+  if (!sys) return [] as { type: string; text: string }[];
   if (Array.isArray(sys)) {
-    return (sys as Array<{ type?: string; text?: string }>).map((s) => ({ type: s.type || 'text', text: s.text || '' }))
+    return (sys as Array<{ type?: string; text?: string }>).map((s) => ({
+      type: s.type || "text",
+      text: s.text || "",
+    }));
   }
-  if (typeof sys === 'string') {
-    return [{ type: 'text', text: sys }]
+  if (typeof sys === "string") {
+    return [{ type: "text", text: sys }];
   }
-  return [{ type: 'unknown', text: JSON.stringify(sys) }]
-})
+  return [{ type: "unknown", text: JSON.stringify(sys) }];
+});
 
 const knownKeys = new Set([
-  'model',
-  'stream',
-  'max_tokens',
-  'thinking',
-  'messages',
-  'tools',
-  'system',
-])
+  "model",
+  "stream",
+  "max_tokens",
+  "thinking",
+  "messages",
+  "tools",
+  "system",
+]);
 
 const otherFields = computed(() => {
-  const result: Record<string, unknown> = {}
+  const result: Record<string, unknown> = {};
   for (const key of Object.keys(body.value)) {
     if (!knownKeys.has(key)) {
-      result[key] = body.value[key]
+      result[key] = body.value[key];
     }
   }
-  return result
-})
+  return result;
+});
 
-const otherFieldsKeys = computed(() => Object.keys(otherFields.value))
-
-const BYTES_PER_KB = 1024
-
-function formatSize(text: string): string {
-  const bytes = new TextEncoder().encode(text).length
-  if (bytes < BYTES_PER_KB) return `${bytes}B`
-  return `${(bytes / BYTES_PER_KB).toFixed(1)}KB`
-}
+const otherFieldsKeys = computed(() => Object.keys(otherFields.value));
 </script>

--- a/frontend/src/components/mappings/CascadingModelSelect.vue
+++ b/frontend/src/components/mappings/CascadingModelSelect.vue
@@ -1,56 +1,57 @@
 <script setup lang="ts">
-import { computed } from 'vue'
-import { useI18n } from 'vue-i18n'
-import CascadingSelect from '@/components/ui/cascading-select/CascadingSelect.vue'
-import type { CascadingGroup, CascadingSelectedValue } from '@/components/ui/cascading-select'
-import type { ProviderGroup, SelectedValue } from './cascading-types'
+import { computed } from "vue";
+import { useI18n } from "vue-i18n";
+import CascadingSelect from "@/components/ui/cascading-select/CascadingSelect.vue";
+import type {
+  CascadingGroup,
+  CascadingSelectedValue,
+} from "@/components/ui/cascading-select";
+import type { ProviderGroup, SelectedValue } from "./cascading-types";
+import { formatContextWindow } from "@/utils/format";
 
-const { t } = useI18n()
+const { t } = useI18n();
 
-const props = withDefaults(defineProps<{
-  providers: ProviderGroup[]
-  modelValue?: SelectedValue
-  placeholder?: string
-  compact?: boolean
-}>(), {
-  placeholder: '',
-})
+const props = withDefaults(
+  defineProps<{
+    providers: ProviderGroup[];
+    modelValue?: SelectedValue;
+    placeholder?: string;
+    compact?: boolean;
+  }>(),
+  {
+    placeholder: "",
+  },
+);
 
-const resolvedPlaceholder = computed(() => props.placeholder || t('mappings.selectProviderModel'))
+const resolvedPlaceholder = computed(
+  () => props.placeholder || t("mappings.selectProviderModel"),
+);
 
 const emit = defineEmits<{
-  'update:modelValue': [value: SelectedValue]
-}>()
-
-const CONTEXT_MILLION = 1_000_000
-const CONTEXT_THOUSAND = 1_000
-
-function formatContextWindow(cw: number): string {
-  if (cw >= CONTEXT_MILLION) return `${cw / CONTEXT_MILLION}M`
-  return `${cw / CONTEXT_THOUSAND}K`
-}
+  "update:modelValue": [value: SelectedValue];
+}>();
 
 const groups = computed<CascadingGroup[]>(() =>
-  props.providers.map(g => ({
+  props.providers.map((g) => ({
     key: g.provider.id,
     label: g.provider.name,
-    badge: g.isNew ? t('common.new') : undefined,
-    options: g.models.map(m => ({
+    badge: g.isNew ? t("common.new") : undefined,
+    options: g.models.map((m) => ({
       value: m.name,
       label: m.name,
       tag: formatContextWindow(m.contextWindow),
     })),
   })),
-)
+);
 
 const selectedValue = computed<CascadingSelectedValue | undefined>(() =>
   props.modelValue
     ? { groupKey: props.modelValue.provider_id, value: props.modelValue.model }
     : undefined,
-)
+);
 
 function onUpdate(val: CascadingSelectedValue) {
-  emit('update:modelValue', { provider_id: val.groupKey, model: val.value })
+  emit("update:modelValue", { provider_id: val.groupKey, model: val.value });
 }
 </script>
 

--- a/frontend/src/components/monitor/RuntimePanel.vue
+++ b/frontend/src/components/monitor/RuntimePanel.vue
@@ -1,24 +1,37 @@
 <template>
-  <div v-if="!runtime" class="text-sm text-muted-foreground">{{ t('monitor.runtimePanel.noData') }}</div>
+  <div v-if="!runtime" class="text-sm text-muted-foreground">
+    {{ t("monitor.runtimePanel.noData") }}
+  </div>
   <div v-else class="grid grid-cols-2 gap-3 text-sm">
     <!-- 运行时间 -->
     <div>
-      <p class="text-muted-foreground">{{ t('monitor.runtimePanel.uptime') }}</p>
-      <p class="font-medium text-foreground">{{ formatUptime(runtime.uptimeMs) }}</p>
+      <p class="text-muted-foreground">
+        {{ t("monitor.runtimePanel.uptime") }}
+      </p>
+      <p class="font-medium text-foreground">
+        {{ formatUptime(runtime.uptimeMs) }}
+      </p>
     </div>
 
     <!-- 内存 RSS -->
     <div>
-      <p class="text-muted-foreground">{{ t('monitor.runtimePanel.memoryRss') }}</p>
-      <p class="font-medium text-foreground">{{ formatBytes(runtime.memoryUsage.rss) }}</p>
+      <p class="text-muted-foreground">
+        {{ t("monitor.runtimePanel.memoryRss") }}
+      </p>
+      <p class="font-medium text-foreground">
+        {{ formatBytes(runtime.memoryUsage.rss) }}
+      </p>
     </div>
 
     <!-- Heap 使用率 -->
     <div class="col-span-2">
       <div class="flex items-center justify-between">
-        <p class="text-muted-foreground">{{ t('monitor.runtimePanel.heapUsage') }}</p>
         <p class="text-muted-foreground">
-          {{ formatBytes(runtime.memoryUsage.heapUsed) }} / {{ formatBytes(runtime.memoryUsage.heapTotal) }}
+          {{ t("monitor.runtimePanel.heapUsage") }}
+        </p>
+        <p class="text-muted-foreground">
+          {{ formatBytes(runtime.memoryUsage.heapUsed) }} /
+          {{ formatBytes(runtime.memoryUsage.heapTotal) }}
         </p>
       </div>
       <div class="h-2 bg-muted rounded-full overflow-hidden mt-1">
@@ -31,52 +44,59 @@
 
     <!-- Active handles -->
     <div>
-      <p class="text-muted-foreground">{{ t('monitor.runtimePanel.activeHandles') }}</p>
+      <p class="text-muted-foreground">
+        {{ t("monitor.runtimePanel.activeHandles") }}
+      </p>
       <p class="font-medium text-foreground">{{ runtime.activeHandles }}</p>
     </div>
 
     <!-- Active requests -->
     <div>
-      <p class="text-muted-foreground">{{ t('monitor.runtimePanel.activeRequests') }}</p>
+      <p class="text-muted-foreground">
+        {{ t("monitor.runtimePanel.activeRequests") }}
+      </p>
       <p class="font-medium text-foreground">{{ runtime.activeRequests }}</p>
     </div>
 
     <!-- Event loop delay -->
     <div class="col-span-2">
-      <p class="text-muted-foreground">{{ t('monitor.runtimePanel.eventLoopDelay') }}</p>
-      <p class="font-medium text-foreground">{{ runtime.eventLoopDelayMs.toFixed(2) }}ms</p>
+      <p class="text-muted-foreground">
+        {{ t("monitor.runtimePanel.eventLoopDelay") }}
+      </p>
+      <p class="font-medium text-foreground">
+        {{ runtime.eventLoopDelayMs.toFixed(2) }}ms
+      </p>
     </div>
   </div>
 </template>
 
 <!-- eslint-disable no-magic-numbers -->
 <script setup lang="ts">
-import { computed } from 'vue'
-import { useI18n } from 'vue-i18n'
-import type { RuntimeMetrics } from '@/types/monitor'
+import { computed } from "vue";
+import { useI18n } from "vue-i18n";
+import type { RuntimeMetrics } from "@/types/monitor";
+import { formatBytes } from "@/utils/format";
 
-const { t } = useI18n()
+const { t } = useI18n();
 
 const props = defineProps<{
-  runtime: RuntimeMetrics | null
-}>()
+  runtime: RuntimeMetrics | null;
+}>();
 
 const heapPercent = computed(() => {
-  if (!props.runtime || props.runtime.memoryUsage.heapTotal === 0) return 0
-  return Math.min(100, (props.runtime.memoryUsage.heapUsed / props.runtime.memoryUsage.heapTotal) * 100)
-})
+  if (!props.runtime || props.runtime.memoryUsage.heapTotal === 0) return 0;
+  return Math.min(
+    100,
+    (props.runtime.memoryUsage.heapUsed / props.runtime.memoryUsage.heapTotal) *
+      100,
+  );
+});
 
 function formatUptime(ms: number): string {
-  const totalSeconds = Math.floor(ms / 1000)
-  const hours = Math.floor(totalSeconds / 3600)
-  const minutes = Math.floor((totalSeconds % 3600) / 60)
-  const seconds = totalSeconds % 60
-  return `${hours}h ${minutes}m ${seconds}s`
-}
-
-function formatBytes(bytes: number): string {
-  if (bytes < 1024) return `${bytes}B`
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}KB`
-  return `${(bytes / (1024 * 1024)).toFixed(1)}MB`
+  const totalSeconds = Math.floor(ms / 1000);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  return `${hours}h ${minutes}m ${seconds}s`;
 }
 </script>

--- a/frontend/src/components/providers/ModelCapabilitiesEditor.vue
+++ b/frontend/src/components/providers/ModelCapabilitiesEditor.vue
@@ -16,7 +16,7 @@ import ConcurrencyControl from "@/components/shared/ConcurrencyControl.vue";
 import TransformRulesForm from "@/components/shared/TransformRulesForm.vue";
 import ProxyConfigForm from "@/components/shared/ProxyConfigForm.vue";
 import { CONTEXT_WINDOW_OPTIONS } from "@/composables/useProviderForm";
-import type { ConcurrencyMode } from "@/composables/useProviderForm";
+import type { ConcurrencyMode } from "@/types/concurrency";
 import type { ModelInfo } from "@/types/mapping";
 import type { ModelConfig } from "@/components/quick-setup/types";
 

--- a/frontend/src/components/quick-setup/ModelCard.vue
+++ b/frontend/src/components/quick-setup/ModelCard.vue
@@ -3,6 +3,7 @@ import { ref, computed } from "vue";
 import { useI18n } from "vue-i18n";
 import type { ModelConfig } from "./types";
 import { CONTEXT_WINDOW_OPTIONS } from "./types";
+import { formatContextWindow } from "@/utils/format";
 import PatchChips from "./PatchChips.vue";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
@@ -73,15 +74,6 @@ function updateContextWindowFromInput(val: string) {
 function updatePatches(patches: string[]) {
   emit("update:model", { ...props.model, patches });
 }
-
-const CONTEXT_MILLION = 1_000_000;
-const CONTEXT_THOUSAND = 1_000;
-
-function formatCw(n: number): string {
-  if (n >= CONTEXT_MILLION) return `${n / CONTEXT_MILLION}M`;
-  if (n >= CONTEXT_THOUSAND) return `${n / CONTEXT_THOUSAND}K`;
-  return `${n}`;
-}
 </script>
 
 <template>
@@ -105,7 +97,9 @@ function formatCw(n: number): string {
           <SelectTrigger class="h-7 w-[72px] text-xs">
             <SelectValue>
               {{
-                isPreset ? matchedOption!.label : formatCw(model.contextWindow)
+                isPreset
+                  ? matchedOption!.label
+                  : formatContextWindow(model.contextWindow)
               }}
             </SelectValue>
           </SelectTrigger>

--- a/frontend/src/components/quick-setup/PatchChips.vue
+++ b/frontend/src/components/quick-setup/PatchChips.vue
@@ -1,70 +1,84 @@
 <script setup lang="ts">
-import { computed } from 'vue'
-import { useI18n } from 'vue-i18n'
-import { PATCH_GROUPS } from './types'
-import type { PatchGroup } from './types'
-import { cn } from '@/lib/utils'
+import { computed } from "vue";
+import { useI18n } from "vue-i18n";
+import { PATCH_GROUPS } from "./types";
+import type { PatchGroup } from "./types";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
 
-const { t } = useI18n()
+const { t } = useI18n();
 
 const props = defineProps<{
-  apiType: string
-  isDeepSeek: boolean
-  isNonOpenaiEndpoint: boolean
-  modelValue: string[]
-}>()
+  apiType: string;
+  isDeepSeek: boolean;
+  isNonOpenaiEndpoint: boolean;
+  modelValue: string[];
+}>();
 
 const emit = defineEmits<{
-  'update:modelValue': [value: string[]]
-}>()
+  "update:modelValue": [value: string[]];
+}>();
 
 const visibleGroups = computed<PatchGroup[]>(() => {
   return PATCH_GROUPS.filter((g) => {
-    if (g.key === 'deepseek_anthropic') return props.isDeepSeek && props.apiType === 'anthropic'
-    if (g.key === 'deepseek_openai') return props.isDeepSeek && props.apiType === 'openai'
-    if (g.key === 'general') return props.apiType === 'openai' && props.isNonOpenaiEndpoint
-    return true
-  })
-})
+    if (g.key === "deepseek_anthropic")
+      return props.isDeepSeek && props.apiType === "anthropic";
+    if (g.key === "deepseek_openai")
+      return props.isDeepSeek && props.apiType === "openai";
+    if (g.key === "general")
+      return props.apiType === "openai" && props.isNonOpenaiEndpoint;
+    return true;
+  });
+});
 
 function toggle(patchId: string) {
   const next = props.modelValue.includes(patchId)
     ? props.modelValue.filter((id) => id !== patchId)
-    : [...props.modelValue, patchId]
-  emit('update:modelValue', next)
+    : [...props.modelValue, patchId];
+  emit("update:modelValue", next);
 }
 
 function isActive(patchId: string): boolean {
-  return props.modelValue.includes(patchId)
+  return props.modelValue.includes(patchId);
 }
 </script>
 
 <template>
   <div class="space-y-3">
     <div v-for="group in visibleGroups" :key="group.key">
-      <p class="mb-1.5 text-xs font-medium text-[var(--muted-foreground)]">{{ t(group.labelKey) }}</p>
+      <p class="mb-1.5 text-xs font-medium text-[var(--muted-foreground)]">
+        {{ t(group.labelKey) }}
+      </p>
       <div class="flex flex-wrap gap-1.5">
-        <button
+        <Button
           v-for="item in group.items"
           :key="item.id"
-          type="button"
+          variant="outline"
+          size="sm"
+          :aria-pressed="isActive(item.id)"
           :title="t(item.descKey)"
-          :class="cn(
-            'inline-flex items-center gap-1.5 rounded-md border px-2 py-1 text-xs font-medium transition-all cursor-pointer select-none',
-            isActive(item.id)
-              ? 'border-[var(--ring)] bg-[var(--primary)]/10 text-[var(--primary)]'
-              : 'border-[var(--border)] bg-transparent text-[var(--muted-foreground)] hover:border-[var(--muted-foreground)] hover:text-[var(--foreground)]',
-          )"
+          :class="
+            cn(
+              'inline-flex items-center gap-1.5 rounded-md border px-2 py-1 text-xs font-medium transition-all cursor-pointer select-none',
+              isActive(item.id)
+                ? 'border-[var(--ring)] bg-[var(--primary)]/10 text-[var(--primary)]'
+                : 'border-[var(--border)] bg-transparent text-[var(--muted-foreground)] hover:border-[var(--muted-foreground)] hover:text-[var(--foreground)]',
+            )
+          "
           @click="toggle(item.id)"
         >
           <span
-            :class="cn(
-              'size-1.5 rounded-full transition-colors',
-              isActive(item.id) ? 'bg-[var(--primary)]' : 'bg-[var(--border)]',
-            )"
+            :class="
+              cn(
+                'size-1.5 rounded-full transition-colors',
+                isActive(item.id)
+                  ? 'bg-[var(--primary)]'
+                  : 'bg-[var(--border)]',
+              )
+            "
           />
           {{ t(item.nameKey) }}
-        </button>
+        </Button>
       </div>
     </div>
   </div>

--- a/frontend/src/composables/useDashboard.ts
+++ b/frontend/src/composables/useDashboard.ts
@@ -1,190 +1,201 @@
-import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
-import { useI18n } from 'vue-i18n'
-import type { ChartData } from 'chart.js'
-import { api, getApiMessage } from '@/api/client'
-import { toast } from 'vue-sonner'
-import { fillTimeseries } from '@/views/metrics-helpers'
-import { CHART_COLORS } from '@/styles/design-tokens'
-import { formatTimeShort } from '@/utils/format'
-import { watchTheme } from '@/composables/useTheme'
-import type { Provider } from '@/types/mapping'
+import { ref, computed, watch, onMounted, onUnmounted } from "vue";
+import { useI18n } from "vue-i18n";
+import type { ChartData } from "chart.js";
+import { api, getApiMessage } from "@/api/client";
+import { toast } from "vue-sonner";
+import { fillTimeseries } from "@/views/metrics-helpers";
+import { CHART_COLORS } from "@/styles/design-tokens";
+import { formatTimeShort, toIsoStart, toIsoEnd } from "@/utils/format";
+import { watchTheme } from "@/composables/useTheme";
+import type { Provider } from "@/types/mapping";
 
 export interface DashboardStats {
-  totalRequests: number
-  successRate: number
-  avgTps: number
-  totalInputTokens: number
-  totalOutputTokens: number
-  startTime: string | null
-  endTime: string | null
+  totalRequests: number;
+  successRate: number;
+  avgTps: number;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  startTime: string | null;
+  endTime: string | null;
 }
 
-function toIsoStart(dateStr: string): string {
-  if (dateStr.includes('T')) return `${dateStr}:00.000Z`
-  return `${dateStr}T00:00:00.000Z`
-}
-
-function toIsoEnd(dateStr: string): string {
-  if (dateStr.includes('T')) return `${dateStr}:59.999Z`
-  return `${dateStr}T23:59:59.999Z`
-}
-
+// eslint-disable-next-line max-lines-per-function -- dashboard composable 各部分（metrics/charts/timeline）紧密耦合，拆分会降低可读性
 export function useDashboard() {
-  const { t } = useI18n()
+  const { t } = useI18n();
 
   // --- Provider list and selection ---
-  const providers = ref<Provider[]>([])
-  const selectedProvider = ref('')
+  const providers = ref<Provider[]>([]);
+  const selectedProvider = ref("");
 
   const sortedProviders = computed(() =>
     [...providers.value].sort((a, b) => {
-      const aOut = providerOutputTokens.value[a.id] ?? 0
-      const bOut = providerOutputTokens.value[b.id] ?? 0
-      return bOut - aOut
+      const aOut = providerOutputTokens.value[a.id] ?? 0;
+      const bOut = providerOutputTokens.value[b.id] ?? 0;
+      return bOut - aOut;
     }),
-  )
+  );
 
   // --- Period tab ---
-  const periodTab = ref<'window' | 'weekly' | 'monthly' | 'custom'>('window')
-  const customStart = ref('')
-  const customEnd = ref('')
+  const periodTab = ref<"window" | "weekly" | "monthly" | "custom">("window");
+  const customStart = ref("");
+  const customEnd = ref("");
 
   // --- Filters ---
-  const modelFilter = ref('all')
-  const keyFilter = ref('all')
-  const clientType = ref('all')
-  const allModelOptions = ref<string[]>([])
-  const keyOptions = ref<{ id: string; name: string }[]>([])
+  const modelFilter = ref("all");
+  const keyFilter = ref("all");
+  const clientType = ref("all");
+  const allModelOptions = ref<string[]>([]);
+  const keyOptions = ref<{ id: string; name: string }[]>([]);
 
   const modelOptions = computed(() => {
     if (selectedProvider.value) {
-      const provider = providers.value.find((p) => p.id === selectedProvider.value)
+      const provider = providers.value.find(
+        (p) => p.id === selectedProvider.value,
+      );
       if (provider) {
-        const providerModels = new Set(provider.models.map((m) => m.name))
-        return allModelOptions.value.filter((m) => providerModels.has(m))
+        const providerModels = new Set(provider.models.map((m) => m.name));
+        return allModelOptions.value.filter((m) => providerModels.has(m));
       }
     }
-    return allModelOptions.value
-  })
+    return allModelOptions.value;
+  });
 
   // --- Time range text ---
   const timeRangeText = computed(() => {
-    const start = stats.value.startTime
-    const end = stats.value.endTime
-    if (!start || !end) return '—'
+    const start = stats.value.startTime;
+    const end = stats.value.endTime;
+    if (!start || !end) return "—";
     try {
-      return `${formatTimeShort(start)} ~ ${formatTimeShort(end)}`
+      return `${formatTimeShort(start)} ~ ${formatTimeShort(end)}`;
     } catch {
-      return '—'
+      return "—";
     }
-  })
+  });
 
   // --- API params ---
   const apiStartTime = computed(() => {
-    if (periodTab.value === 'custom' && customStart.value) {
-      return toIsoStart(customStart.value)
+    if (periodTab.value === "custom" && customStart.value) {
+      return toIsoStart(customStart.value);
     }
-    return undefined
-  })
+    return undefined;
+  });
   const apiEndTime = computed(() => {
-    if (periodTab.value === 'custom' && customEnd.value) {
-      return toIsoEnd(customEnd.value)
+    if (periodTab.value === "custom" && customEnd.value) {
+      return toIsoEnd(customEnd.value);
     }
-    return undefined
-  })
+    return undefined;
+  });
 
   const statsParams = computed(() => {
-    const p: Record<string, string> = {}
-    if (periodTab.value !== 'custom') {
-      p.period = periodTab.value
+    const p: Record<string, string> = {};
+    if (periodTab.value !== "custom") {
+      p.period = periodTab.value;
     } else if (apiStartTime.value && apiEndTime.value) {
-      p.start_time = apiStartTime.value
-      p.end_time = apiEndTime.value
+      p.start_time = apiStartTime.value;
+      p.end_time = apiEndTime.value;
     }
-    if (selectedProvider.value) p.provider_id = selectedProvider.value
-    if (modelFilter.value !== 'all') p.backend_model = modelFilter.value
-    if (keyFilter.value !== 'all') p.router_key_id = keyFilter.value
-    return p
-  })
+    if (selectedProvider.value) p.provider_id = selectedProvider.value;
+    if (modelFilter.value !== "all") p.backend_model = modelFilter.value;
+    if (keyFilter.value !== "all") p.router_key_id = keyFilter.value;
+    return p;
+  });
 
   const cacheSummaryParams = computed(() => {
-    const p: Record<string, string> = {}
-    if (periodTab.value !== 'custom') {
-      p.period = periodTab.value
+    const p: Record<string, string> = {};
+    if (periodTab.value !== "custom") {
+      p.period = periodTab.value;
     } else if (apiStartTime.value && apiEndTime.value) {
-      p.start_time = apiStartTime.value
-      p.end_time = apiEndTime.value
+      p.start_time = apiStartTime.value;
+      p.end_time = apiEndTime.value;
     }
-    if (selectedProvider.value) p.provider_id = selectedProvider.value
-    if (modelFilter.value !== 'all') p.backend_model = modelFilter.value
-    if (keyFilter.value !== 'all') p.router_key_id = keyFilter.value
-    if (clientType.value !== 'all') p.client_type = clientType.value
-    return p
-  })
+    if (selectedProvider.value) p.provider_id = selectedProvider.value;
+    if (modelFilter.value !== "all") p.backend_model = modelFilter.value;
+    if (keyFilter.value !== "all") p.router_key_id = keyFilter.value;
+    if (clientType.value !== "all") p.client_type = clientType.value;
+    return p;
+  });
 
   const timeseriesPeriod = computed(() => {
-    if (periodTab.value === 'custom' && apiStartTime.value && apiEndTime.value) {
-      return 'monthly'
+    if (
+      periodTab.value === "custom" &&
+      apiStartTime.value &&
+      apiEndTime.value
+    ) {
+      return "monthly";
     }
-    return periodTab.value as 'window' | 'weekly' | 'monthly'
-  })
+    return periodTab.value as "window" | "weekly" | "monthly";
+  });
 
   function tsParams(metric: string) {
-    const p: { period?: string; metric: string; provider_id?: string; backend_model?: string; router_key_id?: string; start_time?: string; end_time?: string } = { metric }
-    if (periodTab.value !== 'custom') {
-      p.period = periodTab.value
+    const p: {
+      period?: string;
+      metric: string;
+      provider_id?: string;
+      backend_model?: string;
+      router_key_id?: string;
+      start_time?: string;
+      end_time?: string;
+    } = { metric };
+    if (periodTab.value !== "custom") {
+      p.period = periodTab.value;
     } else if (apiStartTime.value && apiEndTime.value) {
-      p.start_time = apiStartTime.value
-      p.end_time = apiEndTime.value
+      p.start_time = apiStartTime.value;
+      p.end_time = apiEndTime.value;
     }
-    if (selectedProvider.value) p.provider_id = selectedProvider.value
-    if (modelFilter.value !== 'all') p.backend_model = modelFilter.value
-    if (keyFilter.value !== 'all') p.router_key_id = keyFilter.value
-    return p
+    if (selectedProvider.value) p.provider_id = selectedProvider.value;
+    if (modelFilter.value !== "all") p.backend_model = modelFilter.value;
+    if (keyFilter.value !== "all") p.router_key_id = keyFilter.value;
+    return p;
   }
 
   // --- Data state ---
   const stats = ref<DashboardStats>({
-    totalRequests: 0, successRate: 0, avgTps: 0,
-    totalInputTokens: 0, totalOutputTokens: 0,
-    startTime: null, endTime: null,
-  })
-  const cacheHitRate = ref(0)
-  const clientTypeBreakdown = ref<Record<string, number>>({})
-  const tpsChartData = ref<ChartData<'line'> | null>(null)
-  const inputTokensChartData = ref<ChartData<'line'> | null>(null)
-  const outputTokensChartData = ref<ChartData<'line'> | null>(null)
-  const loading = ref(false)
+    totalRequests: 0,
+    successRate: 0,
+    avgTps: 0,
+    totalInputTokens: 0,
+    totalOutputTokens: 0,
+    startTime: null,
+    endTime: null,
+  });
+  const cacheHitRate = ref(0);
+  const clientTypeBreakdown = ref<Record<string, number>>({});
+  const tpsChartData = ref<ChartData<"line"> | null>(null);
+  const inputTokensChartData = ref<ChartData<"line"> | null>(null);
+  const outputTokensChartData = ref<ChartData<"line"> | null>(null);
+  const loading = ref(false);
 
   // --- Per-provider output tokens (for sorting) ---
-  const providerOutputTokens = ref<Record<string, number>>({})
+  const providerOutputTokens = ref<Record<string, number>>({});
 
   function toChartData(
     timeseries: { labels: string[]; values: number[] },
     label: string,
     color: string,
-  ): ChartData<'line'> {
+  ): ChartData<"line"> {
     return {
       labels: timeseries.labels,
-      datasets: [{
-        label,
-        data: timeseries.values,
-        borderColor: color,
-        backgroundColor: color.replace(')', ' / 0.1)'),
-        fill: false,
-        tension: 0.4,
-        pointRadius: 0,
-      }],
-    }
+      datasets: [
+        {
+          label,
+          data: timeseries.values,
+          borderColor: color,
+          backgroundColor: color.replace(")", " / 0.1)"),
+          fill: false,
+          tension: 0.4,
+          pointRadius: 0,
+        },
+      ],
+    };
   }
 
   // --- Fetch providers ---
   async function loadProviders() {
     try {
-      providers.value = await api.getProviders()
+      providers.value = await api.getProviders();
     } catch (e: unknown) {
-      console.error('Failed to load providers:', e)
-      toast.error(getApiMessage(e, t('dashboard.loadProvidersFailed')))
+      console.error("Failed to load providers:", e);
+      toast.error(getApiMessage(e, t("dashboard.loadProvidersFailed")));
     }
   }
 
@@ -194,183 +205,224 @@ export function useDashboard() {
       const [models, keys] = await Promise.allSettled([
         api.getAvailableModels(),
         api.getRouterKeys(),
-      ])
-      if (models.status === 'fulfilled') allModelOptions.value = models.value
-      if (keys.status === 'fulfilled') keyOptions.value = keys.value
+      ]);
+      if (models.status === "fulfilled") allModelOptions.value = models.value;
+      if (keys.status === "fulfilled") keyOptions.value = keys.value;
     } catch (e: unknown) {
-      console.error('Failed to load filter options:', e)
+      console.error("Failed to load filter options:", e);
       /* 非关键操作：filter 缺失不影响主仪表盘功能 */
-      toast.error(getApiMessage(e, t('dashboard.loadFilterFailed')))
+      toast.error(getApiMessage(e, t("dashboard.loadFilterFailed")));
     }
   }
 
   // --- Fetch provider output tokens for sorting ---
   async function loadProviderOutputTokens() {
-    if (providers.value.length === 0) return
-    if (periodTab.value === 'custom' && !(apiStartTime.value && apiEndTime.value)) return
+    if (providers.value.length === 0) return;
+    if (
+      periodTab.value === "custom" &&
+      !(apiStartTime.value && apiEndTime.value)
+    )
+      return;
     // 复用 summary API，一次请求获取所有 provider 的 output tokens
-    const params: Record<string, string> = { ...statsParams.value }
-    delete params.provider_id
-    delete params.backend_model
-    delete params.router_key_id
+    const params: Record<string, string> = { ...statsParams.value };
+    delete params.provider_id;
+    delete params.backend_model;
+    delete params.router_key_id;
     try {
-      const summary = await api.getMetricsSummary(params)
-      const map: Record<string, number> = {}
+      const summary = await api.getMetricsSummary(params);
+      const map: Record<string, number> = {};
       if (summary.rows && Array.isArray(summary.rows)) {
         for (const row of summary.rows) {
           if (row.provider_id) {
-            map[row.provider_id] = row.total_output_tokens || 0
+            map[row.provider_id] = row.total_output_tokens || 0;
           }
         }
       }
-      providerOutputTokens.value = map
+      providerOutputTokens.value = map;
       if (Object.keys(map).length > 0 && !selectedProvider.value) {
-        const top = sortedProviders.value[0]
-        if (top) selectedProvider.value = top.id
+        const top = sortedProviders.value[0];
+        if (top) selectedProvider.value = top.id;
       }
     } catch (e: unknown) {
-      console.error('Failed to load output tokens:', e)
+      console.error("Failed to load output tokens:", e);
       /* 非关键操作：provider 排序降级为默认顺序 */
-      toast.error(getApiMessage(e, t('dashboard.loadOutputTokensFailed')))
+      toast.error(getApiMessage(e, t("dashboard.loadOutputTokensFailed")));
     }
   }
 
   // --- Fetch stats + timeseries ---
   async function refresh() {
-    if (!selectedProvider.value) return
-    if (periodTab.value === 'custom' && !(apiStartTime.value && apiEndTime.value)) return
+    if (!selectedProvider.value) return;
+    if (
+      periodTab.value === "custom" &&
+      !(apiStartTime.value && apiEndTime.value)
+    )
+      return;
     // 相同参数 5s 内不重复请求
-    const key = watchKey.value
-    const now = Date.now()
-    if (key === lastRefreshKey && now - lastRefreshTime < CACHE_TTL) return
-    loading.value = true
+    const key = watchKey.value;
+    const now = Date.now();
+    if (key === lastRefreshKey && now - lastRefreshTime < CACHE_TTL) return;
+    loading.value = true;
     try {
-      const [statsRes, tpsRes, inputRes, outputRes, summaryRes] = await Promise.allSettled([
-        api.getStats(statsParams.value),
-        api.getMetricsTimeseries(tsParams('total_tps')),
-        api.getMetricsTimeseries(tsParams('input_tokens')),
-        api.getMetricsTimeseries(tsParams('output_tokens')),
-        api.getMetricsSummary(cacheSummaryParams.value),
-      ])
+      const [statsRes, tpsRes, inputRes, outputRes, summaryRes] =
+        await Promise.allSettled([
+          api.getStats(statsParams.value),
+          api.getMetricsTimeseries(tsParams("total_tps")),
+          api.getMetricsTimeseries(tsParams("input_tokens")),
+          api.getMetricsTimeseries(tsParams("output_tokens")),
+          api.getMetricsSummary(cacheSummaryParams.value),
+        ]);
 
-      const fulfilled = <T>(r: PromiseSettledResult<T>): r is PromiseFulfilledResult<T> => r.status === 'fulfilled'
+      const fulfilled = <T>(
+        r: PromiseSettledResult<T>,
+      ): r is PromiseFulfilledResult<T> => r.status === "fulfilled";
 
-      if (fulfilled(statsRes)) stats.value = statsRes.value
+      if (fulfilled(statsRes)) stats.value = statsRes.value;
 
-      const period = timeseriesPeriod.value
-      const timeRange = stats.value.startTime && stats.value.endTime
-        ? { startTime: stats.value.startTime, endTime: stats.value.endTime }
-        : undefined
+      const period = timeseriesPeriod.value;
+      const timeRange =
+        stats.value.startTime && stats.value.endTime
+          ? { startTime: stats.value.startTime, endTime: stats.value.endTime }
+          : undefined;
 
       if (fulfilled(tpsRes) && tpsRes.value.length > 0) {
-        const filled = fillTimeseries(tpsRes.value, period, timeRange)
-        tpsChartData.value = toChartData(filled, t('dashboard.charts.tokenOutputSpeed'), CHART_COLORS.indigo)
+        const filled = fillTimeseries(tpsRes.value, period, timeRange);
+        tpsChartData.value = toChartData(
+          filled,
+          t("dashboard.charts.tokenOutputSpeed"),
+          CHART_COLORS.indigo,
+        );
       } else {
-        tpsChartData.value = null
+        tpsChartData.value = null;
       }
 
       if (fulfilled(inputRes) && inputRes.value.length > 0) {
-        const filled = fillTimeseries(inputRes.value, period, timeRange)
-        inputTokensChartData.value = toChartData(filled, t('dashboard.charts.tokenInputTotal'), CHART_COLORS.teal)
+        const filled = fillTimeseries(inputRes.value, period, timeRange);
+        inputTokensChartData.value = toChartData(
+          filled,
+          t("dashboard.charts.tokenInputTotal"),
+          CHART_COLORS.teal,
+        );
       } else {
-        inputTokensChartData.value = null
+        inputTokensChartData.value = null;
       }
 
       if (fulfilled(outputRes) && outputRes.value.length > 0) {
-        const filled = fillTimeseries(outputRes.value, period, timeRange)
-        outputTokensChartData.value = toChartData(filled, t('dashboard.charts.tokenOutputTotal'), CHART_COLORS.green)
+        const filled = fillTimeseries(outputRes.value, period, timeRange);
+        outputTokensChartData.value = toChartData(
+          filled,
+          t("dashboard.charts.tokenOutputTotal"),
+          CHART_COLORS.green,
+        );
       } else {
-        outputTokensChartData.value = null
+        outputTokensChartData.value = null;
       }
 
       if (fulfilled(summaryRes)) {
-        cacheHitRate.value = summaryRes.value.cache_hit_rate
-        clientTypeBreakdown.value = summaryRes.value.client_type_breakdown
+        cacheHitRate.value = summaryRes.value.cache_hit_rate;
+        clientTypeBreakdown.value = summaryRes.value.client_type_breakdown;
       }
     } catch (e: unknown) {
-      console.error('Failed to load dashboard:', e)
-      toast.error(getApiMessage(e, t('dashboard.loadDashboardFailed')))
+      console.error("Failed to load dashboard:", e);
+      toast.error(getApiMessage(e, t("dashboard.loadDashboardFailed")));
     } finally {
-      loading.value = false
-      lastRefreshKey = key
-      lastRefreshTime = Date.now()
+      loading.value = false;
+      lastRefreshKey = key;
+      lastRefreshTime = Date.now();
     }
   }
 
   // --- Watchers ---
 
   // 统一 watch key：所有影响 refresh 的参数
-  const watchKey = computed(() => JSON.stringify({
-    periodTab: periodTab.value,
-    selectedProvider: selectedProvider.value,
-    modelFilter: modelFilter.value,
-    keyFilter: keyFilter.value,
-    clientType: clientType.value,
-    customStart: customStart.value,
-    customEnd: customEnd.value,
-  }))
+  const watchKey = computed(() =>
+    JSON.stringify({
+      periodTab: periodTab.value,
+      selectedProvider: selectedProvider.value,
+      modelFilter: modelFilter.value,
+      keyFilter: keyFilter.value,
+      clientType: clientType.value,
+      customStart: customStart.value,
+      customEnd: customEnd.value,
+    }),
+  );
 
   // 副作用：离开自定义日期模式时清空日期（间接通过 watchKey 变化触发 refresh）
   watch(periodTab, () => {
-    if (periodTab.value !== 'custom') {
-      customStart.value = ''
-      customEnd.value = ''
+    if (periodTab.value !== "custom") {
+      customStart.value = "";
+      customEnd.value = "";
     }
-  })
+  });
 
   // 副作用：切换 provider 时重置 modelFilter（间接通过 watchKey 变化触发 refresh）
   watch(selectedProvider, () => {
-    if (modelFilter.value !== 'all' && !modelOptions.value.includes(modelFilter.value)) {
-      modelFilter.value = 'all'
+    if (
+      modelFilter.value !== "all" &&
+      !modelOptions.value.includes(modelFilter.value)
+    ) {
+      modelFilter.value = "all";
     }
-  })
+  });
 
   // 单一 debounced watch：watchKey 变化时 DEBOUNCE_MS 后 refresh
-  let refreshTimer: ReturnType<typeof setTimeout> | null = null
+  let refreshTimer: ReturnType<typeof setTimeout> | null = null;
   watch(watchKey, () => {
-    if (refreshTimer) clearTimeout(refreshTimer)
-    refreshTimer = setTimeout(() => refresh(), DEBOUNCE_MS)
-  })
+    if (refreshTimer) clearTimeout(refreshTimer);
+    refreshTimer = setTimeout(() => refresh(), DEBOUNCE_MS);
+  });
 
   // periodTab 变化时重新加载 provider 排序数据
   watch(periodTab, () => {
     if (providers.value.length > 0) {
-      loadProviderOutputTokens()
+      loadProviderOutputTokens();
     }
-  })
+  });
 
   // --- Refresh 去重缓存 ---
-  const DEBOUNCE_MS = 300
-  const CACHE_TTL = 5000
-  let lastRefreshKey = ''
-  let lastRefreshTime = 0
+  const DEBOUNCE_MS = 300;
+  const CACHE_TTL = 5000;
+  let lastRefreshKey = "";
+  let lastRefreshTime = 0;
 
   // --- Watch theme changes to re-render charts ---
-  let stopWatchTheme: (() => void) | null = null
+  let stopWatchTheme: (() => void) | null = null;
 
   onMounted(async () => {
-    await loadProviders()
-    await loadFilterOptions()
+    await loadProviders();
+    await loadFilterOptions();
     if (providers.value.length > 0) {
-      await loadProviderOutputTokens()
+      await loadProviderOutputTokens();
     }
-    await refresh()
+    await refresh();
     // Re-render charts when theme changes (Chart.js doesn't support CSS vars)
-    stopWatchTheme = watchTheme(() => refresh())
-  })
+    stopWatchTheme = watchTheme(() => refresh());
+  });
 
   onUnmounted(() => {
-    if (refreshTimer) clearTimeout(refreshTimer)
-    if (stopWatchTheme) stopWatchTheme()
-  })
+    if (refreshTimer) clearTimeout(refreshTimer);
+    if (stopWatchTheme) stopWatchTheme();
+  });
 
   return {
-    providers, selectedProvider, sortedProviders,
-    periodTab, customStart, customEnd,
-    modelFilter, keyFilter, clientType, modelOptions, keyOptions,
+    providers,
+    selectedProvider,
+    sortedProviders,
+    periodTab,
+    customStart,
+    customEnd,
+    modelFilter,
+    keyFilter,
+    clientType,
+    modelOptions,
+    keyOptions,
     timeRangeText,
-    stats, loading,
-    cacheHitRate, clientTypeBreakdown,
-    tpsChartData, inputTokensChartData, outputTokensChartData,
-  }
+    stats,
+    loading,
+    cacheHitRate,
+    clientTypeBreakdown,
+    tpsChartData,
+    inputTokensChartData,
+    outputTokensChartData,
+  };
 }

--- a/frontend/src/composables/useFetchUpstreamModels.ts
+++ b/frontend/src/composables/useFetchUpstreamModels.ts
@@ -1,108 +1,106 @@
-import { ref } from 'vue'
-import { toast } from 'vue-sonner'
-import { api } from '@/api/client'
-import type { ModelInfo } from '@/types/mapping'
-import { getDefaultContextWindow } from '@/components/quick-setup/types'
-import { useI18n } from 'vue-i18n'
+import { ref } from "vue";
+import { toast } from "vue-sonner";
+import { api } from "@/api/client";
+import type { ModelInfo } from "@/types/mapping";
+import { getDefaultContextWindow } from "@/components/quick-setup/types";
+import { useI18n } from "vue-i18n";
+import { computeDefaultPatches } from "@/utils/model-patches";
 
-const DEFAULT_PATCHES_BY_KEYWORD = 'deepseek'
-
-export function useFetchUpstreamModels(form: {
-  value: {
-    api_type: string
-    base_url: string
-    api_key: string
-    models: ModelInfo[]
-  }
-}, getCurrentModelsEndpoint: () => string | undefined, getCurrentPresetModels: () => string[]) {
-  const { t } = useI18n()
-  const fetchingModels = ref(false)
-
-  function getDefaultPatches(modelName: string, apiType: string): string[] {
-    const patches: string[] = []
-    if (modelName.toLowerCase().includes(DEFAULT_PATCHES_BY_KEYWORD)) {
-      patches.push('thinking-consistency')
-      if (apiType === 'anthropic') {
-        patches.push('orphan-tool-results')
-      } else {
-        patches.push('orphan-tool-results-oa')
-      }
-    }
-    return patches
-  }
+export function useFetchUpstreamModels(
+  form: {
+    value: {
+      api_type: string;
+      base_url: string;
+      api_key: string;
+      models: ModelInfo[];
+    };
+  },
+  getCurrentModelsEndpoint: () => string | undefined,
+  getCurrentPresetModels: () => string[],
+) {
+  const { t } = useI18n();
+  const fetchingModels = ref(false);
 
   /** 将模型名称列表添加到表单（自动去重） */
   function addModelsToForm(modelIds: string[], source: string) {
     if (modelIds.length === 0) {
-      toast.info(t('providers.fetchModels.empty'))
-      return
+      toast.info(t("providers.fetchModels.empty"));
+      return;
     }
 
-    const existingNames = new Set(form.value.models.map(m => m.name))
-    let added = 0
+    const existingNames = new Set(form.value.models.map((m) => m.name));
+    let added = 0;
     for (const name of modelIds) {
       if (!existingNames.has(name)) {
         form.value.models.push({
           name,
           context_window: getDefaultContextWindow(name),
-          patches: getDefaultPatches(name, form.value.api_type),
-        })
-        added++
+          patches: computeDefaultPatches(name, form.value.api_type, false),
+        });
+        added++;
       }
     }
     if (added > 0) {
-      toast.success(t('providers.fetchModels.success', { source, total: modelIds.length, added }))
+      toast.success(
+        t("providers.fetchModels.success", {
+          source,
+          total: modelIds.length,
+          added,
+        }),
+      );
     } else {
-      toast.info(t('providers.fetchModels.allExist', { total: modelIds.length }))
+      toast.info(
+        t("providers.fetchModels.allExist", { total: modelIds.length }),
+      );
     }
   }
 
   /** 使用预设的写死模型列表（兜底） */
   function applyPresetModels() {
-    const presetModels = getCurrentPresetModels()
-    addModelsToForm(presetModels, t('providers.fetchModels.sourcePreset'))
+    const presetModels = getCurrentPresetModels();
+    addModelsToForm(presetModels, t("providers.fetchModels.sourcePreset"));
   }
 
   async function fetchUpstreamModels() {
-    const modelsEndpoint = getCurrentModelsEndpoint()
+    const modelsEndpoint = getCurrentModelsEndpoint();
 
     // 兜底1: 没有 modelsEndpoint，直接使用预设模型
     if (!modelsEndpoint) {
-      applyPresetModels()
-      return
+      applyPresetModels();
+      return;
     }
 
     if (!form.value.api_key?.trim()) {
-      toast.error(t('providers.fetchModels.noApiKey'))
-      return
+      toast.error(t("providers.fetchModels.noApiKey"));
+      return;
     }
 
-    fetchingModels.value = true
+    fetchingModels.value = true;
     try {
       const modelIds = await api.fetchUpstreamModels({
         base_url: form.value.base_url,
         models_endpoint: modelsEndpoint,
         api_key: form.value.api_key,
         api_type: form.value.api_type,
-      })
+      });
 
       if (modelIds.length === 0) {
         // 上游返回空列表，兜底使用预设模型
-        applyPresetModels()
-        return
+        applyPresetModels();
+        return;
       }
 
-      addModelsToForm(modelIds, t('providers.fetchModels.sourceUpstream'))
+      addModelsToForm(modelIds, t("providers.fetchModels.sourceUpstream"));
     } catch {
       // 兜底2: 上游调用失败，使用预设模型
-      applyPresetModels()
+      applyPresetModels();
     } finally {
-      fetchingModels.value = false
+      fetchingModels.value = false;
     }
   }
 
   return {
     fetchingModels,
     fetchUpstreamModels,
-  }
+  };
 }

--- a/frontend/src/composables/useLogFilters.ts
+++ b/frontend/src/composables/useLogFilters.ts
@@ -3,6 +3,7 @@ import { toast } from "vue-sonner";
 import { useI18n } from "vue-i18n";
 import { api, getApiMessage } from "@/api/client";
 import type { Provider } from "@/types/mapping";
+import { toIsoStart, toIsoEnd } from "@/utils/format";
 
 const PERIODS = [
   { label: "1h", value: "1h" },
@@ -38,7 +39,7 @@ export function useLogFilters() {
   const dateRangeError = computed(() => {
     const { start, end } = dateRange.value;
     if (!start || !end) return "";
-    return start >= end ? t('logs.validation.endTimeAfterStart') : "";
+    return start >= end ? t("logs.validation.endTimeAfterStart") : "";
   });
 
   const filteredModelOptions = computed(() => {
@@ -48,16 +49,6 @@ export function useLogFilters() {
     const providerModels = new Set(provider.models.map((m) => m.name));
     return modelOptions.value.filter((m) => providerModels.has(m));
   });
-
-  function toIsoStart(dateStr: string): string {
-    if (dateStr.includes("T")) return `${dateStr}:00.000Z`;
-    return `${dateStr}T00:00:00.000Z`;
-  }
-
-  function toIsoEnd(dateStr: string): string {
-    if (dateStr.includes("T")) return `${dateStr}:59.999Z`;
-    return `${dateStr}T23:59:59.999Z`;
-  }
 
   const PERIOD_MS: Record<string, number> = {
     "1h": 3600000,
@@ -95,7 +86,7 @@ export function useLogFilters() {
       providers.value = await api.getProviders();
     } catch (e: unknown) {
       console.error("Failed to load providers:", e);
-      toast.error(getApiMessage(e, t('logs.messages.loadProvidersFailed')));
+      toast.error(getApiMessage(e, t("logs.messages.loadProvidersFailed")));
     }
   }
 
@@ -104,7 +95,7 @@ export function useLogFilters() {
       routerKeys.value = await api.getRouterKeys();
     } catch (e: unknown) {
       console.error("Failed to load router keys:", e);
-      toast.error(getApiMessage(e, t('logs.messages.loadKeysFailed')));
+      toast.error(getApiMessage(e, t("logs.messages.loadKeysFailed")));
     }
   }
 

--- a/frontend/src/composables/useProviderForm.ts
+++ b/frontend/src/composables/useProviderForm.ts
@@ -7,6 +7,7 @@ import { DEFAULT_CONTEXT_WINDOW } from "@/constants";
 import type { ModelConfig } from "@/components/quick-setup/types";
 import { useTransformRules } from "@/composables/useTransformRules";
 import { useProviderPresets } from "@/composables/useProviderPresets";
+import type { ConcurrencyMode } from "@/types/concurrency";
 
 const DEFAULT_CONCURRENCY = 3;
 const DEFAULT_CONCURRENCY_AUTO = 10;
@@ -17,8 +18,6 @@ const MAX_QUEUE_SIZE = 1000;
 const CONTEXT_K = 1000;
 const CONTEXT_M = 1_000_000;
 const MS_PER_SECOND = 1000;
-
-export type ConcurrencyMode = "auto" | "manual" | "none";
 
 interface FormState {
   name: string;

--- a/frontend/src/composables/useProviderPresets.ts
+++ b/frontend/src/composables/useProviderPresets.ts
@@ -2,8 +2,7 @@ import { ref, computed } from "vue";
 import { api, type ProviderGroup } from "@/api/client";
 import type { ModelInfo } from "@/types/mapping";
 import { getDefaultContextWindow } from "@/components/quick-setup/types";
-
-const DEFAULT_PATCHES_BY_KEYWORD = "deepseek";
+import { computeDefaultPatches } from "@/utils/model-patches";
 
 export function useProviderPresets(form: {
   value: {
@@ -58,7 +57,7 @@ export function useProviderPresets(form: {
     form.value.models = preset.models.map((name) => ({
       name,
       context_window: getDefaultContextWindow(name),
-      patches: getDefaultPatches(name, preset.apiType),
+      patches: computeDefaultPatches(name, preset.apiType, false),
       capabilities: preset.modelCapabilities?.[name],
     }));
   }
@@ -77,19 +76,6 @@ export function useProviderPresets(form: {
       (p) => p.plan === presetPlan.value,
     );
     return preset?.models ?? [];
-  }
-
-  function getDefaultPatches(modelName: string, apiType: string): string[] {
-    const patches: string[] = [];
-    if (modelName.toLowerCase().includes(DEFAULT_PATCHES_BY_KEYWORD)) {
-      patches.push("thinking-consistency");
-      if (apiType === "anthropic") {
-        patches.push("orphan-tool-results");
-      } else {
-        patches.push("orphan-tool-results-oa");
-      }
-    }
-    return patches;
   }
 
   async function loadPresets() {

--- a/frontend/src/composables/useQuickSetup.ts
+++ b/frontend/src/composables/useQuickSetup.ts
@@ -1,111 +1,126 @@
-import { ref, computed, onMounted, watch } from 'vue'
-import { useI18n } from 'vue-i18n'
-import { api, getApiMessage, type ProviderGroup, type RecommendedRetryRule, type QuickSetupPayload } from '@/api/client'
-import type { MappingGroup } from '@/types/mapping'
-import type { Provider as ApiProvider } from '@/types/mapping'
-import { toast } from 'vue-sonner'
+import { ref, computed, onMounted, watch } from "vue";
+import { useI18n } from "vue-i18n";
 import {
-  type ClientType, type ModelConfig, type MappingEntry, type MappingTarget,
-  CLIENTS, DEFAULT_CLIENT_MAPPINGS, getDefaultContextWindow,
-} from '@/components/quick-setup/types'
-import type { Rule } from '@/types/mapping'
-import router from '@/router'
+  api,
+  getApiMessage,
+  type ProviderGroup,
+  type RecommendedRetryRule,
+  type QuickSetupPayload,
+} from "@/api/client";
+import type { MappingGroup } from "@/types/mapping";
+import type { Provider as ApiProvider } from "@/types/mapping";
+import { toast } from "vue-sonner";
+import {
+  type ClientType,
+  type ModelConfig,
+  type MappingEntry,
+  type MappingTarget,
+  CLIENTS,
+  DEFAULT_CLIENT_MAPPINGS,
+  getDefaultContextWindow,
+} from "@/components/quick-setup/types";
+import type { Rule } from "@/types/mapping";
+import type { ConcurrencyMode } from "@/types/concurrency";
+import { computeDefaultPatches } from "@/utils/model-patches";
+import router from "@/router";
 
-export type ConcurrencyMode = 'auto' | 'manual' | 'none'
-
-const DEFAULT_CONCURRENCY = 10
-const DEFAULT_QUEUE_TIMEOUT_MS = 120_000
-const DEFAULT_QUEUE_SIZE = 100
-const DEFAULT_CONTEXT_WINDOW = 128_000
-const CONNECTION_TEST_DELAY_MS = 800
-const POST_SAVE_REDIRECT_MS = 1500
+const DEFAULT_CONCURRENCY = 10;
+const DEFAULT_QUEUE_TIMEOUT_MS = 120_000;
+const DEFAULT_QUEUE_SIZE = 100;
+const DEFAULT_CONTEXT_WINDOW = 128_000;
+const CONNECTION_TEST_DELAY_MS = 800;
+const POST_SAVE_REDIRECT_MS = 1500;
 
 /** Convert Chinese provider group name to valid backend name (a-zA-Z0-9_-) */
 const PROVIDER_NAME_MAP: Record<string, string> = {
-  'DeepSeek': 'deepseek',
-  '百度千帆': 'qianfan',
-  '科大讯飞': 'iflytek',
-  '硅基流动': 'siliconflow',
-  '智谱': 'zhipu',
-  '月之暗面': 'moonshot',
-  'Minimax': 'minimax',
-  '火山引擎': 'volcengine',
-  '阿里云': 'aliyun',
-  '腾讯云': 'tencent',
-  'OpenCode': 'opencode',
-  '阶跃星辰': 'stepfun',
-}
+  DeepSeek: "deepseek",
+  百度千帆: "qianfan",
+  科大讯飞: "iflytek",
+  硅基流动: "siliconflow",
+  智谱: "zhipu",
+  月之暗面: "moonshot",
+  Minimax: "minimax",
+  火山引擎: "volcengine",
+  阿里云: "aliyun",
+  腾讯云: "tencent",
+  OpenCode: "opencode",
+  阶跃星辰: "stepfun",
+};
 
 function toProviderName(group: string): string {
-  return PROVIDER_NAME_MAP[group] ?? group.toLowerCase().replace(/[^a-z0-9]/gi, '-').replace(/-+/g, '-')
+  return (
+    PROVIDER_NAME_MAP[group] ??
+    group
+      .toLowerCase()
+      .replace(/[^a-z0-9]/gi, "-")
+      .replace(/-+/g, "-")
+  );
 }
 
-/** Compute default patches for a model based on its name and API format */
-function computeDefaultPatches(
-  modelName: string,
-  format: 'openai' | 'openai-responses' | 'anthropic',
-  isNonOpenaiEndpoint: boolean,
-): string[] {
-  const patches: string[] = []
-  const isDeepseek = modelName.toLowerCase().includes('deepseek')
-  if (isDeepseek) {
-    patches.push('thinking-consistency')
-    if (format === 'anthropic') {
-      patches.push('orphan-tool-results')
-    } else {
-      patches.push('orphan-tool-results-oa')
-    }
-  }
-  if (format === 'openai' && isNonOpenaiEndpoint) {
-    patches.push('developer-role')
-  }
-  return patches
-}
-
-/** Parse transform rules from raw string inputs */
 function parseTransformRules(
   headersInput: string,
   dropFieldsInput: string,
   requestDefaultsInput: string,
   onError: (msg: string) => void,
-): NonNullable<QuickSetupPayload['transform_rules']> | undefined | false {
-  if (!headersInput && !dropFieldsInput && !requestDefaultsInput) return undefined
-  const result: NonNullable<QuickSetupPayload['transform_rules']> = {}
+): NonNullable<QuickSetupPayload["transform_rules"]> | undefined | false {
+  if (!headersInput && !dropFieldsInput && !requestDefaultsInput)
+    return undefined;
+  const result: NonNullable<QuickSetupPayload["transform_rules"]> = {};
   if (headersInput) {
-    try { result.inject_headers = JSON.parse(headersInput) } catch { onError('injectHeadersJsonError'); return false }
+    try {
+      result.inject_headers = JSON.parse(headersInput);
+    } catch {
+      onError("injectHeadersJsonError");
+      return false;
+    }
   }
   if (dropFieldsInput) {
-    result.drop_fields = dropFieldsInput.split(',').map(s => s.trim()).filter(Boolean)
+    result.drop_fields = dropFieldsInput
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean);
   }
   if (requestDefaultsInput) {
-    try { result.request_defaults = JSON.parse(requestDefaultsInput) } catch { onError('requestDefaultsJsonError'); return false }
+    try {
+      result.request_defaults = JSON.parse(requestDefaultsInput);
+    } catch {
+      onError("requestDefaultsJsonError");
+      return false;
+    }
   }
-  return Object.keys(result).length > 0 ? result : undefined
+  return Object.keys(result).length > 0 ? result : undefined;
 }
 
 /** Toggle active state for existing mappings that changed */
-async function toggleChangedMappings(entries: MappingEntry[]): Promise<string[]> {
-  const errors: string[] = []
+async function toggleChangedMappings(
+  entries: MappingEntry[],
+): Promise<string[]> {
+  const errors: string[] = [];
   for (const entry of entries) {
-    if (entry.existing && entry.existingId && entry.originalActive !== undefined && entry.active !== entry.originalActive) {
+    if (
+      entry.existing &&
+      entry.existingId &&
+      entry.originalActive !== undefined &&
+      entry.active !== entry.originalActive
+    ) {
       try {
-        await api.toggleMappingGroup(entry.existingId)
+        await api.toggleMappingGroup(entry.existingId);
       } catch {
-        errors.push(entry.clientModel)
+        errors.push(entry.clientModel);
       }
     }
   }
-  return errors
+  return errors;
 }
 
 /** Build retry rules payload from selected rules */
 function buildRetryRulesPayload(
   rules: RecommendedRetryRule[],
   selectedRules: Set<string>,
-): QuickSetupPayload['retry_rules'] {
+): QuickSetupPayload["retry_rules"] {
   return rules
-    .filter(r => selectedRules.has(r.name) && !r.exists)
-    .map(r => ({
+    .filter((r) => selectedRules.has(r.name) && !r.exists)
+    .map((r) => ({
       name: r.name,
       status_code: r.status_code,
       body_pattern: r.body_pattern,
@@ -113,25 +128,27 @@ function buildRetryRulesPayload(
       retry_delay_ms: r.retry_delay_ms,
       max_retries: r.max_retries,
       max_delay_ms: r.max_delay_ms,
-    }))
+    }));
 }
 
 interface ProviderPayloadInput {
-  isCustom: boolean
-  selectedGroup: string
-  selectedPlan: string
-  apiType: 'openai' | 'openai-responses' | 'anthropic'
-  baseUrl: string
-  upstreamPath: string
-  apiKey: string
-  models: ModelConfig[]
-  concurrencyMode: ConcurrencyMode
-  maxConcurrency: number
-  queueTimeoutMs: number
-  maxQueueSize: number
+  isCustom: boolean;
+  selectedGroup: string;
+  selectedPlan: string;
+  apiType: "openai" | "openai-responses" | "anthropic";
+  baseUrl: string;
+  upstreamPath: string;
+  apiKey: string;
+  models: ModelConfig[];
+  concurrencyMode: ConcurrencyMode;
+  maxConcurrency: number;
+  queueTimeoutMs: number;
+  maxQueueSize: number;
 }
 
-function buildProviderPayload(input: ProviderPayloadInput): QuickSetupPayload['provider'] {
+function buildProviderPayload(
+  input: ProviderPayloadInput,
+): QuickSetupPayload["provider"] {
   return {
     name: input.isCustom
       ? `custom-${Date.now()}`
@@ -140,18 +157,24 @@ function buildProviderPayload(input: ProviderPayloadInput): QuickSetupPayload['p
     base_url: input.baseUrl,
     upstream_path: input.upstreamPath || undefined,
     api_key: input.apiKey,
-    models: input.models.map(m => ({
+    models: input.models.map((m) => ({
       name: m.name,
       context_window: m.contextWindow,
       patches: m.patches.length > 0 ? m.patches : undefined,
       stream_timeout_ms: m.stream_timeout_ms ?? undefined,
-      capabilities: m.capabilities && m.capabilities.length > 0 ? m.capabilities : undefined,
+      capabilities:
+        m.capabilities && m.capabilities.length > 0
+          ? m.capabilities
+          : undefined,
     })),
     concurrency_mode: input.concurrencyMode,
-    max_concurrency: input.concurrencyMode !== 'none' ? input.maxConcurrency : undefined,
-    queue_timeout_ms: input.concurrencyMode !== 'none' ? input.queueTimeoutMs : undefined,
-    max_queue_size: input.concurrencyMode !== 'none' ? input.maxQueueSize : undefined,
-  }
+    max_concurrency:
+      input.concurrencyMode !== "none" ? input.maxConcurrency : undefined,
+    queue_timeout_ms:
+      input.concurrencyMode !== "none" ? input.queueTimeoutMs : undefined,
+    max_queue_size:
+      input.concurrencyMode !== "none" ? input.maxQueueSize : undefined,
+  };
 }
 
 /** Build mapping entries by merging existing DB mappings with client defaults */
@@ -160,408 +183,523 @@ function buildMappingEntries(
   enabledModels: ModelConfig[],
   existingMappings: MappingGroup[],
 ): MappingEntry[] {
-  let clientModelNames: string[]
-  if (clientType === 'pi') {
-    clientModelNames = enabledModels.map(m => m.name)
+  let clientModelNames: string[];
+  if (clientType === "pi") {
+    clientModelNames = enabledModels.map((m) => m.name);
   } else {
-    clientModelNames = DEFAULT_CLIENT_MAPPINGS[clientType] ?? enabledModels.map(m => m.name)
+    clientModelNames =
+      DEFAULT_CLIENT_MAPPINGS[clientType] ?? enabledModels.map((m) => m.name);
   }
 
   return clientModelNames.map((cmName) => {
-    const existingGroup = existingMappings.find(g => g.client_model === cmName)
+    const existingGroup = existingMappings.find(
+      (g) => g.client_model === cmName,
+    );
     if (existingGroup) {
-      let rule: Rule = {}
-      try { rule = JSON.parse(existingGroup.rule) } catch { rule = {} }
-      const targets = rule.targets ?? []
+      let rule: Rule = {};
+      try {
+        rule = JSON.parse(existingGroup.rule);
+      } catch {
+        rule = {};
+      }
+      const targets = rule.targets ?? [];
       return {
         clientModel: cmName,
-        targets: targets.length > 0
-          ? targets.map(t => ({
-            backend_model: t.backend_model,
-            provider_id: t.provider_id,
-            overflow_provider_id: t.overflow_provider_id,
-            overflow_model: t.overflow_model,
-          }))
-          : [{ backend_model: enabledModels[0]?.name ?? '', provider_id: '__new__' }],
+        targets:
+          targets.length > 0
+            ? targets.map((t) => ({
+              backend_model: t.backend_model,
+              provider_id: t.provider_id,
+              overflow_provider_id: t.overflow_provider_id,
+              overflow_model: t.overflow_model,
+            }))
+            : [
+              {
+                backend_model: enabledModels[0]?.name ?? "",
+                provider_id: "__new__",
+              },
+            ],
         existing: true,
         existingId: existingGroup.id,
-        tag: 'existing' as const,
+        tag: "existing" as const,
         active: !!existingGroup.is_active,
         originalActive: !!existingGroup.is_active,
-      }
+      };
     }
 
-    const defaultTarget = enabledModels[clientModelNames.indexOf(cmName)]?.name
-      ?? enabledModels[enabledModels.length - 1]?.name
-      ?? ''
+    const defaultTarget =
+      enabledModels[clientModelNames.indexOf(cmName)]?.name ??
+      enabledModels[enabledModels.length - 1]?.name ??
+      "";
     return {
       clientModel: cmName,
-      targets: [{ backend_model: defaultTarget, provider_id: '__new__' }],
+      targets: [{ backend_model: defaultTarget, provider_id: "__new__" }],
       existing: false,
-      tag: (clientType === 'pi' ? 'auto' : 'def') as 'auto' | 'def',
+      tag: (clientType === "pi" ? "auto" : "def") as "auto" | "def",
       active: true,
-    }
-  })
+    };
+  });
 }
 
-// eslint-disable-next-line max-lines-per-function -- 函数内每个部分都是 QuickSetup 必需逻辑，拆分会降低可读性
+// eslint-disable-next-line max-lines-per-function -- QuickSetup 各步骤（preset/model/patches/submit）构成状态机，拆分会破坏流程连贯性
 export function useQuickSetup() {
-  const { t } = useI18n()
+  const { t } = useI18n();
   // --- State ---
-  const clientType = ref<ClientType>('claude-code')
-  const providerGroups = ref<ProviderGroup[]>([])
-  const selectedGroup = ref('')
-  const selectedPlan = ref('')
-  const apiType = ref<'openai' | 'openai-responses' | 'anthropic'>('anthropic')
-  const apiKey = ref('')
-  const modelConfigs = ref<ModelConfig[]>([])
-  const mappingEntries = ref<MappingEntry[]>([])
-  const allRecommendedRules = ref<RecommendedRetryRule[]>([])
-  const selectedRetryRules = ref<Set<string>>(new Set())
-  const saving = ref(false)
-  const connectionStatus = ref<'idle' | 'testing' | 'ok' | 'error'>('idle')
+  const clientType = ref<ClientType>("claude-code");
+  const providerGroups = ref<ProviderGroup[]>([]);
+  const selectedGroup = ref("");
+  const selectedPlan = ref("");
+  const apiType = ref<"openai" | "openai-responses" | "anthropic">("anthropic");
+  const apiKey = ref("");
+  const modelConfigs = ref<ModelConfig[]>([]);
+  const mappingEntries = ref<MappingEntry[]>([]);
+  const allRecommendedRules = ref<RecommendedRetryRule[]>([]);
+  const selectedRetryRules = ref<Set<string>>(new Set());
+  const saving = ref(false);
+  const connectionStatus = ref<"idle" | "testing" | "ok" | "error">("idle");
 
   // Concurrency state
-  const concurrencyMode = ref<ConcurrencyMode>('auto')
-  const maxConcurrency = ref(DEFAULT_CONCURRENCY)
-  const queueTimeoutMs = ref(DEFAULT_QUEUE_TIMEOUT_MS)
-  const maxQueueSize = ref(DEFAULT_QUEUE_SIZE)
+  const concurrencyMode = ref<ConcurrencyMode>("auto");
+  const maxConcurrency = ref(DEFAULT_CONCURRENCY);
+  const queueTimeoutMs = ref(DEFAULT_QUEUE_TIMEOUT_MS);
+  const maxQueueSize = ref(DEFAULT_QUEUE_SIZE);
 
   // Transform rules state
-  const transformInjectHeaders = ref('')
-  const transformDropFields = ref('')
-  const transformRequestDefaults = ref('')
+  const transformInjectHeaders = ref("");
+  const transformDropFields = ref("");
+  const transformRequestDefaults = ref("");
 
   // Existing mappings + providers for failover/overflow editing
-  const existingMappings = ref<MappingGroup[]>([])
-  const allProviders = ref<ApiProvider[]>([])
+  const existingMappings = ref<MappingGroup[]>([]);
+  const allProviders = ref<ApiProvider[]>([]);
 
   // --- Computed ---
-  const isCustomProvider = computed(() => selectedGroup.value === '__custom__')
+  const isCustomProvider = computed(() => selectedGroup.value === "__custom__");
 
   const currentClient = computed(() =>
-    CLIENTS.find(c => c.id === clientType.value),
-  )
+    CLIENTS.find((c) => c.id === clientType.value),
+  );
 
   const currentPreset = computed(() => {
-    if (!selectedGroup.value || !selectedPlan.value) return undefined
-    const group = providerGroups.value.find(g => g.group === selectedGroup.value)
-    if (!group) return undefined
-    return group.presets.find(p => p.plan === selectedPlan.value)
-  })
+    if (!selectedGroup.value || !selectedPlan.value) return undefined;
+    const group = providerGroups.value.find(
+      (g) => g.group === selectedGroup.value,
+    );
+    if (!group) return undefined;
+    return group.presets.find((p) => p.plan === selectedPlan.value);
+  });
 
-  const customBaseUrl = ref('')
-  const customUpstreamPath = ref('')
-  const baseUrl = computed(() => isCustomProvider.value ? customBaseUrl.value : (currentPreset.value?.baseUrl ?? ''))
+  const customBaseUrl = ref("");
+  const customUpstreamPath = ref("");
+  const baseUrl = computed(() =>
+    isCustomProvider.value
+      ? customBaseUrl.value
+      : (currentPreset.value?.baseUrl ?? ""),
+  );
   const upstreamPath = computed(() => {
-    if (isCustomProvider.value) return customUpstreamPath.value
-    const preset = currentPreset.value
-    if (!preset) return ''
-    const defaultPath = preset.apiType === 'anthropic' ? '/v1/messages'
-      : preset.apiType === 'openai-responses' ? '/v1/responses'
-        : '/v1/chat/completions'
-    if (preset.upstreamPath && preset.upstreamPath !== defaultPath) return preset.upstreamPath
-    return ''
-  })
+    if (isCustomProvider.value) return customUpstreamPath.value;
+    const preset = currentPreset.value;
+    if (!preset) return "";
+    const defaultPath =
+      preset.apiType === "anthropic"
+        ? "/v1/messages"
+        : preset.apiType === "openai-responses"
+          ? "/v1/responses"
+          : "/v1/chat/completions";
+    if (preset.upstreamPath && preset.upstreamPath !== defaultPath)
+      return preset.upstreamPath;
+    return "";
+  });
 
   const availablePlans = computed(() => {
-    const group = providerGroups.value.find(g => g.group === selectedGroup.value)
-    return group?.presets ?? []
-  })
+    const group = providerGroups.value.find(
+      (g) => g.group === selectedGroup.value,
+    );
+    return group?.presets ?? [];
+  });
 
   const isNonOpenaiEndpoint = computed(() => {
-    return !baseUrl.value.includes('openai.com')
-  })
+    return !baseUrl.value.includes("openai.com");
+  });
 
   // Provider groups for CascadingModelSelect (includes current new provider)
   const currentProviderGroup = computed(() => {
-    if (!selectedGroup.value) return null
+    if (!selectedGroup.value) return null;
     // Determine a temporary ID and display name for the new provider
     const tempId = isCustomProvider.value
-      ? '__new_custom__'
-      : `__new_${toProviderName(selectedGroup.value)}_${toProviderName(selectedPlan.value)}__`
+      ? "__new_custom__"
+      : `__new_${toProviderName(selectedGroup.value)}_${toProviderName(selectedPlan.value)}__`;
     const displayName = isCustomProvider.value
-      ? t('quickSetup.provider.customProvider')
-      : `${selectedGroup.value} - ${selectedPlan.value}`
+      ? t("quickSetup.provider.customProvider")
+      : `${selectedGroup.value} - ${selectedPlan.value}`;
     return {
       provider: { id: tempId, name: displayName },
       models: modelConfigs.value
-        .filter(m => m.enabled)
-        .map(m => ({
+        .filter((m) => m.enabled)
+        .map((m) => ({
           name: m.name,
           contextWindow: m.contextWindow,
         })),
       isNew: true,
-    }
-  })
+    };
+  });
 
   const allProviderGroups = computed(() => {
-    const existing = allProviders.value.map(p => ({
+    const existing = allProviders.value.map((p) => ({
       provider: { id: p.id, name: p.name },
-      models: (p.models ?? []).map(m => ({
+      models: (p.models ?? []).map((m) => ({
         name: m.name,
         contextWindow: m.context_window ?? DEFAULT_CONTEXT_WINDOW,
       })),
-    }))
+    }));
     // Only include new provider when there are enabled models configured
-    if (currentProviderGroup.value && currentProviderGroup.value.models.length > 0) {
-      return [...existing, currentProviderGroup.value]
+    if (
+      currentProviderGroup.value &&
+      currentProviderGroup.value.models.length > 0
+    ) {
+      return [...existing, currentProviderGroup.value];
     }
-    return existing
-  })
+    return existing;
+  });
 
   // Filter retry rules by selected provider
   const recommendedRules = computed(() => {
-    const group = selectedGroup.value
-    return allRecommendedRules.value.filter(r => {
-      if (!r.providers || r.providers.length === 0) return true
-      return r.providers.includes(group)
-    })
-  })
+    const group = selectedGroup.value;
+    return allRecommendedRules.value.filter((r) => {
+      if (!r.providers || r.providers.length === 0) return true;
+      return r.providers.includes(group);
+    });
+  });
 
-  function getDefaultPatches(modelName: string, format: 'openai' | 'openai-responses' | 'anthropic'): string[] {
-    return computeDefaultPatches(modelName, format, isNonOpenaiEndpoint.value)
-  }
-
-  function initModels(preset: { models: string[]; modelCapabilities?: Record<string, string[]>; apiType: 'openai' | 'openai-responses' | 'anthropic' }) {
-    modelConfigs.value = preset.models.map(name => ({
+  function initModels(preset: {
+    models: string[];
+    modelCapabilities?: Record<string, string[]>;
+    apiType: "openai" | "openai-responses" | "anthropic";
+  }) {
+    modelConfigs.value = preset.models.map((name) => ({
       name,
       contextWindow: getDefaultContextWindow(name),
       enabled: true,
-      patches: getDefaultPatches(name, preset.apiType),
+      patches: computeDefaultPatches(
+        name,
+        preset.apiType,
+        isNonOpenaiEndpoint.value,
+      ),
       capabilities: preset.modelCapabilities?.[name],
-    }))
+    }));
   }
 
   // --- Custom model management ---
-  function addCustomModel(name: string, contextWindow = DEFAULT_CONTEXT_WINDOW) {
+  function addCustomModel(
+    name: string,
+    contextWindow = DEFAULT_CONTEXT_WINDOW,
+  ) {
     modelConfigs.value.push({
       name,
       contextWindow,
       enabled: true,
-      patches: getDefaultPatches(name, apiType.value),
+      patches: computeDefaultPatches(
+        name,
+        apiType.value,
+        isNonOpenaiEndpoint.value,
+      ),
       capabilities: ["text"],
-    })
+    });
   }
 
   function updateMappings() {
-    const enabledModels = modelConfigs.value.filter(m => m.enabled)
-    mappingEntries.value = buildMappingEntries(clientType.value, enabledModels, existingMappings.value)
+    const enabledModels = modelConfigs.value.filter((m) => m.enabled);
+    mappingEntries.value = buildMappingEntries(
+      clientType.value,
+      enabledModels,
+      existingMappings.value,
+    );
   }
 
   // --- Auto-select retry rules when provider changes ---
   function autoSelectRetryRules() {
     selectedRetryRules.value = new Set(
-      recommendedRules.value
-        .filter(r => !r.exists)
-        .map(r => r.name),
-    )
+      recommendedRules.value.filter((r) => !r.exists).map((r) => r.name),
+    );
   }
 
   // --- Client / Provider / Plan selection ---
   // Client selection only changes client type and rebuilds mappings.
   // It does NOT affect provider configuration (group, plan, apiType, models).
   function selectClient(type: ClientType) {
-    clientType.value = type
-    updateMappings()
+    clientType.value = type;
+    updateMappings();
   }
 
   function onProviderChange(group: string) {
-    selectedGroup.value = group
-    selectedPlan.value = ''
-    modelConfigs.value = []
+    selectedGroup.value = group;
+    selectedPlan.value = "";
+    modelConfigs.value = [];
 
-    if (group === '__custom__') {
-      apiType.value = 'openai'
-      customBaseUrl.value = ''
-      customUpstreamPath.value = ''
-      modelConfigs.value = []
+    if (group === "__custom__") {
+      apiType.value = "openai";
+      customBaseUrl.value = "";
+      customUpstreamPath.value = "";
+      modelConfigs.value = [];
     } else {
-      const groupData = providerGroups.value.find(g => g.group === group)
+      const groupData = providerGroups.value.find((g) => g.group === group);
       if (groupData && groupData.presets.length > 0) {
-        const client = currentClient.value
+        const client = currentClient.value;
         const match = client
-          ? groupData.presets.find(p => p.apiType === client.format)
-          : null
-        const preset = match ?? groupData.presets[0]
-        selectedPlan.value = preset.plan
-        apiType.value = preset.apiType as 'openai' | 'openai-responses' | 'anthropic'
-        initModels(preset)
+          ? groupData.presets.find((p) => p.apiType === client.format)
+          : null;
+        const preset = match ?? groupData.presets[0];
+        selectedPlan.value = preset.plan;
+        apiType.value = preset.apiType as
+          | "openai"
+          | "openai-responses"
+          | "anthropic";
+        initModels(preset);
       }
     }
 
-    updateMappings()
-    autoSelectRetryRules()
+    updateMappings();
+    autoSelectRetryRules();
   }
 
   function onPlanChange(plan: string) {
-    selectedPlan.value = plan
-    const group = providerGroups.value.find(g => g.group === selectedGroup.value)
-    if (!group) return
-    const preset = group.presets.find(p => p.plan === plan)
-    if (!preset) return
-    apiType.value = preset.apiType as 'openai' | 'openai-responses' | 'anthropic'
-    initModels(preset)
-    updateMappings()
+    selectedPlan.value = plan;
+    const group = providerGroups.value.find(
+      (g) => g.group === selectedGroup.value,
+    );
+    if (!group) return;
+    const preset = group.presets.find((p) => p.plan === plan);
+    if (!preset) return;
+    apiType.value = preset.apiType as
+      | "openai"
+      | "openai-responses"
+      | "anthropic";
+    initModels(preset);
+    updateMappings();
   }
 
   watch(apiType, () => {
     for (const model of modelConfigs.value) {
-      model.patches = getDefaultPatches(model.name, apiType.value)
+      model.patches = computeDefaultPatches(
+        model.name,
+        apiType.value,
+        isNonOpenaiEndpoint.value,
+      );
     }
-  })
+  });
 
   // --- Retry rules ---
   function toggleRetryRule(name: string, checked: boolean) {
-    const next = new Set(selectedRetryRules.value)
-    if (checked) next.add(name)
-    else next.delete(name)
-    selectedRetryRules.value = next
+    const next = new Set(selectedRetryRules.value);
+    if (checked) next.add(name);
+    else next.delete(name);
+    selectedRetryRules.value = next;
   }
   // --- Mapping editing ---
   function updateMappingTargets(index: number, targets: MappingTarget[]) {
-    const next = [...mappingEntries.value]
-    next[index] = { ...next[index], targets }
-    mappingEntries.value = next
+    const next = [...mappingEntries.value];
+    next[index] = { ...next[index], targets };
+    mappingEntries.value = next;
   }
 
   function toggleMappingActive(index: number) {
-    const next = [...mappingEntries.value]
-    next[index] = { ...next[index], active: !next[index].active }
-    mappingEntries.value = next
+    const next = [...mappingEntries.value];
+    next[index] = { ...next[index], active: !next[index].active };
+    mappingEntries.value = next;
   }
 
   function addMappingEntry(clientModel: string, targetModel: string) {
-    const existing = mappingEntries.value.filter(m => m.clientModel !== clientModel)
+    const existing = mappingEntries.value.filter(
+      (m) => m.clientModel !== clientModel,
+    );
     existing.push({
       clientModel,
-      targets: [{ backend_model: targetModel, provider_id: '__new__' }],
+      targets: [{ backend_model: targetModel, provider_id: "__new__" }],
       existing: false,
-      tag: 'cust' as const,
+      tag: "cust" as const,
       active: true,
-    })
-    mappingEntries.value = existing
+    });
+    mappingEntries.value = existing;
   }
 
   function removeMappingEntry(clientModel: string) {
-    const entry = mappingEntries.value.find(m => m.clientModel === clientModel)
+    const entry = mappingEntries.value.find(
+      (m) => m.clientModel === clientModel,
+    );
     if (entry?.existing) {
-      toast.error(t('quickSetup.messages.existingMappingDelete'))
-      return
+      toast.error(t("quickSetup.messages.existingMappingDelete"));
+      return;
     }
-    mappingEntries.value = mappingEntries.value.filter(m => m.clientModel !== clientModel)
+    mappingEntries.value = mappingEntries.value.filter(
+      (m) => m.clientModel !== clientModel,
+    );
   }
 
   // --- Concurrency ---
   function onConcurrencyModeChange(mode: ConcurrencyMode) {
-    concurrencyMode.value = mode
-    if (mode === 'auto') maxConcurrency.value = DEFAULT_CONCURRENCY
-    else if (mode === 'manual') maxConcurrency.value = 3
+    concurrencyMode.value = mode;
+    if (mode === "auto") maxConcurrency.value = DEFAULT_CONCURRENCY;
+    else if (mode === "manual") maxConcurrency.value = 3;
   }
 
   // --- Connection test ---
   async function testConnection() {
     if (!apiKey.value.trim()) {
-      connectionStatus.value = 'error'
-      toast.error(t('quickSetup.messages.fillApiKeyFirst'))
-      return
+      connectionStatus.value = "error";
+      toast.error(t("quickSetup.messages.fillApiKeyFirst"));
+      return;
     }
-    connectionStatus.value = 'testing'
-    await new Promise(resolve => setTimeout(resolve, CONNECTION_TEST_DELAY_MS))
-    connectionStatus.value = 'ok'
+    connectionStatus.value = "testing";
+    await new Promise((resolve) =>
+      setTimeout(resolve, CONNECTION_TEST_DELAY_MS),
+    );
+    connectionStatus.value = "ok";
   }
 
   // --- Submit ---
 
   async function submit() {
     if (!currentPreset.value) {
-      toast.error(t('quickSetup.messages.selectProviderAndPlan'))
-      return
+      toast.error(t("quickSetup.messages.selectProviderAndPlan"));
+      return;
     }
     if (!apiKey.value.trim()) {
-      toast.error(t('quickSetup.messages.fillApiKey'))
-      return
+      toast.error(t("quickSetup.messages.fillApiKey"));
+      return;
     }
 
-    saving.value = true
+    saving.value = true;
     try {
       const transformRules = parseTransformRules(
         transformInjectHeaders.value.trim(),
         transformDropFields.value.trim(),
         transformRequestDefaults.value.trim(),
         (key) => toast.error(t(`quickSetup.messages.${key}`)),
-      )
-      if (transformRules === false) return
+      );
+      if (transformRules === false) return;
 
       const payload: QuickSetupPayload = {
         provider: buildProviderPayload({
-          isCustom: isCustomProvider.value, selectedGroup: selectedGroup.value, selectedPlan: selectedPlan.value,
-          apiType: apiType.value, baseUrl: baseUrl.value, upstreamPath: upstreamPath.value, apiKey: apiKey.value.trim(),
-          models: modelConfigs.value, concurrencyMode: concurrencyMode.value,
-          maxConcurrency: maxConcurrency.value, queueTimeoutMs: queueTimeoutMs.value, maxQueueSize: maxQueueSize.value,
+          isCustom: isCustomProvider.value,
+          selectedGroup: selectedGroup.value,
+          selectedPlan: selectedPlan.value,
+          apiType: apiType.value,
+          baseUrl: baseUrl.value,
+          upstreamPath: upstreamPath.value,
+          apiKey: apiKey.value.trim(),
+          models: modelConfigs.value,
+          concurrencyMode: concurrencyMode.value,
+          maxConcurrency: maxConcurrency.value,
+          queueTimeoutMs: queueTimeoutMs.value,
+          maxQueueSize: maxQueueSize.value,
         }),
         mappings: mappingEntries.value
-          .filter(m => m.targets[0]?.backend_model)
-          .map(m => ({
+          .filter((m) => m.targets[0]?.backend_model)
+          .map((m) => ({
             client_model: m.clientModel,
-            backend_model: m.targets[0]?.backend_model ?? '',
+            backend_model: m.targets[0]?.backend_model ?? "",
           })),
-        retry_rules: buildRetryRulesPayload(recommendedRules.value, selectedRetryRules.value),
+        retry_rules: buildRetryRulesPayload(
+          recommendedRules.value,
+          selectedRetryRules.value,
+        ),
         transform_rules: transformRules,
-      }
+      };
 
-      await api.quickSetup(payload)
+      await api.quickSetup(payload);
 
-      const toggleErrors = await toggleChangedMappings(mappingEntries.value)
+      const toggleErrors = await toggleChangedMappings(mappingEntries.value);
       if (toggleErrors.length > 0) {
-        toast.success(t('quickSetup.messages.setupCompleteWithErrors', { count: toggleErrors.length }))
+        toast.success(
+          t("quickSetup.messages.setupCompleteWithErrors", {
+            count: toggleErrors.length,
+          }),
+        );
       } else {
-        toast.success(t('quickSetup.messages.setupComplete'))
+        toast.success(t("quickSetup.messages.setupComplete"));
       }
-      await new Promise(r => setTimeout(r, POST_SAVE_REDIRECT_MS))
-      router.push('/')
+      await new Promise((r) => setTimeout(r, POST_SAVE_REDIRECT_MS));
+      router.push("/");
     } catch (e: unknown) {
-      console.error('quickSetup.save:', e)
-      toast.error(getApiMessage(e, t('quickSetup.messages.setupFailed')))
+      console.error("quickSetup.save:", e);
+      toast.error(getApiMessage(e, t("quickSetup.messages.setupFailed")));
     } finally {
-      saving.value = false
+      saving.value = false;
     }
   }
 
   // --- Init ---
   onMounted(async () => {
     try {
-      const [groupsResult, rulesResult, mappingsResult, providersResult] = await Promise.allSettled([
-        api.recommended.getProviders(),
-        api.recommended.getRetryRules(),
-        api.getMappingGroups(),
-        api.getProviders(),
-      ])
-      if (groupsResult.status === 'fulfilled') providerGroups.value = groupsResult.value
-      if (rulesResult.status === 'fulfilled') allRecommendedRules.value = rulesResult.value
-      if (mappingsResult.status === 'fulfilled') existingMappings.value = mappingsResult.value as MappingGroup[]
-      if (providersResult.status === 'fulfilled') allProviders.value = providersResult.value as ApiProvider[]
+      const [groupsResult, rulesResult, mappingsResult, providersResult] =
+        await Promise.allSettled([
+          api.recommended.getProviders(),
+          api.recommended.getRetryRules(),
+          api.getMappingGroups(),
+          api.getProviders(),
+        ]);
+      if (groupsResult.status === "fulfilled")
+        providerGroups.value = groupsResult.value;
+      if (rulesResult.status === "fulfilled")
+        allRecommendedRules.value = rulesResult.value;
+      if (mappingsResult.status === "fulfilled")
+        existingMappings.value = mappingsResult.value as MappingGroup[];
+      if (providersResult.status === "fulfilled")
+        allProviders.value = providersResult.value as ApiProvider[];
 
-      selectClient('claude-code')
+      selectClient("claude-code");
     } catch (e: unknown) {
-      console.error('quickSetup.load:', e)
-      toast.error(getApiMessage(e, t('quickSetup.messages.loadFailed')))
+      console.error("quickSetup.load:", e);
+      toast.error(getApiMessage(e, t("quickSetup.messages.loadFailed")));
     }
-  })
+  });
 
   return {
-    clientType, providerGroups, selectedGroup, selectedPlan,
-    apiType, apiKey, modelConfigs, mappingEntries,
-    allRecommendedRules, recommendedRules,
-    selectedRetryRules, saving, connectionStatus,
-    currentClient, currentPreset, baseUrl, customBaseUrl, upstreamPath, customUpstreamPath, isCustomProvider,
-    availablePlans, isNonOpenaiEndpoint,
-    concurrencyMode, maxConcurrency, queueTimeoutMs, maxQueueSize,
-    transformInjectHeaders, transformDropFields, transformRequestDefaults,
-    existingMappings, allProviders, allProviderGroups,
-    selectClient, onProviderChange, onPlanChange,
-    initModels, getDefaultPatches, updateMappings,
-    updateMappingTargets, toggleMappingActive, addMappingEntry, removeMappingEntry,
-    toggleRetryRule, onConcurrencyModeChange, testConnection, submit, addCustomModel,
-  }
+    clientType,
+    providerGroups,
+    selectedGroup,
+    selectedPlan,
+    apiType,
+    apiKey,
+    modelConfigs,
+    mappingEntries,
+    allRecommendedRules,
+    recommendedRules,
+    selectedRetryRules,
+    saving,
+    connectionStatus,
+    currentClient,
+    currentPreset,
+    baseUrl,
+    customBaseUrl,
+    upstreamPath,
+    customUpstreamPath,
+    isCustomProvider,
+    availablePlans,
+    isNonOpenaiEndpoint,
+    concurrencyMode,
+    maxConcurrency,
+    queueTimeoutMs,
+    maxQueueSize,
+    transformInjectHeaders,
+    transformDropFields,
+    transformRequestDefaults,
+    existingMappings,
+    allProviders,
+    allProviderGroups,
+    selectClient,
+    onProviderChange,
+    onPlanChange,
+    initModels,
+    updateMappings,
+    updateMappingTargets,
+    toggleMappingActive,
+    addMappingEntry,
+    removeMappingEntry,
+    toggleRetryRule,
+    onConcurrencyModeChange,
+    testConnection,
+    submit,
+    addCustomModel,
+  };
 }

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -1,132 +1,142 @@
-import { createRouter, createWebHistory } from 'vue-router'
-import { api } from '@/api/client'
+import { ref } from "vue";
+import { createRouter, createWebHistory } from "vue-router";
+import { api } from "@/api/client";
 
 const router = createRouter({
-  history: createWebHistory('/admin/'),
+  history: createWebHistory("/admin/"),
   routes: [
     {
-      path: '/setup',
-      name: 'setup',
-      component: () => import('@/views/Setup.vue'),
+      path: "/setup",
+      name: "setup",
+      component: () => import("@/views/Setup.vue"),
     },
     {
-      path: '/login',
-      name: 'login',
-      component: () => import('@/views/Login.vue'),
+      path: "/login",
+      name: "login",
+      component: () => import("@/views/Login.vue"),
     },
     {
-      path: '/',
-      name: 'dashboard',
-      component: () => import('@/views/Dashboard.vue'),
+      path: "/",
+      name: "dashboard",
+      component: () => import("@/views/Dashboard.vue"),
       meta: { requiresAuth: true },
     },
     {
-      path: '/providers',
-      name: 'providers',
-      component: () => import('@/views/Providers.vue'),
+      path: "/providers",
+      name: "providers",
+      component: () => import("@/views/Providers.vue"),
       meta: { requiresAuth: true },
     },
     {
-      path: '/mappings',
-      name: 'mappings',
-      component: () => import('@/views/ModelMappings.vue'),
+      path: "/mappings",
+      name: "mappings",
+      component: () => import("@/views/ModelMappings.vue"),
       meta: { requiresAuth: true },
     },
     {
-      path: '/retry-rules',
-      name: 'retry-rules',
-      component: () => import('@/views/RetryRules.vue'),
+      path: "/retry-rules",
+      name: "retry-rules",
+      component: () => import("@/views/RetryRules.vue"),
       meta: { requiresAuth: true },
     },
     {
-      path: '/router-keys',
-      name: 'router-keys',
-      component: () => import('@/views/RouterKeys.vue'),
+      path: "/router-keys",
+      name: "router-keys",
+      component: () => import("@/views/RouterKeys.vue"),
       meta: { requiresAuth: true },
     },
     {
-      path: '/proxy-enhancement',
-      name: 'proxy-enhancement',
-      component: () => import('@/views/ProxyEnhancement.vue'),
+      path: "/proxy-enhancement",
+      name: "proxy-enhancement",
+      component: () => import("@/views/ProxyEnhancement.vue"),
       meta: { requiresAuth: true },
     },
     {
-      path: '/schedules',
-      name: 'schedules',
-      component: () => import('@/views/Schedules.vue'),
+      path: "/schedules",
+      name: "schedules",
+      component: () => import("@/views/Schedules.vue"),
       meta: { requiresAuth: true },
     },
     {
-      path: '/logs',
-      name: 'logs',
-      component: () => import('@/views/Logs.vue'),
+      path: "/logs",
+      name: "logs",
+      component: () => import("@/views/Logs.vue"),
       meta: { requiresAuth: true },
     },
     {
-      path: '/monitor',
-      name: 'monitor',
-      component: () => import('@/views/Monitor.vue'),
+      path: "/monitor",
+      name: "monitor",
+      component: () => import("@/views/Monitor.vue"),
       meta: { requiresAuth: true },
     },
     {
-      path: '/quick-setup',
-      name: 'quick-setup',
-      component: () => import('@/views/QuickSetup.vue'),
+      path: "/quick-setup",
+      name: "quick-setup",
+      component: () => import("@/views/QuickSetup.vue"),
       meta: { requiresAuth: true },
     },
     {
-      path: '/settings',
-      name: 'settings',
-      component: () => import('@/views/Settings.vue'),
+      path: "/settings",
+      name: "settings",
+      component: () => import("@/views/Settings.vue"),
       meta: { requiresAuth: true },
     },
     {
-      path: '/:pathMatch(.*)*',
-      redirect: '/',
+      path: "/:pathMatch(.*)*",
+      redirect: "/",
     },
   ],
-})
+});
 
 // 全局 setup 状态缓存
-let setupChecked = false
-let isSetupInitialized = false
+let setupChecked = false;
+let isSetupInitialized = false;
+
+/** 认证状态（由 router guard 驱动，供 App.vue 使用） */
+export const isAuthenticated = ref(false);
 
 /** 供 Setup 页面调用：setup 完成后刷新缓存状态 */
 export function markSetupDone() {
-  setupChecked = true
-  isSetupInitialized = true
+  setupChecked = true;
+  isSetupInitialized = true;
 }
 
 router.beforeEach(async (to, _from, next) => {
   if (!setupChecked) {
     try {
-      const status = await api.getSetupStatus()
-      setupChecked = true
-      isSetupInitialized = status.initialized
-      if (!status.initialized && to.name !== 'setup') {
-        next('/setup')
-        return
+      const status = await api.getSetupStatus();
+      setupChecked = true;
+      isSetupInitialized = status.initialized;
+      if (!status.initialized && to.name !== "setup") {
+        isAuthenticated.value = false;
+        next("/setup");
+        return;
       }
-      if (status.initialized && to.name === 'setup') {
-        next('/login')
-        return
+      if (status.initialized && to.name === "setup") {
+        isAuthenticated.value = false;
+        next("/login");
+        return;
       }
     } catch {
-      next()
-      return
+      next();
+      return;
     }
   }
 
   if (to.meta.requiresAuth && isSetupInitialized) {
     try {
-      await api.getStats()
-      next()
+      await api.getStats();
+      isAuthenticated.value = true;
+      next();
     } catch {
-      next('/login')
+      isAuthenticated.value = false;
+      next("/login");
     }
   } else {
-    next()
+    // setup/login 等非认证页面
+    isAuthenticated.value = false;
+    next();
   }
-})
+});
 
-export default router
+export default router;

--- a/frontend/src/types/concurrency.ts
+++ b/frontend/src/types/concurrency.ts
@@ -1,0 +1,1 @@
+export type ConcurrencyMode = "auto" | "manual" | "none";

--- a/frontend/src/types/models.ts
+++ b/frontend/src/types/models.ts
@@ -1,0 +1,22 @@
+export interface RetryRule {
+  id: string;
+  name: string;
+  status_code: number;
+  body_pattern: string;
+  is_active: number;
+  created_at: string;
+  retry_strategy: "fixed" | "exponential";
+  retry_delay_ms: number;
+  max_retries: number;
+  max_delay_ms: number;
+}
+
+export interface RouterKey {
+  id: string;
+  name: string;
+  key: string | null;
+  key_prefix: string;
+  allowed_models: string[] | null;
+  is_active: number;
+  created_at: string;
+}

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -1,51 +1,96 @@
-import { i18n } from '@/i18n'
+import { i18n } from "@/i18n";
 
 function currentLocale(): string {
-  return i18n.global.locale.value
+  return i18n.global.locale.value;
 }
 
 /** 项目展示时区，所有用户可见的时间都应通过此常量格式化 */
-const DISPLAY_TZ = 'Asia/Shanghai'
+const DISPLAY_TZ = "Asia/Shanghai";
 
-const TZ_OPTS: Intl.DateTimeFormatOptions = { timeZone: DISPLAY_TZ }
+const TZ_OPTS: Intl.DateTimeFormatOptions = { timeZone: DISPLAY_TZ };
 
 // --- 解析 ---
 
 /** 将后端返回的 UTC datetime 字符串正确解析为 Date（补 Z 后缀避免被当作本地时间） */
 export function parseUtc(iso: string): Date {
-  return new Date(iso.endsWith('Z') || iso.includes('+') ? iso : iso.replace(' ', 'T') + 'Z')
+  return new Date(
+    iso.endsWith("Z") || iso.includes("+") ? iso : iso.replace(" ", "T") + "Z",
+  );
 }
 
 // --- 格式化 ---
 
 /** 完整时间：2026/04/25 20:21:00 */
 export function formatTime(iso: string): string {
-  return parseUtc(iso).toLocaleString(currentLocale(), TZ_OPTS)
+  return parseUtc(iso).toLocaleString(currentLocale(), TZ_OPTS);
 }
 
 /** 短时间：04/25 20:21（用于表格、图表标签等紧凑场景） */
 export function formatTimeShort(iso: string): string {
   return parseUtc(iso).toLocaleString(currentLocale(), {
     ...TZ_OPTS,
-    month: '2-digit',
-    day: '2-digit',
-    hour: '2-digit',
-    minute: '2-digit',
-  })
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
 }
 
 /** 仅时分：20:21（用于图表 x 轴等） */
 export function formatTimeHM(date: Date): string {
-  return date.toLocaleTimeString(currentLocale(), { ...TZ_OPTS, hour: '2-digit', minute: '2-digit' })
+  return date.toLocaleTimeString(currentLocale(), {
+    ...TZ_OPTS,
+    hour: "2-digit",
+    minute: "2-digit",
+  });
 }
 
 /** 月日时分：4/25 20:00（用于长周期图表标签） */
 export function formatTimeMDH(date: Date): string {
   return date.toLocaleString(currentLocale(), {
     ...TZ_OPTS,
-    month: 'numeric',
-    day: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
-  })
+    month: "numeric",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+// --- 数值格式化 ---
+
+/** 日期字符串 → ISO 开始时间（00:00:00.000Z） */
+export function toIsoStart(dateStr: string): string {
+  if (dateStr.includes("T")) return `${dateStr}:00.000Z`;
+  return `${dateStr}T00:00:00.000Z`;
+}
+
+/** 日期字符串 → ISO 结束时间（23:59:59.999Z） */
+export function toIsoEnd(dateStr: string): string {
+  if (dateStr.includes("T")) return `${dateStr}:59.999Z`;
+  return `${dateStr}T23:59:59.999Z`;
+}
+
+const BYTES_PER_KB = 1024;
+const BYTES_PER_MB = BYTES_PER_KB * BYTES_PER_KB;
+
+/** 字节数 → 可读字符串（B / KB / MB） */
+export function formatBytes(bytes: number): string {
+  if (bytes < BYTES_PER_KB) return `${bytes}B`;
+  if (bytes < BYTES_PER_MB) return `${(bytes / BYTES_PER_KB).toFixed(1)}KB`;
+  return `${(bytes / BYTES_PER_MB).toFixed(1)}MB`;
+}
+export function formatSize(text: string): string {
+  const bytes = new TextEncoder().encode(text).length;
+  if (bytes < BYTES_PER_KB) return `${bytes}B`;
+  return `${(bytes / BYTES_PER_KB).toFixed(1)}KB`;
+}
+
+const CONTEXT_MILLION = 1_000_000;
+const CONTEXT_THOUSAND = 1_000;
+
+/** 上下文窗口数字 → 可读字符串（n / nK / nM） */
+export function formatContextWindow(n: number): string {
+  if (n >= CONTEXT_MILLION) return `${n / CONTEXT_MILLION}M`;
+  if (n >= CONTEXT_THOUSAND) return `${n / CONTEXT_THOUSAND}K`;
+  return `${n}`;
 }

--- a/frontend/src/utils/model-patches.ts
+++ b/frontend/src/utils/model-patches.ts
@@ -1,0 +1,24 @@
+/** 根据模型名称和 API 格式计算默认 patches */
+export function computeDefaultPatches(
+  modelName: string,
+  format: string,
+  isNonOpenaiEndpoint: boolean,
+): string[] {
+  const patches: string[] = [];
+  const isDeepseek = modelName.toLowerCase().includes("deepseek");
+  if (isDeepseek) {
+    patches.push("thinking-consistency");
+    if (format === "anthropic") {
+      patches.push("orphan-tool-results");
+    } else {
+      patches.push("orphan-tool-results-oa");
+    }
+  }
+  if (format === "openai" && isNonOpenaiEndpoint) {
+    patches.push("developer-role");
+  }
+  if (format === "openai-responses") {
+    patches.push("anthropic-arguments");
+  }
+  return patches;
+}

--- a/frontend/src/views/Monitor.vue
+++ b/frontend/src/views/Monitor.vue
@@ -3,10 +3,12 @@
   <div class="p-6">
     <!-- Header: connection status + overview stats -->
     <div class="flex items-center justify-between mb-4">
-      <h2 class="text-lg font-semibold text-foreground">{{ t('monitor.title') }}</h2>
+      <h2 class="text-lg font-semibold text-foreground">
+        {{ t("monitor.title") }}
+      </h2>
       <div class="flex items-center gap-2">
         <Badge :variant="connected ? 'default' : 'destructive'">
-          {{ connected ? t('monitor.connected') : t('monitor.disconnected') }}
+          {{ connected ? t("monitor.connected") : t("monitor.disconnected") }}
         </Badge>
       </div>
     </div>
@@ -24,15 +26,20 @@
       <Card>
         <CardHeader class="pb-2">
           <div class="flex items-center justify-between">
-            <CardTitle class="text-sm font-medium text-foreground">{{ t('monitor.activeRequests') }}</CardTitle>
+            <CardTitle class="text-sm font-medium text-foreground">{{
+              t("monitor.activeRequests")
+            }}</CardTitle>
             <Badge variant="secondary">{{ streamingRequests.length }}</Badge>
           </div>
         </CardHeader>
         <CardContent>
           <TooltipProvider :delay-duration="300">
             <ScrollArea class="h-64">
-              <div v-if="streamingRequests.length === 0" class="text-sm text-muted-foreground py-2">
-                {{ t('monitor.noActiveRequests') }}
+              <div
+                v-if="streamingRequests.length === 0"
+                class="text-sm text-muted-foreground py-2"
+              >
+                {{ t("monitor.noActiveRequests") }}
               </div>
               <div
                 v-for="req in streamingRequests"
@@ -44,32 +51,62 @@
                 <Badge :variant="statusVariant(req.status)" class="shrink-0">
                   {{ statusLabel(req.status) }}
                 </Badge>
-                <span class="text-sm text-foreground truncate flex-1">{{ req.model }}</span>
-                <Badge variant="outline" class="shrink-0 text-xs">{{ req.providerName }}</Badge>
-                <span class="text-xs text-muted-foreground shrink-0">{{ elapsed(req.startTime) }}s</span>
-                <span v-if="req.streamMetrics?.tokensPerSecond" class="text-xs text-muted-foreground shrink-0">
+                <span class="text-sm text-foreground truncate flex-1">{{
+                  req.model
+                }}</span>
+                <Badge variant="outline" class="shrink-0 text-xs">{{
+                  req.providerName
+                }}</Badge>
+                <span class="text-xs text-muted-foreground shrink-0"
+                  >{{ elapsed(req.startTime) }}s</span
+                >
+                <span
+                  v-if="req.streamMetrics?.tokensPerSecond"
+                  class="text-xs text-muted-foreground shrink-0"
+                >
                   {{ req.streamMetrics.tokensPerSecond.toFixed(0) }} t/s
                 </span>
-                <span v-if="req.streamMetrics?.outputTokens" class="text-xs text-muted-foreground shrink-0">
+                <span
+                  v-if="req.streamMetrics?.outputTokens"
+                  class="text-xs text-muted-foreground shrink-0"
+                >
                   {{ req.streamMetrics.outputTokens }} tok
                 </span>
-                <Badge v-if="req.isStream" variant="outline" class="shrink-0 text-xs">SSE</Badge>
+                <Badge
+                  v-if="req.isStream"
+                  variant="outline"
+                  class="shrink-0 text-xs"
+                  >SSE</Badge
+                >
                 <Tooltip>
                   <TooltipTrigger as-child>
-                    <Button variant="ghost" size="icon-xs" class="shrink-0" @click.stop="copy(req.id)">
-                      <CheckIcon v-if="copied" class="size-3 text-success" />
+                    <Button
+                      variant="ghost"
+                      size="icon-xs"
+                      class="shrink-0"
+                      @click.stop="copyId(req.id)"
+                    >
+                      <CheckIcon
+                        v-if="copiedId === req.id"
+                        class="size-3 text-success"
+                      />
                       <CopyIcon v-else class="size-3" />
                     </Button>
                   </TooltipTrigger>
-                  <TooltipContent>{{ t('monitor.copyId') }}</TooltipContent>
+                  <TooltipContent>{{ t("monitor.copyId") }}</TooltipContent>
                 </Tooltip>
                 <Tooltip>
                   <TooltipTrigger as-child>
-                    <Button variant="ghost" size="icon-xs" class="shrink-0 text-destructive hover:text-destructive" @click.stop="openKillDialog(req.id)">
+                    <Button
+                      variant="ghost"
+                      size="icon-xs"
+                      class="shrink-0 text-destructive hover:text-destructive"
+                      @click.stop="openKillDialog(req.id)"
+                    >
                       <XIcon class="size-3" />
                     </Button>
                   </TooltipTrigger>
-                  <TooltipContent>{{ t('monitor.kill') }}</TooltipContent>
+                  <TooltipContent>{{ t("monitor.kill") }}</TooltipContent>
                 </Tooltip>
               </div>
             </ScrollArea>
@@ -81,15 +118,20 @@
       <Card>
         <CardHeader class="pb-2">
           <div class="flex items-center justify-between">
-            <CardTitle class="text-sm font-medium text-foreground">{{ t('monitor.queuedRequests') }}</CardTitle>
+            <CardTitle class="text-sm font-medium text-foreground">{{
+              t("monitor.queuedRequests")
+            }}</CardTitle>
             <Badge variant="secondary">{{ queuedRequests.length }}</Badge>
           </div>
         </CardHeader>
         <CardContent>
           <TooltipProvider :delay-duration="300">
             <ScrollArea class="h-64">
-              <div v-if="queuedRequests.length === 0" class="text-sm text-muted-foreground py-2">
-                {{ t('monitor.noQueuedRequests') }}
+              <div
+                v-if="queuedRequests.length === 0"
+                class="text-sm text-muted-foreground py-2"
+              >
+                {{ t("monitor.noQueuedRequests") }}
               </div>
               <div
                 v-for="req in queuedRequests"
@@ -99,27 +141,46 @@
                 @click="selectRequest(req.id)"
               >
                 <Badge variant="outline" class="shrink-0">
-                  {{ t('monitor.queued') }}
+                  {{ t("monitor.queued") }}
                 </Badge>
-                <span class="text-sm text-foreground truncate flex-1">{{ req.model }}</span>
-                <Badge variant="outline" class="shrink-0 text-xs">{{ req.providerName }}</Badge>
-                <span class="text-xs text-muted-foreground shrink-0">{{ elapsed(req.startTime) }}s</span>
+                <span class="text-sm text-foreground truncate flex-1">{{
+                  req.model
+                }}</span>
+                <Badge variant="outline" class="shrink-0 text-xs">{{
+                  req.providerName
+                }}</Badge>
+                <span class="text-xs text-muted-foreground shrink-0"
+                  >{{ elapsed(req.startTime) }}s</span
+                >
                 <Tooltip>
                   <TooltipTrigger as-child>
-                    <Button variant="ghost" size="icon-xs" class="shrink-0" @click.stop="copy(req.id)">
-                      <CheckIcon v-if="copied" class="size-3 text-success" />
+                    <Button
+                      variant="ghost"
+                      size="icon-xs"
+                      class="shrink-0"
+                      @click.stop="copyId(req.id)"
+                    >
+                      <CheckIcon
+                        v-if="copiedId === req.id"
+                        class="size-3 text-success"
+                      />
                       <CopyIcon v-else class="size-3" />
                     </Button>
                   </TooltipTrigger>
-                  <TooltipContent>{{ t('monitor.copyId') }}</TooltipContent>
+                  <TooltipContent>{{ t("monitor.copyId") }}</TooltipContent>
                 </Tooltip>
                 <Tooltip>
                   <TooltipTrigger as-child>
-                    <Button variant="ghost" size="icon-xs" class="shrink-0 text-destructive hover:text-destructive" @click.stop="openKillDialog(req.id)">
+                    <Button
+                      variant="ghost"
+                      size="icon-xs"
+                      class="shrink-0 text-destructive hover:text-destructive"
+                      @click.stop="openKillDialog(req.id)"
+                    >
                       <XIcon class="size-3" />
                     </Button>
                   </TooltipTrigger>
-                  <TooltipContent>{{ t('monitor.kill') }}</TooltipContent>
+                  <TooltipContent>{{ t("monitor.kill") }}</TooltipContent>
                 </Tooltip>
               </div>
             </ScrollArea>
@@ -131,15 +192,20 @@
       <Card>
         <CardHeader class="pb-2">
           <div class="flex items-center justify-between">
-            <CardTitle class="text-sm font-medium text-foreground">{{ t('monitor.completed') }}</CardTitle>
+            <CardTitle class="text-sm font-medium text-foreground">{{
+              t("monitor.completed")
+            }}</CardTitle>
             <Badge variant="secondary">{{ recentCompleted.length }}</Badge>
           </div>
         </CardHeader>
         <CardContent>
           <TooltipProvider :delay-duration="300">
             <ScrollArea class="h-64">
-              <div v-if="recentCompleted.length === 0" class="text-sm text-muted-foreground py-2">
-                {{ t('monitor.noCompletedRequests') }}
+              <div
+                v-if="recentCompleted.length === 0"
+                class="text-sm text-muted-foreground py-2"
+              >
+                {{ t("monitor.noCompletedRequests") }}
               </div>
               <div
                 v-for="req in recentCompleted"
@@ -151,18 +217,37 @@
                 <Badge :variant="statusVariant(req.status)" class="shrink-0">
                   {{ statusLabel(req.status) }}
                 </Badge>
-                <span class="text-sm text-foreground truncate flex-1">{{ req.model }}</span>
-                <Badge variant="outline" class="shrink-0 text-xs">{{ req.providerName }}</Badge>
-                <Badge v-if="req.isStream" variant="outline" class="shrink-0 text-xs">SSE</Badge>
-                <span class="text-xs text-muted-foreground shrink-0">{{ duration(req) }}</span>
+                <span class="text-sm text-foreground truncate flex-1">{{
+                  req.model
+                }}</span>
+                <Badge variant="outline" class="shrink-0 text-xs">{{
+                  req.providerName
+                }}</Badge>
+                <Badge
+                  v-if="req.isStream"
+                  variant="outline"
+                  class="shrink-0 text-xs"
+                  >SSE</Badge
+                >
+                <span class="text-xs text-muted-foreground shrink-0">{{
+                  duration(req)
+                }}</span>
                 <Tooltip>
                   <TooltipTrigger as-child>
-                    <Button variant="ghost" size="icon-xs" class="shrink-0" @click.stop="copy(req.id)">
-                      <CheckIcon v-if="copied" class="size-3 text-success" />
+                    <Button
+                      variant="ghost"
+                      size="icon-xs"
+                      class="shrink-0"
+                      @click.stop="copyId(req.id)"
+                    >
+                      <CheckIcon
+                        v-if="copiedId === req.id"
+                        class="size-3 text-success"
+                      />
                       <CopyIcon v-else class="size-3" />
                     </Button>
                   </TooltipTrigger>
-                  <TooltipContent>{{ t('monitor.copyId') }}</TooltipContent>
+                  <TooltipContent>{{ t("monitor.copyId") }}</TooltipContent>
                 </Tooltip>
               </div>
             </ScrollArea>
@@ -174,7 +259,9 @@
     <!-- Provider Stats Table -->
     <Card class="mb-4">
       <CardHeader>
-        <CardTitle class="text-sm font-medium text-foreground">{{ t('monitor.providerStats') }}</CardTitle>
+        <CardTitle class="text-sm font-medium text-foreground">{{
+          t("monitor.providerStats")
+        }}</CardTitle>
       </CardHeader>
       <CardContent>
         <ProviderStatsTable :stats="stats" />
@@ -185,7 +272,9 @@
     <div class="grid grid-cols-1 lg:grid-cols-3 gap-4">
       <Card>
         <CardHeader>
-          <CardTitle class="text-sm font-medium text-foreground">{{ t('monitor.concurrency') }}</CardTitle>
+          <CardTitle class="text-sm font-medium text-foreground">{{
+            t("monitor.concurrency")
+          }}</CardTitle>
         </CardHeader>
         <CardContent>
           <ConcurrencyPanel :providers="concurrency" />
@@ -194,7 +283,9 @@
 
       <Card>
         <CardHeader>
-          <CardTitle class="text-sm font-medium text-foreground">{{ t('monitor.statusCodeDistribution') }}</CardTitle>
+          <CardTitle class="text-sm font-medium text-foreground">{{
+            t("monitor.statusCodeDistribution")
+          }}</CardTitle>
         </CardHeader>
         <CardContent>
           <StatusCodePanel :by-status-code="stats?.byStatusCode ?? {}" />
@@ -203,7 +294,9 @@
 
       <Card>
         <CardHeader>
-          <CardTitle class="text-sm font-medium text-foreground">{{ t('monitor.runtime') }}</CardTitle>
+          <CardTitle class="text-sm font-medium text-foreground">{{
+            t("monitor.runtime")
+          }}</CardTitle>
         </CardHeader>
         <CardContent>
           <RuntimePanel :runtime="runtime" />
@@ -224,15 +317,25 @@
     <AlertDialog v-model:open="killDialogOpen">
       <AlertDialogContent>
         <AlertDialogHeader>
-          <AlertDialogTitle>{{ t('monitor.killConfirmTitle') }}</AlertDialogTitle>
+          <AlertDialogTitle>{{
+            t("monitor.killConfirmTitle")
+          }}</AlertDialogTitle>
           <AlertDialogDescription v-if="killTarget">
-            {{ t('monitor.killConfirm', { model: killTarget.model, provider: killTarget.providerName }) }}
+            {{
+              t("monitor.killConfirm", {
+                model: killTarget.model,
+                provider: killTarget.providerName,
+              })
+            }}
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>
-          <AlertDialogCancel>{{ t('monitor.killCancel') }}</AlertDialogCancel>
-          <AlertDialogAction class="bg-destructive text-destructive-foreground hover:bg-destructive/90" @click="executeKill">
-            {{ t('monitor.kill') }}
+          <AlertDialogCancel>{{ t("monitor.killCancel") }}</AlertDialogCancel>
+          <AlertDialogAction
+            class="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            @click="executeKill"
+          >
+            {{ t("monitor.kill") }}
           </AlertDialogAction>
         </AlertDialogFooter>
       </AlertDialogContent>
@@ -241,29 +344,43 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, onUnmounted, ref } from 'vue'
-import { useI18n } from 'vue-i18n'
-import { Badge } from '@/components/ui/badge'
-import { Button } from '@/components/ui/button'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { ScrollArea } from '@/components/ui/scroll-area'
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
-import { CheckIcon, CopyIcon, XIcon } from 'lucide-vue-next'
-import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from '@/components/ui/alert-dialog'
-import { api, getApiMessage } from '@/api/client'
-import { toast } from 'vue-sonner'
-import MonitorHeader from '@/components/monitor/MonitorHeader.vue'
-import ConcurrencyPanel from '@/components/monitor/ConcurrencyPanel.vue'
-import RuntimePanel from '@/components/monitor/RuntimePanel.vue'
-import StatusCodePanel from '@/components/monitor/StatusCodePanel.vue'
-import ProviderStatsTable from '@/components/monitor/ProviderStatsTable.vue'
-import UnifiedRequestDialog from '@/components/request-detail/UnifiedRequestDialog.vue'
-import { useMonitorSSE } from '@/composables/useMonitorSSE'
-import { useMonitorData } from '@/composables/useMonitorData'
-import { useClipboard } from '@/composables/useClipboard'
-import { statusVariant, statusLabel } from '@/utils/status'
+import { computed, onMounted, onUnmounted, ref } from "vue";
+import { useI18n } from "vue-i18n";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { CheckIcon, CopyIcon, XIcon } from "lucide-vue-next";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { api, getApiMessage } from "@/api/client";
+import { toast } from "vue-sonner";
+import MonitorHeader from "@/components/monitor/MonitorHeader.vue";
+import ConcurrencyPanel from "@/components/monitor/ConcurrencyPanel.vue";
+import RuntimePanel from "@/components/monitor/RuntimePanel.vue";
+import StatusCodePanel from "@/components/monitor/StatusCodePanel.vue";
+import ProviderStatsTable from "@/components/monitor/ProviderStatsTable.vue";
+import UnifiedRequestDialog from "@/components/request-detail/UnifiedRequestDialog.vue";
+import { useMonitorSSE } from "@/composables/useMonitorSSE";
+import { useMonitorData } from "@/composables/useMonitorData";
+import { useClipboard } from "@/composables/useClipboard";
+import { statusVariant, statusLabel } from "@/utils/status";
 
-const { t } = useI18n()
+const { t } = useI18n();
 
 // --- Data layer ---
 const {
@@ -286,11 +403,11 @@ const {
   handleSSEOpen,
   handleSSEClose,
   loadInitialData,
-} = useMonitorData()
+} = useMonitorData();
 
 // --- SSE lifecycle (onOpen/onClose 驱动 connected 状态) ---
 const { connect } = useMonitorSSE(
-  '/admin/api/monitor/stream',
+  "/admin/api/monitor/stream",
   {
     request_start: handleSSEMessage,
     request_update: handleSSEMessage,
@@ -301,85 +418,99 @@ const { connect } = useMonitorSSE(
     stream_content_update: handleSSEMessage,
   },
   { onOpen: handleSSEOpen, onClose: handleSSEClose },
-)
+);
 
-const { copied, copy } = useClipboard()
+const { copy } = useClipboard();
+const copiedId = ref<string | null>(null);
+const COPY_FEEDBACK_MS = 2000;
+
+function copyId(id: string) {
+  copy(id);
+  copiedId.value = id;
+  setTimeout(() => {
+    if (copiedId.value === id) copiedId.value = null;
+  }, COPY_FEEDBACK_MS);
+}
 
 // --- Kill request ---
-const killDialogOpen = ref(false)
-const killTargetId = ref<string | null>(null)
+const killDialogOpen = ref(false);
+const killTargetId = ref<string | null>(null);
 const killTarget = computed(() => {
-  if (!killTargetId.value) return null
-  return activeRequests.value.find(r => r.id === killTargetId.value) ?? null
-})
+  if (!killTargetId.value) return null;
+  return activeRequests.value.find((r) => r.id === killTargetId.value) ?? null;
+});
 
 function openKillDialog(id: string) {
-  killTargetId.value = id
-  killDialogOpen.value = true
+  killTargetId.value = id;
+  killDialogOpen.value = true;
 }
 
 async function executeKill() {
-  if (!killTargetId.value) return
+  if (!killTargetId.value) return;
   try {
-    await api.killMonitorRequest(killTargetId.value)
+    await api.killMonitorRequest(killTargetId.value);
     // 立即从活跃列表移除，不等 SSE
-    activeRequests.value = activeRequests.value.filter(r => r.id !== killTargetId.value)
-    toast.success(t('monitor.killSuccess'))
+    activeRequests.value = activeRequests.value.filter(
+      (r) => r.id !== killTargetId.value,
+    );
+    toast.success(t("monitor.killSuccess"));
   } catch (e: unknown) {
-    console.error('Monitor.killRequest:', e)
-    toast.error(getApiMessage(e, t('monitor.killFailed')))
+    console.error("Monitor.killRequest:", e);
+    toast.error(getApiMessage(e, t("monitor.killFailed")));
   }
-  killDialogOpen.value = false
+  killDialogOpen.value = false;
 }
 
 // --- Helper functions ---
 
-const MS_PER_SECOND = 1000
-const NOW_TICK_INTERVAL = 3000
-const now = ref(Date.now())
-let tickTimer: ReturnType<typeof setInterval> | null = null
+const MS_PER_SECOND = 1000;
+const NOW_TICK_INTERVAL = 3000;
+const now = ref(Date.now());
+let tickTimer: ReturnType<typeof setInterval> | null = null;
 
 function startTick() {
-  stopTick()
-  tickTimer = setInterval(() => { now.value = Date.now() }, NOW_TICK_INTERVAL)
+  stopTick();
+  tickTimer = setInterval(() => {
+    now.value = Date.now();
+  }, NOW_TICK_INTERVAL);
 }
 
 function stopTick() {
   if (tickTimer) {
-    clearInterval(tickTimer)
-    tickTimer = null
+    clearInterval(tickTimer);
+    tickTimer = null;
   }
 }
 
 function handleMonitorVisibility() {
   if (document.hidden) {
-    stopTick()
+    stopTick();
   } else {
-    now.value = Date.now()
-    startTick()
+    now.value = Date.now();
+    startTick();
   }
 }
 
 function elapsed(startTime: number): string {
-  return ((now.value - startTime) / MS_PER_SECOND).toFixed(1)
+  return ((now.value - startTime) / MS_PER_SECOND).toFixed(1);
 }
 
 function duration(req: { completedAt?: number; startTime: number }): string {
-  if (!req.completedAt) return '--'
-  return ((req.completedAt - req.startTime) / MS_PER_SECOND).toFixed(1) + 's'
+  if (!req.completedAt) return "--";
+  return ((req.completedAt - req.startTime) / MS_PER_SECOND).toFixed(1) + "s";
 }
 
 // --- Lifecycle ---
 
 onMounted(async () => {
-  await loadInitialData()
-  connect()
-  startTick()
-  document.addEventListener('visibilitychange', handleMonitorVisibility)
-})
+  await loadInitialData();
+  connect();
+  startTick();
+  document.addEventListener("visibilitychange", handleMonitorVisibility);
+});
 
 onUnmounted(() => {
-  stopTick()
-  document.removeEventListener('visibilitychange', handleMonitorVisibility)
-})
+  stopTick();
+  document.removeEventListener("visibilitychange", handleMonitorVisibility);
+});
 </script>

--- a/frontend/src/views/RetryRules.vue
+++ b/frontend/src/views/RetryRules.vue
@@ -1,12 +1,24 @@
 <template>
   <div class="p-6">
     <div class="flex items-center justify-between mb-4">
-      <h2 class="text-lg font-semibold text-foreground">{{ t('retryRules.title') }}</h2>
+      <h2 class="text-lg font-semibold text-foreground">
+        {{ t("retryRules.title") }}
+      </h2>
       <Button @click="openCreate" class="flex items-center gap-1">
-        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/>
+        <svg
+          class="w-4 h-4"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M12 4v16m8-8H4"
+          />
         </svg>
-        {{ t('retryRules.addRule') }}
+        {{ t("retryRules.addRule") }}
       </Button>
     </div>
 
@@ -14,38 +26,82 @@
       <Table>
         <TableHeader>
           <TableRow class="bg-muted">
-            <TableHead class="text-muted-foreground">{{ t('retryRules.tableHeaders.name') }}</TableHead>
-            <TableHead class="text-muted-foreground">{{ t('retryRules.tableHeaders.statusCode') }}</TableHead>
-            <TableHead class="text-muted-foreground">{{ t('retryRules.tableHeaders.bodyPattern') }}</TableHead>
-            <TableHead class="text-muted-foreground">{{ t('retryRules.tableHeaders.retryStrategy') }}</TableHead>
-            <TableHead class="text-muted-foreground">{{ t('retryRules.tableHeaders.status') }}</TableHead>
-            <TableHead class="text-right text-muted-foreground">{{ t('retryRules.tableHeaders.actions') }}</TableHead>
+            <TableHead class="text-muted-foreground">{{
+              t("retryRules.tableHeaders.name")
+            }}</TableHead>
+            <TableHead class="text-muted-foreground">{{
+              t("retryRules.tableHeaders.statusCode")
+            }}</TableHead>
+            <TableHead class="text-muted-foreground">{{
+              t("retryRules.tableHeaders.bodyPattern")
+            }}</TableHead>
+            <TableHead class="text-muted-foreground">{{
+              t("retryRules.tableHeaders.retryStrategy")
+            }}</TableHead>
+            <TableHead class="text-muted-foreground">{{
+              t("retryRules.tableHeaders.status")
+            }}</TableHead>
+            <TableHead class="text-right text-muted-foreground">{{
+              t("retryRules.tableHeaders.actions")
+            }}</TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>
           <TableRow v-for="r in rules" :key="r.id">
             <TableCell class="font-mono text-sm">{{ r.name }}</TableCell>
             <TableCell>{{ r.status_code }}</TableCell>
-            <TableCell class="font-mono text-xs text-muted-foreground">{{ r.body_pattern }}</TableCell>
+            <TableCell class="font-mono text-xs text-muted-foreground">{{
+              r.body_pattern
+            }}</TableCell>
             <TableCell>
               <div class="flex items-center gap-2">
-                <Badge variant="outline">{{ r.retry_strategy === 'fixed' ? t('retryRules.strategy.fixed') : t('retryRules.strategy.exponential') }}</Badge>
+                <Badge variant="outline">{{
+                  r.retry_strategy === "fixed"
+                    ? t("retryRules.strategy.fixed")
+                    : t("retryRules.strategy.exponential")
+                }}</Badge>
                 <span class="text-xs text-muted-foreground">
-                  {{ r.retry_delay_ms / 1000 }}s · {{ t('retryRules.times', { count: r.max_retries }) }}
-                  <template v-if="r.retry_strategy === 'exponential'"> · {{ t('retryRules.upperLimit', { value: r.max_delay_ms / 1000 }) }}</template>
+                  {{ r.retry_delay_ms / 1000 }}s ·
+                  {{ t("retryRules.times", { count: r.max_retries }) }}
+                  <template v-if="r.retry_strategy === 'exponential'">
+                    ·
+                    {{
+                      t("retryRules.upperLimit", {
+                        value: r.max_delay_ms / 1000,
+                      })
+                    }}</template
+                  >
                 </span>
               </div>
             </TableCell>
             <TableCell>
-              <Badge :variant="r.is_active ? 'default' : 'secondary'">{{ r.is_active ? t('common.enabled') : t('common.disabled') }}</Badge>
+              <Badge :variant="r.is_active ? 'default' : 'secondary'">{{
+                r.is_active ? t("common.enabled") : t("common.disabled")
+              }}</Badge>
             </TableCell>
             <TableCell class="text-right">
-              <Button variant="ghost" size="sm" @click="openEdit(r)" class="mr-2">{{ t('common.edit') }}</Button>
-              <Button variant="ghost" size="sm" class="text-destructive hover:text-destructive" @click="confirmDelete(r)">{{ t('common.delete') }}</Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                @click="openEdit(r)"
+                class="mr-2"
+                >{{ t("common.edit") }}</Button
+              >
+              <Button
+                variant="ghost"
+                size="sm"
+                class="text-destructive hover:text-destructive"
+                @click="confirmDelete(r)"
+                >{{ t("common.delete") }}</Button
+              >
             </TableCell>
           </TableRow>
           <TableRow v-if="rules.length === 0">
-            <TableCell colspan="6" class="text-center text-muted-foreground py-8">{{ t('retryRules.noRules') }}</TableCell>
+            <TableCell
+              colspan="6"
+              class="text-center text-muted-foreground py-8"
+              >{{ t("retryRules.noRules") }}</TableCell
+            >
           </TableRow>
         </TableBody>
       </Table>
@@ -55,76 +111,177 @@
     <Dialog v-model:open="dialogOpen">
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>{{ editingId ? t('retryRules.dialog.editRule') : t('retryRules.dialog.addRule') }}</DialogTitle>
+          <DialogTitle>{{
+            editingId
+              ? t("retryRules.dialog.editRule")
+              : t("retryRules.dialog.addRule")
+          }}</DialogTitle>
         </DialogHeader>
         <form @submit.prevent="handleSave" class="space-y-3">
           <div>
-            <Label class="block text-sm font-medium text-foreground mb-1">{{ t('retryRules.dialog.name') }}</Label>
-            <Input v-model="form.name" type="text" required @input="delete errors.name" />
-            <p v-if="errors.name" class="text-sm text-destructive mt-1">{{ errors.name }}</p>
+            <Label class="block text-sm font-medium text-foreground mb-1">{{
+              t("retryRules.dialog.name")
+            }}</Label>
+            <Input
+              v-model="form.name"
+              type="text"
+              required
+              @input="delete errors.name"
+            />
+            <p v-if="errors.name" class="text-sm text-destructive mt-1">
+              {{ errors.name }}
+            </p>
           </div>
           <div>
-            <Label class="block text-sm font-medium text-foreground mb-1">{{ t('retryRules.dialog.statusCode') }}</Label>
-            <Input v-model.number="form.status_code" type="number" required @input="delete errors.status_code" />
-            <p v-if="errors.status_code" class="text-sm text-destructive mt-1">{{ errors.status_code }}</p>
+            <Label class="block text-sm font-medium text-foreground mb-1">{{
+              t("retryRules.dialog.statusCode")
+            }}</Label>
+            <Input
+              v-model.number="form.status_code"
+              type="number"
+              required
+              @input="delete errors.status_code"
+            />
+            <p v-if="errors.status_code" class="text-sm text-destructive mt-1">
+              {{ errors.status_code }}
+            </p>
           </div>
           <div>
-            <Label class="block text-sm font-medium text-foreground mb-1">{{ t('retryRules.dialog.bodyPattern') }}</Label>
-            <Input v-model="form.body_pattern" type="text" :placeholder="t('retryRules.dialog.bodyPatternPlaceholder')" required @input="delete errors.body_pattern" />
-            <p v-if="errors.body_pattern" class="text-sm text-destructive mt-1">{{ errors.body_pattern }}</p>
+            <Label class="block text-sm font-medium text-foreground mb-1">{{
+              t("retryRules.dialog.bodyPattern")
+            }}</Label>
+            <Input
+              v-model="form.body_pattern"
+              type="text"
+              :placeholder="t('retryRules.dialog.bodyPatternPlaceholder')"
+              required
+              @input="delete errors.body_pattern"
+            />
+            <p v-if="errors.body_pattern" class="text-sm text-destructive mt-1">
+              {{ errors.body_pattern }}
+            </p>
           </div>
           <!-- 重试策略 -->
           <div>
-            <Label class="block text-sm font-medium text-foreground mb-1">{{ t('retryRules.dialog.retryStrategy') }}</Label>
+            <Label class="block text-sm font-medium text-foreground mb-1">{{
+              t("retryRules.dialog.retryStrategy")
+            }}</Label>
             <Select v-model="form.retry_strategy">
               <SelectTrigger class="w-full">
-                <SelectValue :placeholder="t('retryRules.dialog.selectStrategy')" />
+                <SelectValue
+                  :placeholder="t('retryRules.dialog.selectStrategy')"
+                />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="exponential">{{ t('retryRules.strategy.exponential') }}</SelectItem>
-                <SelectItem value="fixed">{{ t('retryRules.strategy.fixed') }}</SelectItem>
+                <SelectItem value="exponential">{{
+                  t("retryRules.strategy.exponential")
+                }}</SelectItem>
+                <SelectItem value="fixed">{{
+                  t("retryRules.strategy.fixed")
+                }}</SelectItem>
               </SelectContent>
             </Select>
           </div>
           <div class="grid grid-cols-2 gap-3">
             <div>
-              <Label class="block text-sm font-medium text-foreground mb-1">{{ form.retry_strategy === 'fixed' ? t('retryRules.dialog.intervalMs') : t('retryRules.dialog.initialDelayMs') }}</Label>
-              <Input v-model.number="form.retry_delay_ms" type="number" :min="100" required @input="delete errors.retry_delay_ms" />
-              <p v-if="errors.retry_delay_ms" class="text-sm text-destructive mt-1">{{ errors.retry_delay_ms }}</p>
+              <Label class="block text-sm font-medium text-foreground mb-1">{{
+                form.retry_strategy === "fixed"
+                  ? t("retryRules.dialog.intervalMs")
+                  : t("retryRules.dialog.initialDelayMs")
+              }}</Label>
+              <Input
+                v-model.number="form.retry_delay_ms"
+                type="number"
+                :min="100"
+                required
+                @input="delete errors.retry_delay_ms"
+              />
+              <p
+                v-if="errors.retry_delay_ms"
+                class="text-sm text-destructive mt-1"
+              >
+                {{ errors.retry_delay_ms }}
+              </p>
             </div>
             <div>
-              <Label class="block text-sm font-medium text-foreground mb-1">{{ t('retryRules.dialog.maxRetries') }}</Label>
-              <Input v-model.number="form.max_retries" type="number" :min="0" :max="100" required @input="delete errors.max_retries" />
-              <p v-if="errors.max_retries" class="text-sm text-destructive mt-1">{{ errors.max_retries }}</p>
+              <Label class="block text-sm font-medium text-foreground mb-1">{{
+                t("retryRules.dialog.maxRetries")
+              }}</Label>
+              <Input
+                v-model.number="form.max_retries"
+                type="number"
+                :min="0"
+                :max="100"
+                required
+                @input="delete errors.max_retries"
+              />
+              <p
+                v-if="errors.max_retries"
+                class="text-sm text-destructive mt-1"
+              >
+                {{ errors.max_retries }}
+              </p>
             </div>
           </div>
           <div v-if="form.retry_strategy === 'exponential'">
-            <Label class="block text-sm font-medium text-foreground mb-1">{{ t('retryRules.dialog.maxDelayMs') }}</Label>
-            <Input v-model.number="form.max_delay_ms" type="number" :min="100" required @input="delete errors.max_delay_ms" />
-            <p v-if="errors.max_delay_ms" class="text-sm text-destructive mt-1">{{ errors.max_delay_ms }}</p>
+            <Label class="block text-sm font-medium text-foreground mb-1">{{
+              t("retryRules.dialog.maxDelayMs")
+            }}</Label>
+            <Input
+              v-model.number="form.max_delay_ms"
+              type="number"
+              :min="100"
+              required
+              @input="delete errors.max_delay_ms"
+            />
+            <p v-if="errors.max_delay_ms" class="text-sm text-destructive mt-1">
+              {{ errors.max_delay_ms }}
+            </p>
           </div>
           <div class="flex items-center gap-2">
             <Checkbox v-model="form.is_active" id="rule-active" />
-            <Label for="rule-active" class="text-sm text-foreground">{{ t('retryRules.dialog.enable') }}</Label>
+            <Label for="rule-active" class="text-sm text-foreground">{{
+              t("retryRules.dialog.enable")
+            }}</Label>
           </div>
           <DialogFooter>
-            <Button type="button" variant="outline" @click="dialogOpen = false">{{ t('common.cancel') }}</Button>
-            <Button type="submit">{{ t('common.save') }}</Button>
+            <Button
+              type="button"
+              variant="outline"
+              @click="dialogOpen = false"
+              >{{ t("common.cancel") }}</Button
+            >
+            <Button type="submit">{{ t("common.save") }}</Button>
           </DialogFooter>
         </form>
       </DialogContent>
     </Dialog>
 
     <!-- Delete Confirm AlertDialog -->
-    <AlertDialog :open="!!deleteTarget" @update:open="(val) => { if (!val) deleteTarget = null }">
+    <AlertDialog
+      :open="!!deleteTarget"
+      @update:open="
+        (val) => {
+          if (!val) deleteTarget = null;
+        }
+      "
+    >
       <AlertDialogContent>
         <AlertDialogHeader>
-          <AlertDialogTitle>{{ t('retryRules.deleteConfirm.title') }}</AlertDialogTitle>
-          <AlertDialogDescription>{{ t('retryRules.deleteConfirm.description', { name: deleteTarget?.name }) }}</AlertDialogDescription>
+          <AlertDialogTitle>{{
+            t("retryRules.deleteConfirm.title")
+          }}</AlertDialogTitle>
+          <AlertDialogDescription>{{
+            t("retryRules.deleteConfirm.description", {
+              name: deleteTarget?.name,
+            })
+          }}</AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>
-          <AlertDialogCancel>{{ t('common.cancel') }}</AlertDialogCancel>
-          <Button variant="destructive" @click="handleDelete">{{ t('common.delete') }}</Button>
+          <AlertDialogCancel>{{ t("common.cancel") }}</AlertDialogCancel>
+          <Button variant="destructive" @click="handleDelete">{{
+            t("common.delete")
+          }}</Button>
         </AlertDialogFooter>
       </AlertDialogContent>
     </AlertDialog>
@@ -133,10 +290,19 @@
     <Card v-if="recommendedRules.length > 0" class="mt-6">
       <Collapsible v-model:open="recOpen">
         <CollapsibleTrigger as-child>
-          <CardHeader class="cursor-pointer hover:bg-muted/50 transition-colors">
+          <CardHeader
+            class="cursor-pointer hover:bg-muted/50 transition-colors"
+          >
             <div class="flex items-center justify-between">
-              <CardTitle class="text-sm font-medium">{{ t('retryRules.recommended.title', { count: recommendedRules.length }) }}</CardTitle>
-              <ChevronDown class="h-4 w-4 text-muted-foreground transition-transform" :class="{ 'rotate-180': recOpen }" />
+              <CardTitle class="text-sm font-medium">{{
+                t("retryRules.recommended.title", {
+                  count: recommendedRules.length,
+                })
+              }}</CardTitle>
+              <ChevronDown
+                class="h-4 w-4 text-muted-foreground transition-transform"
+                :class="{ 'rotate-180': recOpen }"
+              />
             </div>
           </CardHeader>
         </CollapsibleTrigger>
@@ -144,32 +310,62 @@
           <CardContent>
             <div class="flex items-center justify-between mb-3">
               <div class="flex items-center gap-2">
-                <Checkbox :model-value="recAllChecked" @update:model-value="toggleRecAll" />
-                <span class="text-sm text-muted-foreground">{{ t('retryRules.recommended.selectAll') }}</span>
+                <Checkbox
+                  :model-value="recAllChecked"
+                  @update:model-value="toggleRecAll"
+                />
+                <span class="text-sm text-muted-foreground">{{
+                  t("retryRules.recommended.selectAll")
+                }}</span>
               </div>
-              <Button size="sm" :disabled="recSelected.size === 0" @click="addRecRules">
-                {{ t('retryRules.recommended.addSelected', { count: recSelected.size }) }}
+              <Button
+                size="sm"
+                :disabled="recSelected.size === 0"
+                @click="addRecRules"
+              >
+                {{
+                  t("retryRules.recommended.addSelected", {
+                    count: recSelected.size,
+                  })
+                }}
               </Button>
             </div>
             <Table>
               <TableHeader>
                 <TableRow>
                   <TableHead class="w-10"></TableHead>
-                  <TableHead>{{ t('retryRules.recommended.headers.name') }}</TableHead>
-                  <TableHead>{{ t('retryRules.recommended.headers.statusCode') }}</TableHead>
-                  <TableHead>{{ t('retryRules.recommended.headers.pattern') }}</TableHead>
-                  <TableHead>{{ t('retryRules.recommended.headers.strategy') }}</TableHead>
+                  <TableHead>{{
+                    t("retryRules.recommended.headers.name")
+                  }}</TableHead>
+                  <TableHead>{{
+                    t("retryRules.recommended.headers.statusCode")
+                  }}</TableHead>
+                  <TableHead>{{
+                    t("retryRules.recommended.headers.pattern")
+                  }}</TableHead>
+                  <TableHead>{{
+                    t("retryRules.recommended.headers.strategy")
+                  }}</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
                 <TableRow v-for="rule in recommendedRules" :key="rule.name">
                   <TableCell>
-                    <Checkbox :model-value="recSelected.has(rule.name)" @update:model-value="() => toggleRec(rule.name)" />
+                    <Checkbox
+                      :model-value="recSelected.has(rule.name)"
+                      @update:model-value="() => toggleRec(rule.name)"
+                    />
                   </TableCell>
                   <TableCell>{{ rule.name }}</TableCell>
                   <TableCell>{{ rule.status_code }}</TableCell>
-                  <TableCell class="font-mono text-xs max-w-[200px] truncate">{{ rule.body_pattern }}</TableCell>
-                  <TableCell>{{ rule.retry_strategy === 'fixed' ? t('retryRules.strategy.fixed') : t('retryRules.strategy.exponential') }}</TableCell>
+                  <TableCell class="font-mono text-xs max-w-[200px] truncate">{{
+                    rule.body_pattern
+                  }}</TableCell>
+                  <TableCell>{{
+                    rule.retry_strategy === "fixed"
+                      ? t("retryRules.strategy.fixed")
+                      : t("retryRules.strategy.exponential")
+                  }}</TableCell>
                 </TableRow>
               </TableBody>
             </Table>
@@ -181,104 +377,146 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted } from 'vue'
-import { useI18n } from 'vue-i18n'
-import { toast } from 'vue-sonner'
-import { api, getApiMessage, type RecommendedRetryRule } from '@/api/client'
-import { Button } from '@/components/ui/button'
-import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
-import { Badge } from '@/components/ui/badge'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { Table, TableHeader, TableBody, TableRow, TableHead, TableCell } from '@/components/ui/table'
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog'
-import { AlertDialog, AlertDialogContent, AlertDialogHeader, AlertDialogTitle, AlertDialogDescription, AlertDialogFooter, AlertDialogCancel } from '@/components/ui/alert-dialog'
-import { Checkbox } from '@/components/ui/checkbox'
-import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
-import { ChevronDown } from 'lucide-vue-next'
+import { ref, computed, onMounted } from "vue";
+import { useI18n } from "vue-i18n";
+import { toast } from "vue-sonner";
+import { api, getApiMessage, type RecommendedRetryRule } from "@/api/client";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableRow,
+  TableHead,
+  TableCell,
+} from "@/components/ui/table";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogCancel,
+} from "@/components/ui/alert-dialog";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { ChevronDown } from "lucide-vue-next";
 
-const { t } = useI18n()
+const { t } = useI18n();
 
-interface RetryRule {
-  id: string
-  name: string
-  status_code: number
-  body_pattern: string
-  is_active: number
-  created_at: string
-  retry_strategy: "fixed" | "exponential"
-  retry_delay_ms: number
-  max_retries: number
-  max_delay_ms: number
-}
+import type { RetryRule } from "@/types/models";
 
 const DEFAULT_FORM = {
-  name: '', status_code: 429, body_pattern: '', is_active: true,
-  retry_strategy: 'exponential' as "fixed" | "exponential",
+  name: "",
+  status_code: 429,
+  body_pattern: "",
+  is_active: true,
+  retry_strategy: "exponential" as "fixed" | "exponential",
   retry_delay_ms: 5000,
   max_retries: 10,
   max_delay_ms: 60000,
-}
+};
 
-const rules = ref<RetryRule[]>([])
-const dialogOpen = ref(false)
-const editingId = ref<string | null>(null)
-const deleteTarget = ref<RetryRule | null>(null)
-const form = ref({ ...DEFAULT_FORM })
-const errors = ref<Record<string, string>>({})
+const rules = ref<RetryRule[]>([]);
+const dialogOpen = ref(false);
+const editingId = ref<string | null>(null);
+const deleteTarget = ref<RetryRule | null>(null);
+const form = ref({ ...DEFAULT_FORM });
+const errors = ref<Record<string, string>>({});
 
-const MIN_STATUS_CODE = 100
-const MAX_STATUS_CODE = 599
-const MIN_DELAY_MS = 100
-const MAX_RETRIES = 100
+const MIN_STATUS_CODE = 100;
+const MAX_STATUS_CODE = 599;
+const MIN_DELAY_MS = 100;
+const MAX_RETRIES = 100;
 
 function validate(): boolean {
-  const errs: Record<string, string> = {}
-  if (!form.value.name.trim()) errs.name = t('retryRules.validation.nameRequired')
+  const errs: Record<string, string> = {};
+  if (!form.value.name.trim())
+    errs.name = t("retryRules.validation.nameRequired");
 
-  const sc = Number(form.value.status_code)
-  if (!Number.isInteger(sc) || sc < MIN_STATUS_CODE || sc > MAX_STATUS_CODE) errs.status_code = t('retryRules.validation.statusCodeRange', { min: MIN_STATUS_CODE, max: MAX_STATUS_CODE })
+  const sc = Number(form.value.status_code);
+  if (!Number.isInteger(sc) || sc < MIN_STATUS_CODE || sc > MAX_STATUS_CODE)
+    errs.status_code = t("retryRules.validation.statusCodeRange", {
+      min: MIN_STATUS_CODE,
+      max: MAX_STATUS_CODE,
+    });
 
-  if (!form.value.body_pattern.trim()) errs.body_pattern = t('retryRules.validation.bodyPatternRequired')
+  if (!form.value.body_pattern.trim())
+    errs.body_pattern = t("retryRules.validation.bodyPatternRequired");
   else {
-    try { new RegExp(form.value.body_pattern) } catch { errs.body_pattern = t('retryRules.validation.bodyPatternInvalid') }
+    try {
+      new RegExp(form.value.body_pattern);
+    } catch {
+      errs.body_pattern = t("retryRules.validation.bodyPatternInvalid");
+    }
   }
 
-  const delay = Number(form.value.retry_delay_ms)
-  if (!delay || delay < MIN_DELAY_MS) errs.retry_delay_ms = t('retryRules.validation.delayMin', { min: MIN_DELAY_MS })
+  const delay = Number(form.value.retry_delay_ms);
+  if (!delay || delay < MIN_DELAY_MS)
+    errs.retry_delay_ms = t("retryRules.validation.delayMin", {
+      min: MIN_DELAY_MS,
+    });
 
-  const retries = Number(form.value.max_retries)
-  if (!Number.isInteger(retries) || retries < 0 || retries > MAX_RETRIES) errs.max_retries = t('retryRules.validation.retriesRange', { max: MAX_RETRIES })
+  const retries = Number(form.value.max_retries);
+  if (!Number.isInteger(retries) || retries < 0 || retries > MAX_RETRIES)
+    errs.max_retries = t("retryRules.validation.retriesRange", {
+      max: MAX_RETRIES,
+    });
 
-  if (form.value.retry_strategy === 'exponential') {
-    const maxDelay = Number(form.value.max_delay_ms)
-    if (!maxDelay || maxDelay < MIN_DELAY_MS) errs.max_delay_ms = t('retryRules.validation.delayMin', { min: MIN_DELAY_MS })
+  if (form.value.retry_strategy === "exponential") {
+    const maxDelay = Number(form.value.max_delay_ms);
+    if (!maxDelay || maxDelay < MIN_DELAY_MS)
+      errs.max_delay_ms = t("retryRules.validation.delayMin", {
+        min: MIN_DELAY_MS,
+      });
   }
 
-  errors.value = errs
-  return Object.keys(errs).length === 0
+  errors.value = errs;
+  return Object.keys(errs).length === 0;
 }
 
 async function loadData() {
   try {
-    const res = await api.getRetryRules()
-    rules.value = res
+    const res = await api.getRetryRules();
+    rules.value = res;
   } catch (e: unknown) {
-    console.error('Failed to load retry rules:', e)
-    toast.error(getApiMessage(e, t('retryRules.messages.loadFailed')))
+    console.error("Failed to load retry rules:", e);
+    toast.error(getApiMessage(e, t("retryRules.messages.loadFailed")));
   }
 }
 
 function openCreate() {
-  editingId.value = null
-  form.value = { ...DEFAULT_FORM }
-  errors.value = {}
-  dialogOpen.value = true
+  editingId.value = null;
+  form.value = { ...DEFAULT_FORM };
+  errors.value = {};
+  dialogOpen.value = true;
 }
 
 function openEdit(r: RetryRule) {
-  editingId.value = r.id
+  editingId.value = r.id;
   form.value = {
     name: r.name,
     status_code: r.status_code,
@@ -288,13 +526,13 @@ function openEdit(r: RetryRule) {
     retry_delay_ms: r.retry_delay_ms,
     max_retries: r.max_retries,
     max_delay_ms: r.max_delay_ms,
-  }
-  errors.value = {}
-  dialogOpen.value = true
+  };
+  errors.value = {};
+  dialogOpen.value = true;
 }
 
 async function handleSave() {
-  if (!validate()) return
+  if (!validate()) return;
   try {
     const payload = {
       name: form.value.name,
@@ -305,64 +543,77 @@ async function handleSave() {
       retry_delay_ms: Number(form.value.retry_delay_ms),
       max_retries: Number(form.value.max_retries),
       max_delay_ms: Number(form.value.max_delay_ms),
-    }
+    };
     if (editingId.value) {
-      await api.updateRetryRule(editingId.value, payload)
+      await api.updateRetryRule(editingId.value, payload);
     } else {
-      await api.createRetryRule(payload)
+      await api.createRetryRule(payload);
     }
-    dialogOpen.value = false
-    await loadData()
+    dialogOpen.value = false;
+    await loadData();
   } catch (e: unknown) {
-    console.error('Failed to save retry rule:', e)
-    toast.error(getApiMessage(e, t('retryRules.messages.saveFailed')))
+    console.error("Failed to save retry rule:", e);
+    toast.error(getApiMessage(e, t("retryRules.messages.saveFailed")));
   }
 }
 
 function confirmDelete(r: RetryRule) {
-  deleteTarget.value = r
+  deleteTarget.value = r;
 }
 
 async function handleDelete() {
-  const target = deleteTarget.value
-  if (!target) return
-  deleteTarget.value = null
+  const target = deleteTarget.value;
+  if (!target) return;
+  deleteTarget.value = null;
   try {
-    await api.deleteRetryRule(target.id)
-    await loadData()
+    await api.deleteRetryRule(target.id);
+    await loadData();
   } catch (e: unknown) {
-    console.error('Failed to delete retry rule:', e)
-    toast.error(getApiMessage(e, t('retryRules.messages.deleteFailed')))
+    console.error("Failed to delete retry rule:", e);
+    toast.error(getApiMessage(e, t("retryRules.messages.deleteFailed")));
   }
 }
 
 // 推荐规则
-const recOpen = ref(false)
-const recommendedRules = ref<RecommendedRetryRule[]>([])
-const recSelected = ref(new Set<string>())
+const recOpen = ref(false);
+const recommendedRules = ref<RecommendedRetryRule[]>([]);
+const recSelected = ref(new Set<string>());
 
-const recAllChecked = computed(() =>
-  recommendedRules.value.length > 0 && recSelected.value.size === recommendedRules.value.length
-)
+const recAllChecked = computed(
+  () =>
+    recommendedRules.value.length > 0 &&
+    recSelected.value.size === recommendedRules.value.length,
+);
 
 async function loadRecommended() {
   try {
-    recommendedRules.value = await api.recommended.getRetryRules()
-  } catch { recommendedRules.value = [] }
+    recommendedRules.value = await api.recommended.getRetryRules();
+  } catch {
+    recommendedRules.value = [];
+  }
 }
 
 function toggleRec(name: string) {
-  const s = new Set(recSelected.value)
-  if (s.has(name)) { s.delete(name) } else { s.add(name) }
-  recSelected.value = s
+  const s = new Set(recSelected.value);
+  if (s.has(name)) {
+    s.delete(name);
+  } else {
+    s.add(name);
+  }
+  recSelected.value = s;
 }
 
 function toggleRecAll(checked: boolean | string) {
-  recSelected.value = checked === true ? new Set(recommendedRules.value.map(r => r.name)) : new Set()
+  recSelected.value =
+    checked === true
+      ? new Set(recommendedRules.value.map((r) => r.name))
+      : new Set();
 }
 
 async function addRecRules() {
-  const toAdd = recommendedRules.value.filter(r => recSelected.value.has(r.name))
+  const toAdd = recommendedRules.value.filter((r) =>
+    recSelected.value.has(r.name),
+  );
   for (const rule of toAdd) {
     await api.createRetryRule({
       name: rule.name,
@@ -373,12 +624,15 @@ async function addRecRules() {
       retry_delay_ms: rule.retry_delay_ms,
       max_retries: rule.max_retries,
       max_delay_ms: rule.max_delay_ms,
-    })
+    });
   }
-  toast.success(t('retryRules.messages.addedCount', { count: toAdd.length }))
-  recSelected.value = new Set()
-  await Promise.allSettled([loadRecommended(), loadData()])
+  toast.success(t("retryRules.messages.addedCount", { count: toAdd.length }));
+  recSelected.value = new Set();
+  await Promise.allSettled([loadRecommended(), loadData()]);
 }
 
-onMounted(() => { loadData(); loadRecommended() })
+onMounted(() => {
+  loadData();
+  loadRecommended();
+});
 </script>

--- a/frontend/src/views/RouterKeys.vue
+++ b/frontend/src/views/RouterKeys.vue
@@ -2,10 +2,24 @@
 <template>
   <div class="p-6">
     <div class="flex items-center justify-between mb-4">
-      <h2 class="text-lg font-semibold text-foreground">{{ t('routerKeys.title') }}</h2>
+      <h2 class="text-lg font-semibold text-foreground">
+        {{ t("routerKeys.title") }}
+      </h2>
       <Button @click="openCreate" class="flex items-center gap-1">
-        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/></svg>
-        {{ t('routerKeys.createKey') }}
+        <svg
+          class="w-4 h-4"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M12 4v16m8-8H4"
+          />
+        </svg>
+        {{ t("routerKeys.createKey") }}
       </Button>
     </div>
 
@@ -13,26 +27,71 @@
       <Table>
         <TableHeader>
           <TableRow class="bg-muted">
-            <TableHead class="text-muted-foreground">{{ t('routerKeys.tableHeaders.name') }}</TableHead>
-            <TableHead class="text-muted-foreground">{{ t('routerKeys.tableHeaders.key') }}</TableHead>
-            <TableHead class="text-muted-foreground">{{ t('routerKeys.tableHeaders.whitelist') }}</TableHead>
-            <TableHead class="text-muted-foreground">{{ t('routerKeys.tableHeaders.status') }}</TableHead>
-            <TableHead class="text-muted-foreground">{{ t('routerKeys.tableHeaders.createdAt') }}</TableHead>
-            <TableHead class="text-right text-muted-foreground">{{ t('routerKeys.tableHeaders.actions') }}</TableHead>
+            <TableHead class="text-muted-foreground">{{
+              t("routerKeys.tableHeaders.name")
+            }}</TableHead>
+            <TableHead class="text-muted-foreground">{{
+              t("routerKeys.tableHeaders.key")
+            }}</TableHead>
+            <TableHead class="text-muted-foreground">{{
+              t("routerKeys.tableHeaders.whitelist")
+            }}</TableHead>
+            <TableHead class="text-muted-foreground">{{
+              t("routerKeys.tableHeaders.status")
+            }}</TableHead>
+            <TableHead class="text-muted-foreground">{{
+              t("routerKeys.tableHeaders.createdAt")
+            }}</TableHead>
+            <TableHead class="text-right text-muted-foreground">{{
+              t("routerKeys.tableHeaders.actions")
+            }}</TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>
-          <TableRow v-for="k in keys" :key="k.id" :class="{ 'opacity-60': !k.is_active }">
+          <TableRow
+            v-for="k in keys"
+            :key="k.id"
+            :class="{ 'opacity-60': !k.is_active }"
+          >
             <TableCell class="font-medium">{{ k.name }}</TableCell>
             <TableCell>
               <div class="flex items-center gap-1">
-                <span class="font-mono text-xs text-muted-foreground">{{ maskKey(k.key) }}</span>
-                <Button variant="ghost" size="sm" class="h-6 w-6 p-0" @click="k.key && tableCopy(k.key)">
-                  <svg v-if="!tableCopied" class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"/>
+                <span class="font-mono text-xs text-muted-foreground">{{
+                  maskKey(k.key)
+                }}</span>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  class="h-6 w-6 p-0"
+                  @click="k.key && tableCopy(k.key)"
+                >
+                  <svg
+                    v-if="!tableCopied"
+                    class="w-3.5 h-3.5"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                      d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"
+                    />
                   </svg>
-                  <svg v-else class="w-3.5 h-3.5 text-success" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                  <svg
+                    v-else
+                    class="w-3.5 h-3.5 text-success"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                      d="M5 13l4 4L19 7"
+                    />
                   </svg>
                 </Button>
               </div>
@@ -40,22 +99,50 @@
             <TableCell>
               <template v-if="k.allowed_models && k.allowed_models.length > 0">
                 <div class="flex flex-wrap gap-1">
-                  <Badge v-for="m in k.allowed_models" :key="m" variant="outline" class="text-xs">{{ m }}</Badge>
+                  <Badge
+                    v-for="m in k.allowed_models"
+                    :key="m"
+                    variant="outline"
+                    class="text-xs"
+                    >{{ m }}</Badge
+                  >
                 </div>
               </template>
-              <Badge v-else variant="secondary">{{ t('common.allModels') }}</Badge>
+              <Badge v-else variant="secondary">{{
+                t("common.allModels")
+              }}</Badge>
             </TableCell>
             <TableCell>
-              <Badge :variant="k.is_active ? 'default' : 'secondary'">{{ k.is_active ? t('common.enabled') : t('common.disabled') }}</Badge>
+              <Badge :variant="k.is_active ? 'default' : 'secondary'">{{
+                k.is_active ? t("common.enabled") : t("common.disabled")
+              }}</Badge>
             </TableCell>
-            <TableCell class="text-muted-foreground text-sm">{{ formatDate(k.created_at) }}</TableCell>
+            <TableCell class="text-muted-foreground text-sm">{{
+              formatDate(k.created_at)
+            }}</TableCell>
             <TableCell class="text-right">
-              <Button variant="ghost" size="sm" @click="openEdit(k)" class="text-muted-foreground hover:text-primary mr-2">{{ t('common.edit') }}</Button>
-              <Button variant="ghost" size="sm" @click="confirmDelete(k)" class="text-muted-foreground hover:text-destructive">{{ t('common.delete') }}</Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                @click="openEdit(k)"
+                class="text-muted-foreground hover:text-primary mr-2"
+                >{{ t("common.edit") }}</Button
+              >
+              <Button
+                variant="ghost"
+                size="sm"
+                @click="confirmDelete(k)"
+                class="text-muted-foreground hover:text-destructive"
+                >{{ t("common.delete") }}</Button
+              >
             </TableCell>
           </TableRow>
           <TableRow v-if="keys.length === 0">
-            <TableCell colspan="6" class="text-center text-muted-foreground py-8">{{ t('routerKeys.noKeys') }}</TableCell>
+            <TableCell
+              colspan="6"
+              class="text-center text-muted-foreground py-8"
+              >{{ t("routerKeys.noKeys") }}</TableCell
+            >
           </TableRow>
         </TableBody>
       </Table>
@@ -65,18 +152,36 @@
     <Dialog v-model:open="dialogOpen">
       <DialogContent class="sm:max-w-lg">
         <DialogHeader>
-          <DialogTitle>{{ editingId ? t('routerKeys.editKey') : t('routerKeys.createKey') }}</DialogTitle>
+          <DialogTitle>{{
+            editingId ? t("routerKeys.editKey") : t("routerKeys.createKey")
+          }}</DialogTitle>
         </DialogHeader>
         <form @submit.prevent="handleSave" class="space-y-4">
           <div>
-            <Label class="block text-sm font-medium text-foreground mb-1">{{ t('routerKeys.tableHeaders.name') }}</Label>
-            <Input v-model="form.name" type="text" required :placeholder="t('routerKeys.placeholder.name')" @input="delete errors.name" />
-            <p v-if="errors.name" class="text-sm text-destructive mt-1">{{ errors.name }}</p>
+            <Label class="block text-sm font-medium text-foreground mb-1">{{
+              t("routerKeys.tableHeaders.name")
+            }}</Label>
+            <Input
+              v-model="form.name"
+              type="text"
+              required
+              :placeholder="t('routerKeys.placeholder.name')"
+              @input="delete errors.name"
+            />
+            <p v-if="errors.name" class="text-sm text-destructive mt-1">
+              {{ errors.name }}
+            </p>
           </div>
           <div>
-            <Label class="block text-sm font-medium text-foreground mb-1">{{ t('routerKeys.whitelistLabel') }}</Label>
-            <div class="text-xs text-muted-foreground mb-2">{{ t('routerKeys.whitelistHint') }}</div>
-            <div class="border rounded-md p-3 max-h-48 overflow-y-auto space-y-2 bg-muted">
+            <Label class="block text-sm font-medium text-foreground mb-1">{{
+              t("routerKeys.whitelistLabel")
+            }}</Label>
+            <div class="text-xs text-muted-foreground mb-2">
+              {{ t("routerKeys.whitelistHint") }}
+            </div>
+            <div
+              class="border rounded-md p-3 max-h-48 overflow-y-auto space-y-2 bg-muted"
+            >
               <Label
                 v-for="model in availableModels"
                 :key="model"
@@ -84,43 +189,94 @@
               >
                 <Checkbox
                   :model-value="form.allowed_models.includes(model)"
-                  @update:model-value="(val: boolean | 'indeterminate') => { if (val && val !== 'indeterminate' && !form.allowed_models.includes(model)) form.allowed_models.push(model); else if (!val) { const idx = form.allowed_models.indexOf(model); if (idx >= 0) form.allowed_models.splice(idx, 1) } }"
+                  @update:model-value="
+                    (val: boolean | 'indeterminate') => {
+                      if (
+                        val &&
+                        val !== 'indeterminate' &&
+                        !form.allowed_models.includes(model)
+                      )
+                        form.allowed_models.push(model);
+                      else if (!val) {
+                        const idx = form.allowed_models.indexOf(model);
+                        if (idx >= 0) form.allowed_models.splice(idx, 1);
+                      }
+                    }
+                  "
                 />
                 <span class="font-mono text-xs">{{ model }}</span>
               </Label>
-              <div v-if="availableModels.length === 0" class="text-muted-foreground text-sm text-center py-2">
-                {{ t('routerKeys.noModels') }}
+              <div
+                v-if="availableModels.length === 0"
+                class="text-muted-foreground text-sm text-center py-2"
+              >
+                {{ t("routerKeys.noModels") }}
               </div>
             </div>
-            <div v-if="form.allowed_models.length > 0" class="flex flex-wrap gap-1 mt-2">
-              <Badge v-for="m in form.allowed_models" :key="m" variant="outline" class="text-xs">
+            <div
+              v-if="form.allowed_models.length > 0"
+              class="flex flex-wrap gap-1 mt-2"
+            >
+              <Badge
+                v-for="m in form.allowed_models"
+                :key="m"
+                variant="outline"
+                class="text-xs"
+              >
                 {{ m }}
-                <Button type="button" variant="ghost" size="sm" class="ml-1 h-4 w-4 p-0 text-muted-foreground hover:text-destructive" @click="removeModel(m)">&times;</Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  class="ml-1 h-4 w-4 p-0 text-muted-foreground hover:text-destructive"
+                  @click="removeModel(m)"
+                  >&times;</Button
+                >
               </Badge>
             </div>
           </div>
           <div v-if="editingId" class="flex items-center gap-2">
             <Checkbox v-model="form.is_active" id="key-active" />
-            <Label for="key-active" class="text-sm text-foreground">{{ t('common.enable') }}</Label>
+            <Label for="key-active" class="text-sm text-foreground">{{
+              t("common.enable")
+            }}</Label>
           </div>
           <DialogFooter>
-            <Button type="button" variant="outline" @click="dialogOpen = false">{{ t('common.cancel') }}</Button>
-            <Button type="submit">{{ t('common.save') }}</Button>
+            <Button
+              type="button"
+              variant="outline"
+              @click="dialogOpen = false"
+              >{{ t("common.cancel") }}</Button
+            >
+            <Button type="submit">{{ t("common.save") }}</Button>
           </DialogFooter>
         </form>
       </DialogContent>
     </Dialog>
 
     <!-- Delete Confirm AlertDialog -->
-    <AlertDialog :open="!!deleteTarget" @update:open="(val) => { if (!val) deleteTarget = null }">
+    <AlertDialog
+      :open="!!deleteTarget"
+      @update:open="
+        (val) => {
+          if (!val) deleteTarget = null;
+        }
+      "
+    >
       <AlertDialogContent>
         <AlertDialogHeader>
-          <AlertDialogTitle>{{ t('routerKeys.confirmDeleteTitle') }}</AlertDialogTitle>
-          <AlertDialogDescription>{{ t('routerKeys.confirmDeleteDesc', { name: deleteTarget?.name }) }}</AlertDialogDescription>
+          <AlertDialogTitle>{{
+            t("routerKeys.confirmDeleteTitle")
+          }}</AlertDialogTitle>
+          <AlertDialogDescription>{{
+            t("routerKeys.confirmDeleteDesc", { name: deleteTarget?.name })
+          }}</AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>
-          <AlertDialogCancel>{{ t('common.cancel') }}</AlertDialogCancel>
-          <Button variant="destructive" @click="handleDelete">{{ t('common.delete') }}</Button>
+          <AlertDialogCancel>{{ t("common.cancel") }}</AlertDialogCancel>
+          <Button variant="destructive" @click="handleDelete">{{
+            t("common.delete")
+          }}</Button>
         </AlertDialogFooter>
       </AlertDialogContent>
     </AlertDialog>
@@ -128,57 +284,74 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
-import { useI18n } from 'vue-i18n'
-import { toast } from 'vue-sonner'
-import { api, getApiMessage } from '@/api/client'
-import { formatTime } from '@/utils/format'
-import { useClipboard } from '@/composables/useClipboard'
-import { Button } from '@/components/ui/button'
-import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
-import { Badge } from '@/components/ui/badge'
-import { Table, TableHeader, TableBody, TableRow, TableHead, TableCell } from '@/components/ui/table'
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog'
-import { AlertDialog, AlertDialogContent, AlertDialogHeader, AlertDialogTitle, AlertDialogDescription, AlertDialogFooter, AlertDialogCancel } from '@/components/ui/alert-dialog'
-import { Checkbox } from '@/components/ui/checkbox'
+import { ref, onMounted } from "vue";
+import { useI18n } from "vue-i18n";
+import { toast } from "vue-sonner";
+import { api, getApiMessage } from "@/api/client";
+import { formatTime } from "@/utils/format";
+import { useClipboard } from "@/composables/useClipboard";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableRow,
+  TableHead,
+  TableCell,
+} from "@/components/ui/table";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogCancel,
+} from "@/components/ui/alert-dialog";
+import { Checkbox } from "@/components/ui/checkbox";
 
-const { t } = useI18n()
+const { t } = useI18n();
 
-interface RouterKey {
-  id: string
-  name: string
-  key: string | null
-  key_prefix: string
-  allowed_models: string[] | null
-  is_active: number
-  created_at: string
-}
+import type { RouterKey } from "@/types/models";
 
-const DEFAULT_FORM = { name: '', allowed_models: [] as string[], is_active: true }
+const DEFAULT_FORM = {
+  name: "",
+  allowed_models: [] as string[],
+  is_active: true,
+};
 
-const keys = ref<RouterKey[]>([])
-const availableModels = ref<string[]>([])
-const dialogOpen = ref(false)
-const editingId = ref<string | null>(null)
-const deleteTarget = ref<RouterKey | null>(null)
-const form = ref({ ...DEFAULT_FORM, allowed_models: [] as string[] })
-const errors = ref<Record<string, string>>({})
+const keys = ref<RouterKey[]>([]);
+const availableModels = ref<string[]>([]);
+const dialogOpen = ref(false);
+const editingId = ref<string | null>(null);
+const deleteTarget = ref<RouterKey | null>(null);
+const form = ref({ ...DEFAULT_FORM, allowed_models: [] as string[] });
+const errors = ref<Record<string, string>>({});
 
-const { copied: tableCopied, copy: tableCopy } = useClipboard()
+const { copied: tableCopied, copy: tableCopy } = useClipboard();
 
 function maskKey(key: string | null): string {
-  if (!key) return ''
-  return key.slice(0, 7) + '*'.repeat(7) // eslint-disable-line no-magic-numbers
+  if (!key) return "";
+  return key.slice(0, 7) + "*".repeat(7); // eslint-disable-line no-magic-numbers
 }
 
 function formatDate(dateStr: string): string {
-  return formatTime(dateStr)
+  return formatTime(dateStr);
 }
 
 function removeModel(model: string) {
-  const idx = form.value.allowed_models.indexOf(model)
-  if (idx >= 0) form.value.allowed_models.splice(idx, 1)
+  const idx = form.value.allowed_models.indexOf(model);
+  if (idx >= 0) form.value.allowed_models.splice(idx, 1);
 }
 
 async function loadData() {
@@ -186,85 +359,95 @@ async function loadData() {
     const [keysRes, modelsRes] = await Promise.allSettled([
       api.getRouterKeys(),
       api.getAvailableModels(),
-    ])
-    if (keysRes.status === 'fulfilled') keys.value = keysRes.value
-    if (modelsRes.status === 'fulfilled') availableModels.value = modelsRes.value
+    ]);
+    if (keysRes.status === "fulfilled") keys.value = keysRes.value;
+    if (modelsRes.status === "fulfilled")
+      availableModels.value = modelsRes.value;
   } catch (e: unknown) {
-    console.error('Failed to load data:', e)
-    toast.error(getApiMessage(e, t('routerKeys.loadFailed')))
+    console.error("Failed to load data:", e);
+    toast.error(getApiMessage(e, t("routerKeys.loadFailed")));
   }
 }
 
 function openCreate() {
-  editingId.value = null
-  form.value = { ...DEFAULT_FORM, allowed_models: [] }
-  errors.value = {}
-  dialogOpen.value = true
+  editingId.value = null;
+  form.value = { ...DEFAULT_FORM, allowed_models: [] };
+  errors.value = {};
+  dialogOpen.value = true;
 }
 
 function openEdit(k: RouterKey) {
-  editingId.value = k.id
+  editingId.value = k.id;
   form.value = {
     name: k.name,
     allowed_models: k.allowed_models ? [...k.allowed_models] : [],
     is_active: !!k.is_active,
-  }
-  errors.value = {}
-  dialogOpen.value = true
+  };
+  errors.value = {};
+  dialogOpen.value = true;
 }
 
-function buildUpdatePayload(): { name: string; allowed_models: string[] | null; is_active: number } {
+function buildUpdatePayload(): {
+  name: string;
+  allowed_models: string[] | null;
+  is_active: number;
+  } {
   return {
     name: form.value.name,
-    allowed_models: form.value.allowed_models.length > 0 ? form.value.allowed_models : null,
+    allowed_models:
+      form.value.allowed_models.length > 0 ? form.value.allowed_models : null,
     is_active: form.value.is_active ? 1 : 0,
-  }
+  };
 }
 
-function buildCreatePayload(): { name: string; allowed_models: string[] | null } {
+function buildCreatePayload(): {
+  name: string;
+  allowed_models: string[] | null;
+  } {
   return {
     name: form.value.name,
-    allowed_models: form.value.allowed_models.length > 0 ? form.value.allowed_models : null,
-  }
+    allowed_models:
+      form.value.allowed_models.length > 0 ? form.value.allowed_models : null,
+  };
 }
 
 async function handleSave() {
-  const errs: Record<string, string> = {}
-  const name = form.value.name.trim()
-  if (!name) errs.name = t('routerKeys.nameRequired')
-  errors.value = errs
-  if (Object.keys(errs).length > 0) return
+  const errs: Record<string, string> = {};
+  const name = form.value.name.trim();
+  if (!name) errs.name = t("routerKeys.nameRequired");
+  errors.value = errs;
+  if (Object.keys(errs).length > 0) return;
 
   try {
     if (editingId.value) {
-      await api.updateRouterKey(editingId.value, buildUpdatePayload())
+      await api.updateRouterKey(editingId.value, buildUpdatePayload());
     } else {
-      await api.createRouterKey(buildCreatePayload())
+      await api.createRouterKey(buildCreatePayload());
     }
-    dialogOpen.value = false
-    await loadData()
+    dialogOpen.value = false;
+    await loadData();
   } catch (e: unknown) {
-    console.error('Failed to save router key:', e)
-    toast.error(getApiMessage(e, t('routerKeys.saveFailed')))
+    console.error("Failed to save router key:", e);
+    toast.error(getApiMessage(e, t("routerKeys.saveFailed")));
   }
 }
 
 function confirmDelete(k: RouterKey) {
-  deleteTarget.value = k
+  deleteTarget.value = k;
 }
 
 async function handleDelete() {
-  const target = deleteTarget.value
-  if (!target) return
-  deleteTarget.value = null
+  const target = deleteTarget.value;
+  if (!target) return;
+  deleteTarget.value = null;
   try {
-    await api.deleteRouterKey(target.id)
-    await loadData()
+    await api.deleteRouterKey(target.id);
+    await loadData();
   } catch (e: unknown) {
-    console.error('Failed to delete router key:', e)
-    toast.error(getApiMessage(e, t('routerKeys.deleteFailed')))
+    console.error("Failed to delete router key:", e);
+    toast.error(getApiMessage(e, t("routerKeys.deleteFailed")));
   }
 }
 
-onMounted(loadData)
+onMounted(loadData);
 </script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -936,6 +936,7 @@
       "resolved": "https://registry.npmmirror.com/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -3107,6 +3108,7 @@
       "resolved": "https://registry.npmmirror.com/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
       "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -3188,6 +3190,7 @@
       "resolved": "https://registry.npmmirror.com/@noble/ciphers/-/ciphers-1.3.0.tgz",
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -3659,8 +3662,7 @@
       "optional": true,
       "os": [
         "android"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
       "version": "4.60.2",
@@ -3674,8 +3676,7 @@
       "optional": true,
       "os": [
         "android"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.60.2",
@@ -3689,8 +3690,7 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
       "version": "4.60.2",
@@ -3704,8 +3704,7 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
       "version": "4.60.2",
@@ -3719,8 +3718,7 @@
       "optional": true,
       "os": [
         "freebsd"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
       "version": "4.60.2",
@@ -3734,8 +3732,7 @@
       "optional": true,
       "os": [
         "freebsd"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
       "version": "4.60.2",
@@ -3749,8 +3746,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
       "version": "4.60.2",
@@ -3764,8 +3760,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
       "version": "4.60.2",
@@ -3779,8 +3774,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
       "version": "4.60.2",
@@ -3794,8 +3788,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
       "version": "4.60.2",
@@ -3809,8 +3802,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
       "version": "4.60.2",
@@ -3824,8 +3816,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
       "version": "4.60.2",
@@ -3839,8 +3830,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
       "version": "4.60.2",
@@ -3854,8 +3844,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
       "version": "4.60.2",
@@ -3869,8 +3858,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
       "version": "4.60.2",
@@ -3884,8 +3872,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
       "version": "4.60.2",
@@ -3899,8 +3886,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.60.2",
@@ -3914,8 +3900,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
       "version": "4.60.2",
@@ -3929,8 +3914,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
       "version": "4.60.2",
@@ -3944,8 +3928,7 @@
       "optional": true,
       "os": [
         "openbsd"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
       "version": "4.60.2",
@@ -3959,8 +3942,7 @@
       "optional": true,
       "os": [
         "openharmony"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
       "version": "4.60.2",
@@ -3974,8 +3956,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
       "version": "4.60.2",
@@ -3989,8 +3970,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
       "version": "4.60.2",
@@ -4004,8 +3984,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.60.2",
@@ -4019,8 +3998,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@silvia-odwyer/photon-node": {
       "version": "0.3.4",
@@ -4978,6 +4956,7 @@
       "integrity": "sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.1",
         "@typescript-eslint/types": "8.59.1",
@@ -5607,6 +5586,7 @@
       "resolved": "https://registry.npmmirror.com/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6102,6 +6082,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -6310,6 +6291,7 @@
       "resolved": "https://registry.npmmirror.com/chart.js/-/chart.js-4.5.1.tgz",
       "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@kurkle/color": "^0.3.0"
       },
@@ -7297,6 +7279,7 @@
       "resolved": "https://registry.npmmirror.com/eslint/-/eslint-10.3.0.tgz",
       "integrity": "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -8670,6 +8653,7 @@
       "resolved": "https://registry.npmmirror.com/hono/-/hono-4.12.16.tgz",
       "integrity": "sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -9094,6 +9078,7 @@
       "resolved": "https://registry.npmmirror.com/jiti/-/jiti-2.6.1.tgz",
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -9391,6 +9376,7 @@
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "dev": true,
       "license": "MPL-2.0",
+      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.3"
       },
@@ -10802,6 +10788,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -12488,6 +12475,7 @@
       "resolved": "https://registry.npmmirror.com/stylus/-/stylus-0.57.0.tgz",
       "integrity": "sha512-yOI6G8WYfr0q8v8rRvE91wbxFU+rJPo760Va4MF6K0I6BZjO4r+xSynkvyPBP9tV1CIEUeRsiidjIs2rzb1CnQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "css": "^3.0.0",
         "debug": "^4.3.2",
@@ -12734,6 +12722,7 @@
       "resolved": "https://registry.npmmirror.com/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -13095,6 +13084,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -13122,7 +13112,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13140,7 +13129,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13158,7 +13146,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13176,7 +13163,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13194,7 +13180,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13212,7 +13197,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13230,7 +13214,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13248,7 +13231,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13266,7 +13248,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13284,7 +13265,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13302,7 +13282,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13320,7 +13299,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13338,7 +13316,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13356,7 +13333,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13374,7 +13350,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13392,7 +13367,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13410,7 +13384,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13428,7 +13401,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13446,7 +13418,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13464,7 +13435,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13482,7 +13452,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13500,7 +13469,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13518,7 +13486,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13536,7 +13503,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13554,7 +13520,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13572,7 +13537,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13682,6 +13646,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -13879,6 +13844,7 @@
       "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -15140,6 +15106,7 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -15221,6 +15188,7 @@
       "resolved": "https://registry.npmmirror.com/vue/-/vue-3.5.33.tgz",
       "integrity": "sha512-1AgChhx5w3ALgT4oK3acm2Es/7jyZhWSVUfs3rOBlGQC0rjEDkS7G4lWlJJGGNQD+BV3reCwbQrOe1mPNwKHBQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.33",
         "@vue/compiler-sfc": "3.5.33",
@@ -15630,6 +15598,7 @@
       "integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
       "devOptional": true,
       "license": "ISC",
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -15779,6 +15748,7 @@
       "resolved": "https://registry.npmmirror.com/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/router/src/proxy/handler/create-proxy-handler.ts
+++ b/router/src/proxy/handler/create-proxy-handler.ts
@@ -27,12 +27,7 @@ import type { ProxyAgentFactory } from "../transport/proxy-agent.js";
 import { createPipelineContext } from "../pipeline/context.js";
 import { proxyPipeline } from "../pipeline/pipeline.js";
 import { executeFailoverLoop, type FailoverLoopDeps } from "./failover-loop.js";
-import { loadEnhancementConfig } from "../routing/enhancement-config.js";
-import { ToolLoopGuard, type SessionTracker } from "../../core/loop-prevention/index.js";
-import { HTTP_UNPROCESSABLE_ENTITY } from "../../core/constants.js";
 import { PipelineAbort } from "../pipeline/types.js";
-import { applyToolRoundLimit } from "../patch/tool-round-limiter.js";
-import { extractLastToolUse } from "./proxy-handler-utils.js";
 
 // ---------- Factory config ----------
 
@@ -129,71 +124,6 @@ function handleModelsRequest(db: Database.Database) {
   };
 }
 
-// ---------- Enhancement preprocessing (extracted from old handleProxyRequest) ----------
-
-const TIER2_LOOP_THRESHOLD = 2;
-
-function applyEnhancementPreprocess(
-  request: FastifyRequest,
-  reply: FastifyReply,
-  ctx: import("../pipeline/types.js").PipelineContext,
-  db: Database.Database,
-  container: ServiceContainer,
-): void {
-  const enhancementConfig = loadEnhancementConfig(db);
-  const apiType = ctx.apiType as "openai" | "openai-responses" | "anthropic";
-  const sessionId = ctx.metadata.get("session_id") as string | undefined;
-
-  // 工具轮数限制
-  if (enhancementConfig.tool_round_limit_enabled) {
-    const roundResult = applyToolRoundLimit(ctx.body, apiType);
-    if (roundResult.injected) {
-      ctx.body = roundResult.body;
-      ctx.snapshot.add({ stage: "tool_round_limit", action: "inject_warning", rounds: roundResult.rounds });
-      request.log.info({ sessionId, rounds: roundResult.rounds }, "Tool round limit reached, injecting warning prompt");
-    }
-  }
-
-  // 工具循环检测
-  if (!enhancementConfig.tool_call_loop_enabled || !sessionId) return;
-
-  const sessionTracker = container.resolve<SessionTracker>(SERVICE_KEYS.sessionTracker);
-  if (!sessionTracker) return;
-
-  const routerKeyId = (request.routerKey as { id?: string } | undefined)?.id ?? null;
-  const sessionKey = routerKeyId ? `${routerKeyId}:${sessionId}` : sessionId;
-  const lastToolUse = extractLastToolUse(ctx.body);
-  if (!lastToolUse) return;
-
-  const toolGuard = new ToolLoopGuard(sessionTracker, {
-    enabled: true,
-    minConsecutiveCount: 3,
-    detectorConfig: { n: 6, windowSize: 500, repeatThreshold: 5 },
-  });
-  const checkResult = toolGuard.check(sessionKey, lastToolUse);
-  if (!checkResult.detected) return;
-
-  const loopCount = sessionTracker.getLoopCount(sessionKey);
-  if (loopCount === 1) {
-    ctx.body = toolGuard.injectLoopBreakPrompt(ctx.body, apiType, lastToolUse.toolName);
-    ctx.snapshot.add({ stage: "tool_guard", action: "inject_break_prompt", tool: lastToolUse.toolName });
-    request.log.warn({ sessionId, toolName: lastToolUse.toolName, loopCount },
-      "Tool call loop detected, injecting break prompt");
-  } else if (loopCount === TIER2_LOOP_THRESHOLD) {
-    throw new PipelineAbort(HTTP_UNPROCESSABLE_ENTITY, {
-      error: {
-        type: "tool_call_loop_detected",
-        message: `检测到工具调用循环（连续重复调用 "${lastToolUse.toolName}"）。请求已中断。`,
-        suggestion: "请回顾对话历史，停止重复调用工具，直接告知用户当前的进展和遇到的问题。",
-      },
-    });
-  } else {
-    request.log.warn({ sessionId, toolName: lastToolUse.toolName, loopCount },
-      "Tool call loop detected, hard disconnecting");
-    throw new PipelineAbort(HTTP_CLIENT_CLOSED, { _disconnect: true });
-  }
-}
-
 // ---------- Factory ----------
 
 export function createProxyHandler(config: ProxyHandlerConfig) {
@@ -274,15 +204,11 @@ export function createProxyHandler(config: ProxyHandlerConfig) {
 
       // 注入 DB 到 metadata（hooks 需要访问 settings/写入数据）
       ctx.metadata.set("db", db);
+      ctx.metadata.set("container", container);
 
       // 执行 pre_route 阶段 hooks（client-detection 在此阶段设置 client_type / session_id）
-      await proxyPipeline.emit("pre_route", ctx).catch(err => {
-        request.log.error({ err }, "pre_route hook failed");
-      });
-
-      // 增强预处理（工具轮数限制 + 工具循环检测）
       try {
-        applyEnhancementPreprocess(request, reply, ctx, db, container);
+        await proxyPipeline.emit("pre_route", ctx);
       } catch (e) {
         if (e instanceof PipelineAbort) {
           if (e.statusCode === HTTP_CLIENT_CLOSED && (e.body as Record<string, unknown>)?._disconnect) {
@@ -291,7 +217,7 @@ export function createProxyHandler(config: ProxyHandlerConfig) {
           }
           return reply.code(e.statusCode).send(e.body);
         }
-        throw e;
+        request.log.error({ err: e }, "pre_route hook failed");
       }
 
       const deps: FailoverLoopDeps = {

--- a/router/src/proxy/orchestration/resilience.ts
+++ b/router/src/proxy/orchestration/resilience.ts
@@ -238,7 +238,7 @@ export class ResilienceLayer {
       try {
         transportResult = await fn(currentTarget);
       } catch (err: unknown) {
-        const errMsg = err instanceof Error ? err.message : err instanceof Error ? err.message : JSON.stringify(err);
+        const errMsg = err instanceof Error ? err.message : JSON.stringify(err);
         transportResult = { kind: "throw", error: err instanceof Error ? err : new Error(errMsg) };
       }
 


### PR DESCRIPTION
## Summary

Code review improvements identified through systematic frontend + backend audit. 21 files changed, -190 net lines.

### Backend (Group A)
- **R5**: Fix duplicate ternary in `resilience.ts` errMsg (`err instanceof Error ? ... : err instanceof Error ? ...` → single check)
- **R6**: Inject `container` into proxy handler metadata, enabling `enhancement-preprocess` hook to execute via pipeline. Remove 55-line inline `applyEnhancementPreprocess` function.

### Frontend (Group B - Shared Module Extraction)
- Extract `format.ts`: `toIsoStart`, `toIsoEnd`, `formatBytes`, `formatSize`, `formatContextWindow`
- Extract `model-patches.ts`: `computeDefaultPatches`
- Extract `types/concurrency.ts`: `ConcurrencyMode`
- Extract `types/models.ts`: `RetryRule`, `RouterKey` interfaces
- 12 consumer files updated to use shared modules

### Frontend (Group C - Bug Fixes)
- **R1**: Monitor clipboard — global `copied` state caused all rows to show checkmark simultaneously → per-row `copiedId` tracking
- **R2**: Auth consolidation — remove `App.vue` checkAuth/watch/publicPages, single source of truth in router guard
- **R3**: PatchChips — native `<button>` → shadcn `Button` component

### Decisions (Group D)
- Pipeline dead code (828 lines): Option C (document + defer). Will address in separate spec/plan.

## Test Plan
- 120 test files, 1447 tests passing
- vue-tsc, ESLint (frontend + backend), vue_rules_checker all clean
- Full harness: spec → plan → dev → test → PR (Phase 5)

## Spec
`.xyz-harness/2026-05-18-improvement/spec.md`