### PR TITLE
debug: add OIDC diagnostic output before publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           node-version: 24
           cache: npm
+          registry-url: 'https://registry.npmjs.org'
 
       # OIDC trusted publishing 要求 npm >= 11.5.1
       - name: Upgrade npm for OIDC support
@@ -71,10 +72,24 @@ jobs:
           cd ../frontend && npm run build
 
       # ── 步骤 5: Publish llm-simple-router (OIDC) ───
-      # 不用 setup-node 的 registry-url（它会设置 NODE_AUTH_TOKEN 阻断 OIDC）
-      # npm >= 11.5.1 在检测到 GitHub Actions OIDC 环境时自动交换 token
+      - name: Debug OIDC environment
+        run: |
+          echo "=== npm $(npm --version), node $(node --version) ==="
+          echo "ACTIONS_ID_TOKEN_REQUEST_URL: ${ACTIONS_ID_TOKEN_REQUEST_URL:-NOT_SET}"
+          echo "ACTIONS_ID_TOKEN_REQUEST_TOKEN: ${ACTIONS_ID_TOKEN_REQUEST_TOKEN:+SET(length=${#ACTIONS_ID_TOKEN_REQUEST_TOKEN})}"
+          echo "NODE_AUTH_TOKEN: ${NODE_AUTH_TOKEN:+SET(length=${#NODE_AUTH_TOKEN})}"
+          echo "NPM_CONFIG_USERCONFIG: ${NPM_CONFIG_USERCONFIG:-NOT_SET}"
+          echo "=== .npmrc content ==="
+          cat "$RUNNER_TEMP/.npmrc" 2>/dev/null || echo "(not found)"
+          echo "=== /home/runner/.npmrc ==="
+          cat /home/runner/.npmrc 2>/dev/null || echo "(not found)"
+
       - name: Publish llm-simple-router to npm
-        run: cd router && npm publish --registry https://registry.npmjs.org
+        run: |
+          # 清除 setup-node 注入的 auth 残留，让 npm 走 OIDC
+          unset NODE_AUTH_TOKEN
+          sed -i '/_authToken/d' "$RUNNER_TEMP/.npmrc"
+          cd router && npm publish
 
       # ── 步骤 6: Docker 镜像 ─────────────────────────
       - uses: docker/login-action@v4


### PR DESCRIPTION
添加诊断步骤，打印 npm 版本、OIDC 环境变量、.npmrc 内容，定位 OIDC 不工作的根因。