### PR TITLE
fix: CherryStudio Responses SSE + failover 跳过已删除 provider (#163)

### DIFF
--- a/router/src/proxy/handler/failover-loop.ts
+++ b/router/src/proxy/handler/failover-loop.ts
@@ -319,8 +319,22 @@ export async function executeFailoverLoop(
 
     const provider = getProviderById(db, resolved.provider_id);
     if (!provider || !provider.is_active) {
-      return rejectAndReply(reply, rCtx, errors.providerUnavailable(),
-        `Provider '${resolved.provider_id}' unavailable`, resolved.provider_id);
+      lastFailoverTrigger = "provider_unavailable";
+      insertRejectedLog({
+        db, logId, apiType: clientApiType as "openai" | "openai-responses" | "anthropic",
+        model: clientModel, statusCode: 503,
+        errorMessage: `Provider '${resolved.provider_id}' unavailable`,
+        startTime, isStream, routerKeyId,
+        originalBody: rawBody, clientHeaders: cliHdrs,
+        providerId: resolved.provider_id, originalModel: null,
+        isFailover: isFailoverIteration, originalRequestId: isFailoverIteration ? rootLogId : null,
+        sessionId: ctx.metadata.get("session_id") as string | undefined,
+        pipelineSnapshot: iterationSnapshot.toJSON(),
+        matcher, logFileWriter,
+        mapping_reason: rCtx.mappingReason ?? null,
+      });
+      excludeTargets.push(resolved);
+      continue;
     }
 
 

--- a/router/src/proxy/transform/stream-ant2resp.ts
+++ b/router/src/proxy/transform/stream-ant2resp.ts
@@ -97,6 +97,7 @@ export class AnthropicToResponsesTransform extends BaseSSETransform {
             type: RESPONSES_SSE_EVENTS.REASONING_SUMMARY_PART_ADDED,
             output_index: this.outputIndex,
             summary_index: 0,
+            item_id: this.currentItemId,
             part: { type: "summary_text", text: "" },
             sequence_number: this.nextSeq(),
           });
@@ -115,6 +116,7 @@ export class AnthropicToResponsesTransform extends BaseSSETransform {
             type: RESPONSES_SSE_EVENTS.CONTENT_PART_ADDED,
             output_index: this.outputIndex,
             content_index: 0,
+            item_id: this.currentItemId,
             part: { type: "output_text", text: "", annotations: [] },
             sequence_number: this.nextSeq(),
           });
@@ -158,6 +160,7 @@ export class AnthropicToResponsesTransform extends BaseSSETransform {
               type: RESPONSES_SSE_EVENTS.REASONING_SUMMARY_TEXT_DELTA,
               output_index: this.outputIndex,
               summary_index: 0,
+              item_id: this.currentItemId,
               delta: thinking,
               sequence_number: this.nextSeq(),
             });
@@ -170,6 +173,7 @@ export class AnthropicToResponsesTransform extends BaseSSETransform {
               type: RESPONSES_SSE_EVENTS.OUTPUT_TEXT_DELTA,
               output_index: this.outputIndex,
               content_index: 0,
+              item_id: this.currentItemId,
               delta: text,
               sequence_number: this.nextSeq(),
             });
@@ -201,6 +205,7 @@ export class AnthropicToResponsesTransform extends BaseSSETransform {
             type: RESPONSES_SSE_EVENTS.REASONING_SUMMARY_TEXT_DONE,
             output_index: this.outputIndex,
             summary_index: 0,
+            item_id: this.currentItemId,
             text,
             sequence_number: this.nextSeq(),
           });
@@ -208,6 +213,7 @@ export class AnthropicToResponsesTransform extends BaseSSETransform {
             type: RESPONSES_SSE_EVENTS.REASONING_SUMMARY_PART_DONE,
             output_index: this.outputIndex,
             summary_index: 0,
+            item_id: this.currentItemId,
             part: { type: "summary_text", text },
             sequence_number: this.nextSeq(),
           });
@@ -225,6 +231,7 @@ export class AnthropicToResponsesTransform extends BaseSSETransform {
             type: RESPONSES_SSE_EVENTS.OUTPUT_TEXT_DONE,
             output_index: this.outputIndex,
             content_index: 0,
+            item_id: this.currentItemId,
             text,
             sequence_number: this.nextSeq(),
           });
@@ -232,6 +239,7 @@ export class AnthropicToResponsesTransform extends BaseSSETransform {
             type: RESPONSES_SSE_EVENTS.CONTENT_PART_DONE,
             output_index: this.outputIndex,
             content_index: 0,
+            item_id: this.currentItemId,
             part: { type: "output_text", text, annotations: [] },
             sequence_number: this.nextSeq(),
           });

--- a/router/src/proxy/transform/stream-bridge-chat2resp.ts
+++ b/router/src/proxy/transform/stream-bridge-chat2resp.ts
@@ -75,6 +75,7 @@ export class ChatToResponsesBridgeTransform extends BaseSSETransform {
         type: RESPONSES_SSE_EVENTS.OUTPUT_TEXT_DONE,
         output_index: this.outputIndex,
         content_index: this.contentIndex,
+        item_id: this.currentMessageItemId,
         text: this.textBuffer,
         sequence_number: this.nextSeq(),
       });
@@ -82,6 +83,7 @@ export class ChatToResponsesBridgeTransform extends BaseSSETransform {
         type: RESPONSES_SSE_EVENTS.CONTENT_PART_DONE,
         output_index: this.outputIndex,
         content_index: this.contentIndex,
+        item_id: this.currentMessageItemId,
         part: { type: "output_text", text: this.textBuffer, annotations: [] },
         sequence_number: this.nextSeq(),
       });
@@ -117,6 +119,7 @@ export class ChatToResponsesBridgeTransform extends BaseSSETransform {
       type: RESPONSES_SSE_EVENTS.REASONING_SUMMARY_TEXT_DONE,
       output_index: this.outputIndex,
       summary_index: 0,
+      item_id: this.currentReasoningItemId,
       text: this.reasoningBuffer,
       sequence_number: this.nextSeq(),
     });
@@ -124,6 +127,7 @@ export class ChatToResponsesBridgeTransform extends BaseSSETransform {
       type: RESPONSES_SSE_EVENTS.REASONING_SUMMARY_PART_DONE,
       output_index: this.outputIndex,
       summary_index: 0,
+      item_id: this.currentReasoningItemId,
       part: { type: "summary_text", text: this.reasoningBuffer },
       sequence_number: this.nextSeq(),
     });
@@ -274,6 +278,7 @@ export class ChatToResponsesBridgeTransform extends BaseSSETransform {
           type: RESPONSES_SSE_EVENTS.REASONING_SUMMARY_PART_ADDED,
           output_index: this.outputIndex,
           summary_index: 0,
+          item_id: this.currentReasoningItemId,
           part: { type: "summary_text", text: "" },
           sequence_number: this.nextSeq(),
         });
@@ -282,6 +287,7 @@ export class ChatToResponsesBridgeTransform extends BaseSSETransform {
         type: RESPONSES_SSE_EVENTS.REASONING_SUMMARY_TEXT_DELTA,
         output_index: this.outputIndex,
         summary_index: 0,
+        item_id: this.currentReasoningItemId,
         delta: delta.reasoning_content as string,
         sequence_number: this.nextSeq(),
       });
@@ -318,6 +324,7 @@ export class ChatToResponsesBridgeTransform extends BaseSSETransform {
           type: RESPONSES_SSE_EVENTS.CONTENT_PART_ADDED,
           output_index: this.outputIndex,
           content_index: this.contentIndex,
+          item_id: this.currentMessageItemId,
           part: { type: "output_text", text: "", annotations: [] },
           sequence_number: this.nextSeq(),
         });
@@ -326,6 +333,7 @@ export class ChatToResponsesBridgeTransform extends BaseSSETransform {
         type: RESPONSES_SSE_EVENTS.OUTPUT_TEXT_DELTA,
         output_index: this.outputIndex,
         content_index: this.contentIndex,
+        item_id: this.currentMessageItemId,
         delta: delta.content as string,
         sequence_number: this.nextSeq(),
       });

--- a/router/tests/failover-log-grouping.test.ts
+++ b/router/tests/failover-log-grouping.test.ts
@@ -403,6 +403,109 @@ describe("Failover log grouping", () => {
     expect(logs[2].provider_id).toBeNull();
   });
 
+  it("failover: primary provider does not exist, falls back to secondary provider", async () => {
+    const { server: fallbackServer, port: fallbackPort } =
+      await createMockBackend((_req, res) => {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify(SUCCESS_BODY));
+      });
+    servers.push(fallbackServer);
+
+    db = initDatabase(":memory:");
+    setSetting(db, "encryption_key", TEST_ENCRYPTION_KEY);
+    setSetting(db, "initialized", "true");
+
+    const now = new Date().toISOString();
+    const encryptedKey = encrypt("sk-test-key", TEST_ENCRYPTION_KEY);
+
+    // Insert fallback provider only; primary provider "prov-missing" is absent
+    db.prepare(
+      `INSERT INTO providers (id, name, api_type, base_url, api_key, is_active, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+    ).run(
+      "prov-fallback",
+      "Fallback",
+      "openai",
+      `http://127.0.0.1:${fallbackPort}`,
+      encryptedKey,
+      1,
+      now,
+      now
+    );
+
+    db.prepare(
+      `INSERT INTO mapping_groups (id, client_model, rule, is_active, created_at)
+       VALUES (?, ?, ?, ?, ?)`
+    ).run(
+      "mg-failover",
+      "gpt-4",
+      JSON.stringify({
+        targets: [
+          { backend_model: "gpt-4", provider_id: "prov-missing" },
+          { backend_model: "gpt-4", provider_id: "prov-fallback" },
+        ],
+      }),
+      1,
+      now
+    );
+
+    db.prepare(
+      "INSERT INTO router_keys (id, name, key_hash, key_prefix) VALUES (?, ?, ?, ?)"
+    ).run("test-router-key", "Test Key", API_KEY_HASH, API_KEY.slice(0, 8));
+
+    const container = new ServiceContainer();
+    container.register("semaphoreManager", () => new ProviderSemaphoreManager());
+    container.register("tracker", (c) => new RequestTracker({ semaphoreManager: c.resolve("semaphoreManager") }));
+    container.register("matcher", () => undefined);
+    container.register("usageWindowTracker", () => undefined);
+    container.register("sessionTracker", () => undefined);
+    container.register("adaptiveController", () => undefined);
+    container.register(SERVICE_KEYS.logFileWriter, () => null);
+    container.register(SERVICE_KEYS.pluginRegistry, () => undefined);
+    container.register(SERVICE_KEYS.proxyAgentFactory, () => new ProxyAgentFactory());
+
+    const formatRegistry = new FormatRegistry();
+    formatRegistry.registerAdapter(openaiAdapter);
+    container.register(SERVICE_KEYS.formatRegistry, () => formatRegistry);
+    app = Fastify();
+    app.register(authMiddleware, { db });
+    app.register(createProxyHandler({ apiType: "openai", paths: ["/v1/chat/completions", "/chat/completions"] }), { db: db, container });
+
+    const resp = await app.inject({
+      method: "POST",
+      url: "/v1/chat/completions",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${API_KEY}`,
+      },
+      payload: {
+        model: "gpt-4",
+        messages: [{ role: "user", content: "Hi" }],
+      },
+    });
+
+    // Should succeed via failover to fallback provider
+    expect(resp.statusCode).toBe(200);
+
+    const logs = db
+      .prepare("SELECT id, status_code, is_failover, is_retry, original_request_id, provider_id FROM request_logs ORDER BY rowid ASC")
+      .all() as any[];
+
+    // 2 logs: first iteration skipped (provider missing, no network call) + fallback success
+    expect(logs).toHaveLength(2);
+
+    // First log: provider missing, marked as failover with no provider_id
+    expect(logs[0].status_code).toBe(503);
+    expect(logs[0].is_failover).toBe(0);
+    expect(logs[0].provider_id).toBe("prov-missing");
+
+    // Second log: fallback success
+    expect(logs[1].status_code).toBe(200);
+    expect(logs[1].is_failover).toBe(1);
+    expect(logs[1].provider_id).toBe("prov-fallback");
+    expect(logs[1].original_request_id).toBe(logs[0].id);
+  });
+
   it("retry+failover: primary retriable error exhausts retries, failover to fallback succeeds", async () => {
     let primaryCalls = 0;
     const { server: primaryServer, port: primaryPort } =

--- a/router/tests/proxy/transform/stream-ant2resp.test.ts
+++ b/router/tests/proxy/transform/stream-ant2resp.test.ts
@@ -324,4 +324,42 @@ describe("AnthropicToResponsesTransform", () => {
     const partDone = events.find((e) => e.event === RESPONSES_SSE_EVENTS.CONTENT_PART_DONE);
     expect((partDone?.data as Record<string, unknown>)?.item_id).toBe(itemId);
   });
+
+  it("reasoning_summary events include item_id", async () => {
+    const t = new AnthropicToResponsesTransform("claude-3");
+    const output = collectOutput(t);
+    t.write('event: message_start\ndata: {"type":"message_start","message":{"id":"msg_r","role":"assistant","content":[],"usage":{"input_tokens":10}}}\n\n');
+    t.write('event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}\n\n');
+    t.write('event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"Let me think..."}}\n\n');
+    t.write('event: content_block_stop\ndata: {"type":"content_block_stop","index":0}\n\n');
+    t.write('event: content_block_start\ndata: {"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}\n\n');
+    t.write('event: content_block_delta\ndata: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"42"}}\n\n');
+    t.write('event: content_block_stop\ndata: {"type":"content_block_stop","index":1}\n\n');
+    t.write('event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":5}}\n\n');
+    t.write('event: message_stop\ndata: {"type":"message_stop"}\n\n');
+    t.end();
+    const result = await output;
+    const events = parseSSEEvents(result);
+
+    const reasoningItemAdded = events.find((e) => {
+      const item = ((e.data as Record<string, unknown>)?.item as Record<string, unknown>);
+      return e.event === RESPONSES_SSE_EVENTS.OUTPUT_ITEM_ADDED && item?.type === "reasoning";
+    });
+    const reasoningItemId = ((reasoningItemAdded?.data as Record<string, unknown>)?.item as Record<string, unknown>)?.id as string;
+    expect(reasoningItemId).toBeTruthy();
+
+    const partAdded = events.find((e) => e.event === RESPONSES_SSE_EVENTS.REASONING_SUMMARY_PART_ADDED);
+    expect((partAdded?.data as Record<string, unknown>)?.item_id).toBe(reasoningItemId);
+
+    const textDeltas = events.filter((e) => e.event === RESPONSES_SSE_EVENTS.REASONING_SUMMARY_TEXT_DELTA);
+    for (const d of textDeltas) {
+      expect((d.data as Record<string, unknown>)?.item_id).toBe(reasoningItemId);
+    }
+
+    const textDone = events.find((e) => e.event === RESPONSES_SSE_EVENTS.REASONING_SUMMARY_TEXT_DONE);
+    expect((textDone?.data as Record<string, unknown>)?.item_id).toBe(reasoningItemId);
+
+    const partDone = events.find((e) => e.event === RESPONSES_SSE_EVENTS.REASONING_SUMMARY_PART_DONE);
+    expect((partDone?.data as Record<string, unknown>)?.item_id).toBe(reasoningItemId);
+  });
 });

--- a/router/tests/proxy/transform/stream-ant2resp.test.ts
+++ b/router/tests/proxy/transform/stream-ant2resp.test.ts
@@ -292,4 +292,36 @@ describe("AnthropicToResponsesTransform", () => {
     expect(resp?.status).toBe("completed");
     expect((resp?.output as unknown[])?.length).toBe(3);
   });
+
+  it("content_part and output_text events include item_id", async () => {
+    const t = new AnthropicToResponsesTransform("claude-3");
+    const output = collectOutput(t);
+    t.write('event: message_start\ndata: {"type":"message_start","message":{"id":"msg_1","role":"assistant","content":[],"usage":{"input_tokens":10}}}\n\n');
+    t.write('event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n');
+    t.write('event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}\n\n');
+    t.write('event: content_block_stop\ndata: {"type":"content_block_stop","index":0}\n\n');
+    t.write('event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":5}}\n\n');
+    t.write('event: message_stop\ndata: {"type":"message_stop"}\n\n');
+    t.end();
+    const result = await output;
+    const events = parseSSEEvents(result);
+
+    const itemAdded = events.find((e) => e.event === RESPONSES_SSE_EVENTS.OUTPUT_ITEM_ADDED);
+    const itemId = ((itemAdded?.data as Record<string, unknown>)?.item as Record<string, unknown>)?.id as string;
+    expect(itemId).toBeTruthy();
+
+    const partAdded = events.find((e) => e.event === RESPONSES_SSE_EVENTS.CONTENT_PART_ADDED);
+    expect((partAdded?.data as Record<string, unknown>)?.item_id).toBe(itemId);
+
+    const textDeltas = events.filter((e) => e.event === RESPONSES_SSE_EVENTS.OUTPUT_TEXT_DELTA);
+    for (const d of textDeltas) {
+      expect((d.data as Record<string, unknown>)?.item_id).toBe(itemId);
+    }
+
+    const textDone = events.find((e) => e.event === RESPONSES_SSE_EVENTS.OUTPUT_TEXT_DONE);
+    expect((textDone?.data as Record<string, unknown>)?.item_id).toBe(itemId);
+
+    const partDone = events.find((e) => e.event === RESPONSES_SSE_EVENTS.CONTENT_PART_DONE);
+    expect((partDone?.data as Record<string, unknown>)?.item_id).toBe(itemId);
+  });
 });

--- a/router/tests/proxy/transform/stream-bridge.test.ts
+++ b/router/tests/proxy/transform/stream-bridge.test.ts
@@ -118,6 +118,39 @@ describe("ChatToResponsesBridgeTransform", () => {
     expect((partDone?.data as Record<string, unknown>)?.item_id).toBe(itemId);
   });
 
+  it("reasoning_summary events include item_id", async () => {
+    const t = new ChatToResponsesBridgeTransform("gpt-4o");
+    const output = collectOutput(t);
+    t.write(chatSSE({ id: "chatcmpl-1", object: "chat.completion.chunk", choices: [{ index: 0, delta: { role: "assistant" }, finish_reason: null }] }));
+    t.write(chatSSE({ id: "chatcmpl-1", object: "chat.completion.chunk", choices: [{ index: 0, delta: { reasoning_content: "Let me" }, finish_reason: null }] }));
+    t.write(chatSSE({ id: "chatcmpl-1", object: "chat.completion.chunk", choices: [{ index: 0, delta: { content: "42" }, finish_reason: null }] }));
+    t.write(chatSSE({ id: "chatcmpl-1", object: "chat.completion.chunk", choices: [{ index: 0, delta: {}, finish_reason: "stop" }], usage: { prompt_tokens: 5, completion_tokens: 3, total_tokens: 8 } }));
+    t.end();
+    const result = await output;
+    const events = parseSSEEvents(result);
+
+    const reasoningItemAdded = events.find((e) => {
+      const item = ((e.data as Record<string, unknown>)?.item as Record<string, unknown>);
+      return e.event === RESPONSES_SSE_EVENTS.OUTPUT_ITEM_ADDED && item?.type === "reasoning";
+    });
+    const reasoningItemId = ((reasoningItemAdded?.data as Record<string, unknown>)?.item as Record<string, unknown>)?.id as string;
+    expect(reasoningItemId).toBeTruthy();
+
+    const partAdded = events.find((e) => e.event === RESPONSES_SSE_EVENTS.REASONING_SUMMARY_PART_ADDED);
+    expect((partAdded?.data as Record<string, unknown>)?.item_id).toBe(reasoningItemId);
+
+    const textDeltas = events.filter((e) => e.event === RESPONSES_SSE_EVENTS.REASONING_SUMMARY_TEXT_DELTA);
+    for (const d of textDeltas) {
+      expect((d.data as Record<string, unknown>)?.item_id).toBe(reasoningItemId);
+    }
+
+    const textDone = events.find((e) => e.event === RESPONSES_SSE_EVENTS.REASONING_SUMMARY_TEXT_DONE);
+    expect((textDone?.data as Record<string, unknown>)?.item_id).toBe(reasoningItemId);
+
+    const partDone = events.find((e) => e.event === RESPONSES_SSE_EVENTS.REASONING_SUMMARY_PART_DONE);
+    expect((partDone?.data as Record<string, unknown>)?.item_id).toBe(reasoningItemId);
+  });
+
   it("converts text delta to output_text.delta events", async () => {
     const t = new ChatToResponsesBridgeTransform("gpt-4o");
     const output = collectOutput(t);

--- a/router/tests/proxy/transform/stream-bridge.test.ts
+++ b/router/tests/proxy/transform/stream-bridge.test.ts
@@ -83,6 +83,41 @@ describe("ChatToResponsesBridgeTransform", () => {
     expect(resp2?.status).toBe("in_progress");
   });
 
+  it("content_part and output_text events include item_id", async () => {
+    const t = new ChatToResponsesBridgeTransform("gpt-4o");
+    const output = collectOutput(t);
+    t.write(chatSSE({ id: "chatcmpl-1", object: "chat.completion.chunk", choices: [{ index: 0, delta: { role: "assistant" }, finish_reason: null }] }));
+    t.write(chatSSE({ id: "chatcmpl-1", object: "chat.completion.chunk", choices: [{ index: 0, delta: { content: "Hello" }, finish_reason: null }] }));
+    t.write(chatSSE({ id: "chatcmpl-1", object: "chat.completion.chunk", choices: [{ index: 0, delta: { content: " world" }, finish_reason: null }] }));
+    t.write(chatSSE({ id: "chatcmpl-1", object: "chat.completion.chunk", choices: [{ index: 0, delta: {}, finish_reason: "stop" }], usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 } }));
+    t.end();
+    const result = await output;
+    const events = parseSSEEvents(result);
+
+    // Get item_id from output_item.added
+    const itemAdded = events.find((e) => e.event === RESPONSES_SSE_EVENTS.OUTPUT_ITEM_ADDED);
+    const itemId = ((itemAdded?.data as Record<string, unknown>)?.item as Record<string, unknown>)?.id as string;
+    expect(itemId).toBeTruthy();
+
+    // CONTENT_PART_ADDED must have item_id
+    const partAdded = events.find((e) => e.event === RESPONSES_SSE_EVENTS.CONTENT_PART_ADDED);
+    expect((partAdded?.data as Record<string, unknown>)?.item_id).toBe(itemId);
+
+    // OUTPUT_TEXT_DELTA must have item_id
+    const textDeltas = events.filter((e) => e.event === RESPONSES_SSE_EVENTS.OUTPUT_TEXT_DELTA);
+    for (const d of textDeltas) {
+      expect((d.data as Record<string, unknown>)?.item_id).toBe(itemId);
+    }
+
+    // OUTPUT_TEXT_DONE must have item_id
+    const textDone = events.find((e) => e.event === RESPONSES_SSE_EVENTS.OUTPUT_TEXT_DONE);
+    expect((textDone?.data as Record<string, unknown>)?.item_id).toBe(itemId);
+
+    // CONTENT_PART_DONE must have item_id
+    const partDone = events.find((e) => e.event === RESPONSES_SSE_EVENTS.CONTENT_PART_DONE);
+    expect((partDone?.data as Record<string, unknown>)?.item_id).toBe(itemId);
+  });
+
   it("converts text delta to output_text.delta events", async () => {
     const t = new ChatToResponsesBridgeTransform("gpt-4o");
     const output = collectOutput(t);


### PR DESCRIPTION
## 问题 1: Responses SSE 缺少 item_id（CherryStudio #163）

ChatToResponsesBridgeTransform 和 AnthropicToResponsesTransform 生成的 Responses SSE 事件中 content_part / output_text / reasoning_summary 系列事件缺少 item_id。

CherryStudio 的 Responses 解析器依赖 item_id 将 delta 关联到 output item，缺失时内容被静默丢弃，只显示 token 计数。

### 修复
- stream-bridge-chat2resp.ts: 8 处补上 item_id
- stream-ant2resp.ts: 8 处补上 item_id

### 测试
- 新增 2 个 text content item_id 验证测试
- 新增 2 个 reasoning content item_id 验证测试

---

## 问题 2: schedule 引用已删除 provider 导致 Provider unavailable

mapping group 的 schedule 中配置了已删除的 provider（如 1f776740-f5ce-4db3-be04-52a701d3ec6f），当 schedule 命中时，failover 循环遇到不存在的 provider 直接返回 503，导致整个请求链中断。

### 修复
- failover-loop.ts: provider 不存在/未激活时，记录诊断日志并跳过到下一个 target，而非立即失败

### 测试
- 新增 failover-log-grouping 测试：primary provider 缺失时正确 fail over 到 secondary

---

全部 1492 个测试通过。

---
🤖 Generated with Pi