### PR TITLE
fix: upgrade to node 24 for npm 11+ OIDC support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
           registry-url: 'https://registry.npmjs.org'
 


### PR DESCRIPTION
## 问题

OIDC 发布仍然失败（ENEEDAUTH），因为 Node 22 自带 npm 10.x，不支持 OIDC（需要 npm >= 11.5.1）。

## 修复

CI 发布步骤升级到 Node 24（自带 npm 11.5.1+，原生 OIDC 支持）。不影响用户运行时环境要求。