### PR TITLE
chore: switch npm publish to OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,6 +19,7 @@ jobs:
     permissions:
       contents: write
       packages: write
+      id-token: write
     steps:
       - uses: actions/checkout@v6
         with:
@@ -28,6 +29,7 @@ jobs:
         with:
           node-version: 22
           cache: npm
+          registry-url: 'https://registry.npmjs.org'
 
       # ── 步骤 1: 升级版本号 ──────────────────────────
       - name: Bump version
@@ -65,11 +67,9 @@ jobs:
           cd router && npm run build
           cd ../frontend && npm run build
 
-      # ── 步骤 5: Publish llm-simple-router ────────────
+      # ── 步骤 5: Publish llm-simple-router (OIDC) ───
       - name: Publish llm-simple-router to npm
-        run: |
-          npm config set //registry.npmjs.org/:_authToken ${{ secrets.NPM_TOKEN }}
-          cd router && npm publish
+        run: cd router && npm publish
 
       # ── 步骤 6: Docker 镜像 ─────────────────────────
       - uses: docker/login-action@v4


### PR DESCRIPTION
## 变更内容

将 npm publish 从手动 NPM_TOKEN 切换为 OIDC trusted publishing。

### 改动
- 新增 `id-token: write` 权限（OIDC 前提）
- `setup-node` 加 `registry-url`（OIDC token 交换需要）
- 删除手动 `npm config set` token 写入，改由 npm CLI 自动走 OIDC

### npmjs.com 配置
已手动在 npmjs.com 配置 trusted publisher（zhushanwen321 / llm-simple-router / publish.yml）。

### 验证
合并后通过发布流程验证 OIDC 是否正常工作。