### PR TITLE
fix: clear .npmrc before npm publish for OIDC

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -68,8 +68,10 @@ jobs:
           cd ../frontend && npm run build
 
       # ── 步骤 5: Publish llm-simple-router (OIDC) ───
+      # setup-node registry-url 会在 .npmrc 写入 _authToken=${NODE_AUTH_TOKEN}
+      # 未设置该变量时展开为空串，npm 看到 _authToken= 行后不走 OIDC
       - name: Publish llm-simple-router to npm
-        run: cd router && npm publish
+        run: rm -f "$RUNNER_TEMP/.npmrc" && cd router && npm publish
 
       # ── 步骤 6: Docker 镜像 ─────────────────────────
       - uses: docker/login-action@v4


### PR DESCRIPTION
## 问题

首次 OIDC 发布失败（E404），原因是 `setup-node` 的 `registry-url` 在 `RUNNER_TEMP/.npmrc` 写入 `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}`。当 `NODE_AUTH_TOKEN` 未设置时展开为空串，npm 看到这行后跳过 OIDC token 交换。

## 修复

在 `npm publish` 前清除 `$RUNNER_TEMP/.npmrc`，让 npm CLI 自动走 OIDC。