### PR TITLE
fix: resolve model-directory.json path for dev mode, downgrade frontend dist warning

### DIFF
--- a/router/src/config/model-context.ts
+++ b/router/src/config/model-context.ts
@@ -184,10 +184,9 @@ export function loadModelDirectory(configDir?: string): void {
     if (data.context_windows && typeof data.context_windows === "object") {
       directoryContextWindows = data.context_windows
     }
-  // eslint-disable-next-line taste/no-silent-catch -- 加载失败不影响启动，使用硬编码白名单兆底。但记录到 stderr 供诊断
   } catch (err: unknown) {
-  // 加载失败不影响启动，使用硬编码白名单兆底。但记录到 stderr 供诊断
-    console.error('loadModelDirectory: failed to load, using hardcoded fallback', err)
+    const msg = err instanceof Error ? err.message : typeof err === 'string' ? err : JSON.stringify(err)
+    console.warn(`loadModelDirectory: failed to load (${msg}), using hardcoded fallback`)
   }
 }
 

--- a/router/src/config/model-context.ts
+++ b/router/src/config/model-context.ts
@@ -173,8 +173,17 @@ let directoryContextWindows: Record<string, number> = {}
  */
 export function loadModelDirectory(configDir?: string): void {
   try {
-    // 默认相对于当前文件所在目录（dist/config/ 或 src/config/），而非 process.cwd()
-    const dir = configDir ?? path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "config")
+    // 优先使用传入的 configDir，否则自动检测：
+    // - 生产 (dist/config/model-context.js): 上溯一级到 dist/ → dist/config/ (postbuild 已复制)
+    // - 开发 (src/config/model-context.ts): 上溯二级到包根 → config/
+    let dir = configDir
+    if (!dir) {
+      const fileDir = path.dirname(fileURLToPath(import.meta.url))
+      const prodDir = path.resolve(fileDir, "..", "config")
+      dir = fs.existsSync(path.join(prodDir, "model-directory.json"))
+        ? prodDir
+        : path.resolve(fileDir, "..", "..", "config")
+    }
     const filePath = path.join(dir, "model-directory.json")
     const raw = fs.readFileSync(filePath, "utf-8")
     const data: ModelDirectoryData = JSON.parse(raw)

--- a/router/src/index.ts
+++ b/router/src/index.ts
@@ -379,7 +379,7 @@ export async function buildApp(
       reply.code(HTTP_NOT_FOUND).send({ error: { message: "Not Found" } });
     });
   } else {
-    app.log.warn(
+    app.log.debug(
       `Frontend dist not found at ${frontendDist}, skipping static serving`
     );
   }


### PR DESCRIPTION
## Dev-mode 启动修复

两个开发模式下的日志噪音问题：

### 1. model-directory.json ENOENT (router/src/config/model-context.ts)
- **问题**: dev 模式下 tsx 执行 src/config/model-context.ts，`../config` 解析回 src/config/ 而非项目根的 config/
- **修复**: 双路径检测 — 先尝试 prod 路径，失败后 fallback 到 dev 路径
- **附加**: console.error + full Error stack → console.warn + message-only

### 2. frontend dist not found (router/src/index.ts)
- **问题**: dev 模式前端由 Vite 提供，不存在 dist 目录，每次启动都打印 WARN
- **修复**: WARN → DEBUG（dev 模式下预期行为）

### 验证
- build: ✅
- lint: ✅ (0 errors, 0 warnings)
- tests: ✅ (120 files, 1447 tests, 0 failures)
- 变更: 2 files, +14 -6