### PR TITLE
fix: SSE monitor stream broken + tool_calls not parsed in stream content

### DIFF
--- a/router/src/admin/monitor.ts
+++ b/router/src/admin/monitor.ts
@@ -28,17 +28,12 @@ export const adminMonitorRoutes: FastifyPluginCallback<MonitorRoutesOptions> = (
     // hijack() 让 Fastify 完全放弃响应管理，避免 onSend hook 向 SSE 流注入信封 JSON
     reply.hijack();
 
-    const sseClient = adaptSSEClient(reply.raw);
-    tracker.addClient(sseClient);
-
-    // 在 writeHead 之前注册 close 处理器，避免竞态导致 tracker 泄漏
-    reply.raw.on("close", () => {
-      tracker.removeClient(sseClient);
-    });
-
     // 客户端在 hijack 之前已断连，无需发送响应头
     if (reply.raw.destroyed) return;
 
+    // writeHead 必须在 addClient 之前调用，否则 sendInitialSnapshot 的 write()
+    // 会触发 Node.js 隐式 header 发送（Content-Type 默认非 text/event-stream），
+    // 导致浏览器 EventSource 解析失败、不断重连。
     try {
       reply.raw.writeHead(HTTP_OK, {
         "Content-Type": "text/event-stream",
@@ -47,7 +42,15 @@ export const adminMonitorRoutes: FastifyPluginCallback<MonitorRoutesOptions> = (
       });
     } catch {
       request.log.debug("client disconnected before writeHead");
+      return;
     }
+
+    const sseClient = adaptSSEClient(reply.raw);
+    tracker.addClient(sseClient);
+
+    reply.raw.on("close", () => {
+      tracker.removeClient(sseClient);
+    });
   });
 
   app.get("/admin/api/monitor/request/:id", async (request, reply) => {

--- a/router/src/core/monitor/stream-extractor.ts
+++ b/router/src/core/monitor/stream-extractor.ts
@@ -2,6 +2,11 @@ import type { ContentBlock } from "./types.js";
 
 const SSE_DATA_PREFIX = "data: ";
 
+// OpenAI stream block index 分配：reasoning/text/tools 使用不同区间避免混合
+const OPENAI_BLOCK_REASONING = 0;
+const OPENAI_BLOCK_TEXT = 1;
+const OPENAI_BLOCK_TOOLS = 2;
+
 export interface StreamExtraction {
   text: string;
   block?: { index: number; type: ContentBlock["type"]; content: string; name?: string } | null;
@@ -22,8 +27,33 @@ export function extractStreamText(line: string, apiType: "openai" | "openai-resp
   if (apiType === "openai") {
     const choices = obj.choices as Array<Record<string, unknown>> | undefined;
     const delta = choices?.[0]?.delta as Record<string, unknown> | undefined;
-    const text = (delta?.content as string) ?? (delta?.reasoning_content as string) ?? "";
-    return { text, block: text ? { index: 0, type: "text", content: text } : null };
+    const text = (delta?.content as string) ?? "";
+    const reasoning = (delta?.reasoning_content as string) ?? "";
+
+    // OpenAI 不像 Anthropic 那样为不同 content type 分配独立 index。
+    // 策略：reasoning → OPENAI_BLOCK_REASONING, text → OPENAI_BLOCK_TEXT,
+    // tool_calls[N] → OPENAI_BLOCK_TOOLS + N。
+    // 这样不同类型的内容不会混在同一个 block 中。
+    if (reasoning) {
+      return { text: reasoning, block: { index: OPENAI_BLOCK_REASONING, type: "thinking", content: reasoning } };
+    }
+    if (text) {
+      return { text, block: { index: OPENAI_BLOCK_TEXT, type: "text", content: text } };
+    }
+    const toolCalls = delta?.tool_calls as Array<Record<string, unknown>> | undefined;
+    if (toolCalls) {
+      const tc = toolCalls[0];
+      if (tc) {
+        const tcIndex = (tc.index as number) ?? 0;
+        const fn = tc.function as Record<string, unknown> | undefined;
+        const args = (fn?.arguments as string) ?? "";
+        const name = (fn?.name as string) ?? "";
+        if (args || name) {
+          return { text: "", block: { index: OPENAI_BLOCK_TOOLS + tcIndex, type: "tool_use", content: args, name: name || undefined } };
+        }
+      }
+    }
+    return empty;
   }
 
   if (apiType === "openai-responses") {


### PR DESCRIPTION
1. monitor.ts: move writeHead() before addClient() to fix SSE connection.
   Previously addClient() called sendInitialSnapshot() → res.write() before
   writeHead(), causing Node.js implicit header with wrong Content-Type.
   Browser EventSource couldn't parse the response, triggering infinite reconnects.
   This was the root cause of: SSE disconnected, requests stuck in active, and
   raw SSE shown in response viewer.

2. stream-extractor.ts: add OpenAI tool_calls delta parsing for stream content.
   Previously only delta.content and reasoning_content were extracted, so tool_call
   responses showed raw SSE chunks instead of structured tool_use blocks.

3. stream-extractor.ts: use separate block indices for OpenAI content types.
   reasoning → index 0, text → index 1, tool_calls[N] → index 2+N.
   Prevents text content from being concatenated into tool_use block content.