### PR TITLE
fix: clipboard fallback for non-HTTPS and merge provider_meta into usage chunk

### DIFF
--- a/frontend/src/composables/useProviderActions.ts
+++ b/frontend/src/composables/useProviderActions.ts
@@ -1,113 +1,150 @@
-import { ref } from 'vue'
-import { useI18n } from 'vue-i18n'
-import { toast } from 'vue-sonner'
-import { api, getApiMessage } from '@/api/client'
-import type { Provider } from '@/types/mapping'
+import { ref } from "vue";
+import { useI18n } from "vue-i18n";
+import { toast } from "vue-sonner";
+import { api, getApiMessage } from "@/api/client";
+import type { Provider } from "@/types/mapping";
+import { useClipboard } from "@/composables/useClipboard";
 
-const MASK_VISIBLE_LEN = 7
-const MASK_ASTERISK_COUNT = 7
-const COPY_FEEDBACK_MS = 2000
+const MASK_VISIBLE_LEN = 7;
+const MASK_ASTERISK_COUNT = 7;
+const COPY_FEEDBACK_MS = 2000;
 
 export function useProviderActions() {
-  const { t } = useI18n()
+  const { t } = useI18n();
 
-  const providers = ref<Provider[]>([])
-  const reloading = ref(false)
-  const copiedId = ref<string | null>(null)
-  const deleteTarget = ref<Provider | null>(null)
-  const toggleTarget = ref<Provider | null>(null)
-  const pendingToggleId = ref<string | null>(null)
-  const pendingToggleActive = ref(false)
-  const toggleDependencies = ref<string[]>([])
+  const providers = ref<Provider[]>([]);
+  const reloading = ref(false);
+  const copiedId = ref<string | null>(null);
+  const deleteTarget = ref<Provider | null>(null);
+  const toggleTarget = ref<Provider | null>(null);
+  const pendingToggleId = ref<string | null>(null);
+  const pendingToggleActive = ref(false);
+  const toggleDependencies = ref<string[]>([]);
 
   async function loadProviders() {
     try {
-      providers.value = await api.getProviders()
+      providers.value = await api.getProviders();
     } catch (e: unknown) {
-      console.error('Failed to load providers:', e)
-      toast.error(getApiMessage(e, t('providers.toast.loadFailed')))
+      console.error("Failed to load providers:", e);
+      toast.error(getApiMessage(e, t("providers.toast.loadFailed")));
     }
   }
 
   function maskKey(key: string): string {
-    if (!key) return ''
-    return key.slice(0, MASK_VISIBLE_LEN) + '*'.repeat(MASK_ASTERISK_COUNT)
+    if (!key) return "";
+    return key.slice(0, MASK_VISIBLE_LEN) + "*".repeat(MASK_ASTERISK_COUNT);
   }
+
+  const { copy: doCopy } = useClipboard();
 
   async function copyKey(key: string, id: string) {
-    await navigator.clipboard.writeText(key)
-    copiedId.value = id
-    setTimeout(() => { copiedId.value = null }, COPY_FEEDBACK_MS)
+    const ok = await doCopy(key);
+    if (ok) {
+      copiedId.value = id;
+      setTimeout(() => {
+        copiedId.value = null;
+      }, COPY_FEEDBACK_MS);
+    }
   }
 
-  function confirmDelete(p: Provider) { deleteTarget.value = p }
+  function confirmDelete(p: Provider) {
+    deleteTarget.value = p;
+  }
 
   async function confirmToggle(p: Provider) {
-    toggleTarget.value = p
-    pendingToggleId.value = p.id
-    pendingToggleActive.value = !!p.is_active
-    toggleDependencies.value = []
+    toggleTarget.value = p;
+    pendingToggleId.value = p.id;
+    pendingToggleActive.value = !!p.is_active;
+    toggleDependencies.value = [];
     if (p.is_active) {
       try {
-        toggleDependencies.value = (await api.getProviderDependencies(p.id)).references
-      } catch { toggleDependencies.value = [] }
+        toggleDependencies.value = (
+          await api.getProviderDependencies(p.id)
+        ).references;
+      } catch {
+        toggleDependencies.value = [];
+      }
     }
   }
 
   async function handleToggle() {
-    const id = pendingToggleId.value
-    if (!id) return
-    const wasActive = pendingToggleActive.value
-    toggleTarget.value = null
-    pendingToggleId.value = null
+    const id = pendingToggleId.value;
+    if (!id) return;
+    const wasActive = pendingToggleActive.value;
+    toggleTarget.value = null;
+    pendingToggleId.value = null;
     try {
-      const res = await api.updateProvider(id, { is_active: wasActive ? 0 : 1 })
+      const res = await api.updateProvider(id, {
+        is_active: wasActive ? 0 : 1,
+      });
       if (res.cascadedGroups?.length) {
-        const disabled = res.cascadedGroups.filter((g: { disabled: boolean }) => g.disabled).length
-        const cleaned = res.cascadedGroups.length - disabled
-        const parts: string[] = []
-        if (cleaned > 0) parts.push(t('providers.toast.cascadeClean', { count: cleaned }))
-        if (disabled > 0) parts.push(t('providers.toast.cascadeDisable', { count: disabled }))
-        toast.warning(t('providers.toast.cascadeAuto', { actions: parts.join(', ') }))
+        const disabled = res.cascadedGroups.filter(
+          (g: { disabled: boolean }) => g.disabled,
+        ).length;
+        const cleaned = res.cascadedGroups.length - disabled;
+        const parts: string[] = [];
+        if (cleaned > 0)
+          parts.push(t("providers.toast.cascadeClean", { count: cleaned }));
+        if (disabled > 0)
+          parts.push(t("providers.toast.cascadeDisable", { count: disabled }));
+        toast.warning(
+          t("providers.toast.cascadeAuto", { actions: parts.join(", ") }),
+        );
       }
-      await loadProviders()
+      await loadProviders();
     } catch (e: unknown) {
-      console.error('Failed to toggle provider:', e)
-      toast.error(getApiMessage(e, t('providers.toast.toggleFailed')))
+      console.error("Failed to toggle provider:", e);
+      toast.error(getApiMessage(e, t("providers.toast.toggleFailed")));
     }
   }
 
   async function handleDelete() {
-    const target = deleteTarget.value
-    if (!target) return
-    deleteTarget.value = null
+    const target = deleteTarget.value;
+    if (!target) return;
+    deleteTarget.value = null;
     try {
-      await api.deleteProvider(target.id)
-      await loadProviders()
+      await api.deleteProvider(target.id);
+      await loadProviders();
     } catch (e: unknown) {
-      console.error('providerActions.delete:', e)
-      toast.error(getApiMessage(e, t('providers.toast.deleteFailed')))
+      console.error("providerActions.delete:", e);
+      toast.error(getApiMessage(e, t("providers.toast.deleteFailed")));
     }
   }
 
   async function handleReload() {
-    reloading.value = true
+    reloading.value = true;
     try {
-      const result = await api.reloadTransformRules()
-      toast.success(t('providers.toast.reloadSuccess', { pluginCount: result.loadedPlugins.length, rulesCount: result.rulesCount }))
+      const result = await api.reloadTransformRules();
+      toast.success(
+        t("providers.toast.reloadSuccess", {
+          pluginCount: result.loadedPlugins.length,
+          rulesCount: result.rulesCount,
+        }),
+      );
     } catch (e: unknown) {
-      console.error('providerActions.reload:', e)
-      toast.error(getApiMessage(e, t('providers.toast.reloadFailed')))
+      console.error("providerActions.reload:", e);
+      toast.error(getApiMessage(e, t("providers.toast.reloadFailed")));
     } finally {
-      reloading.value = false
+      reloading.value = false;
     }
   }
 
   return {
-    providers, reloading, copiedId,
-    deleteTarget, toggleTarget, pendingToggleId, pendingToggleActive, toggleDependencies,
-    maskKey, copyKey,
-    loadProviders, confirmDelete, confirmToggle, handleToggle,
-    handleDelete, handleReload,
-  }
+    providers,
+    reloading,
+    copiedId,
+    deleteTarget,
+    toggleTarget,
+    pendingToggleId,
+    pendingToggleActive,
+    toggleDependencies,
+    maskKey,
+    copyKey,
+    loadProviders,
+    confirmDelete,
+    confirmToggle,
+    handleToggle,
+    handleDelete,
+    handleReload,
+  };
 }

--- a/frontend/src/views/RouterKeys.vue
+++ b/frontend/src/views/RouterKeys.vue
@@ -325,6 +325,7 @@ import { Checkbox } from "@/components/ui/checkbox";
 const { t } = useI18n();
 
 import type { RouterKey } from "@/types/models";
+import { useClipboard } from "@/composables/useClipboard";
 
 const DEFAULT_FORM = {
   name: "",
@@ -340,15 +341,18 @@ const deleteTarget = ref<RouterKey | null>(null);
 const form = ref({ ...DEFAULT_FORM, allowed_models: [] as string[] });
 const errors = ref<Record<string, string>>({});
 
+const { copy: doCopy } = useClipboard();
 const copiedId = ref<string | null>(null);
 const COPY_FEEDBACK_MS = 2000;
 
-function copyKey(key: string, id: string) {
-  navigator.clipboard.writeText(key);
-  copiedId.value = id;
-  setTimeout(() => {
-    if (copiedId.value === id) copiedId.value = null;
-  }, COPY_FEEDBACK_MS);
+async function copyKey(key: string, id: string) {
+  const ok = await doCopy(key);
+  if (ok) {
+    copiedId.value = id;
+    setTimeout(() => {
+      if (copiedId.value === id) copiedId.value = null;
+    }, COPY_FEEDBACK_MS);
+  }
 }
 
 function maskKey(key: string | null): string {

--- a/router/src/index.ts
+++ b/router/src/index.ts
@@ -157,13 +157,24 @@ export async function buildApp(
   app.addHook("onRequest", (request, reply, done) => {
     (request as unknown as { receivedAt: number }).receivedAt = Date.now();
 
-    // 全局 EPIPE 防护：ServerResponse 的 write 异步完成失败时，
-    // 内部 socketErrorListener → response.destroy(err) → response.emit('error')。
-    // 若无 listener 则该 error 成为 uncaught exception。
+    // 全局 EPIPE 防护：
+    // EPIPE 从底层 socket 的 WriteWrap.onWriteComplete 触发，emit 在 socket 上，
+    // 不会传播到 reply.raw（ServerResponse）。reply.raw.on("error") 无法拦截 socket 的 EPIPE。
+    // 因此必须直接在 socket 上注册 error handler。
+    // Node.js HTTP server 内置的 socketOnError 只处理第一次 error（随后注册 noop 兜底），
+    // 本 handler 提供额外的永久保护层。
     // 代理路由在 create-proxy-handler.ts 中已有额外监听，此处覆盖所有路由。
+    const sock = request.raw.socket;
+    sock.on("error", (err: NodeJS.ErrnoException) => {
+      if (err.code === "EPIPE" || err.code === "ECONNRESET") {
+        request.log.debug({ err }, "client socket error");
+      } else {
+        request.log.warn({ err }, "unexpected socket error");
+      }
+    });
     reply.raw.on("error", (err: Error) => {
       const code = (err as { code?: string }).code;
-      if (code === 'EPIPE') {
+      if (code === "EPIPE") {
         request.log.debug({ err }, "client disconnected (EPIPE)");
       } else {
         request.log.warn({ err }, "response stream error");

--- a/router/src/index.ts
+++ b/router/src/index.ts
@@ -165,20 +165,28 @@ export async function buildApp(
     // 本 handler 提供额外的永久保护层。
     // 代理路由在 create-proxy-handler.ts 中已有额外监听，此处覆盖所有路由。
     const sock = request.raw.socket;
-    sock.on("error", (err: NodeJS.ErrnoException) => {
+    const socketErrorHandler = (err: NodeJS.ErrnoException) => {
       if (err.code === "EPIPE" || err.code === "ECONNRESET") {
         request.log.debug({ err }, "client socket error");
       } else {
         request.log.warn({ err }, "unexpected socket error");
       }
-    });
-    reply.raw.on("error", (err: Error) => {
+    };
+    sock.on("error", socketErrorHandler);
+
+    const replyErrorHandler = (err: Error) => {
       const code = (err as { code?: string }).code;
       if (code === "EPIPE") {
         request.log.debug({ err }, "client disconnected (EPIPE)");
       } else {
         request.log.warn({ err }, "response stream error");
       }
+    };
+    reply.raw.on("error", replyErrorHandler);
+
+    reply.raw.on("close", () => {
+      sock.removeListener("error", socketErrorHandler);
+      reply.raw.removeListener("error", replyErrorHandler);
     });
 
     done();

--- a/router/src/proxy/handler/create-proxy-handler.ts
+++ b/router/src/proxy/handler/create-proxy-handler.ts
@@ -181,9 +181,9 @@ export function createProxyHandler(config: ProxyHandlerConfig) {
       request.raw.socket.on("error", socketErrorHandler);
 
       // reply.raw (ServerResponse) error handling
-      // Node.js 中，TCP socket write 异步完成失败时（如 EPIPE），
-      // 内部 socketErrorListener → response.destroy(err) → response.emit('error')。
-      // 若无 listener，该 error 成为 uncaught exception 导致进程退出。
+      // 注意：EPIPE 从底层 socket 的 WriteWrap.onWriteComplete emit，不会传播到 reply.raw。
+      // 因此 reply.raw.on("error") 无法拦截 socket EPIPE——socket 级别由上面的 socketErrorHandler 和全局 onRequest hook 覆盖。
+      // 本 handler 仅处理 ServerResponse 自身可能产生的其他 error。
       const replyErrorHandler = (err: Error) => {
         const code = (err as { code?: string }).code;
         if (code === 'EPIPE') {

--- a/router/src/proxy/transform/stream-ant2oa.ts
+++ b/router/src/proxy/transform/stream-ant2oa.ts
@@ -144,19 +144,13 @@ export class AnthropicToOpenAITransform extends BaseSSETransform {
       }
 
       case "message_stop": {
-        // emit PSF as custom message_meta event before final usage
-        if (this.thinkingSignatures.length > 0 || this.cacheUsage) {
-          const meta: AnthropicProviderMeta = {};
-          if (this.thinkingSignatures.length > 0) meta.thinking_signatures = this.thinkingSignatures;
-          if (this.cacheUsage) meta.cache_usage = this.cacheUsage;
-          this.push(`event: message_meta\ndata: ${JSON.stringify({ provider_meta: { anthropic: meta } })}\n\n`);
-        }
-
         // Anthropic input_tokens excludes cache; OpenAI prompt_tokens includes cache
         const cacheRead = this.cacheUsage?.cache_read_input_tokens ?? 0;
         const cacheCreation = this.cacheUsage?.cache_creation_input_tokens ?? 0;
         const totalInput = this.inputTokens + cacheRead + cacheCreation;
-        this.pushOpenAISSE({
+
+        // 将 provider_meta 合并到 usage chunk 中，避免独立 SSE 事件导致客户端 SDK 校验失败
+        const usageChunk: Record<string, unknown> = {
           id: this.chatcmplId, object: "chat.completion.chunk",
           choices: [],
           usage: {
@@ -168,7 +162,16 @@ export class AnthropicToOpenAITransform extends BaseSSETransform {
               cached_write_tokens: cacheCreation,
             },
           },
-        });
+        };
+
+        if (this.thinkingSignatures.length > 0 || this.cacheUsage) {
+          const meta: AnthropicProviderMeta = {};
+          if (this.thinkingSignatures.length > 0) meta.thinking_signatures = this.thinkingSignatures;
+          if (this.cacheUsage) meta.cache_usage = this.cacheUsage;
+          usageChunk.provider_meta = { anthropic: meta };
+        }
+
+        this.pushOpenAISSE(usageChunk);
         this.pushDone();
         break;
       }

--- a/router/src/proxy/transport/stream.ts
+++ b/router/src/proxy/transport/stream.ts
@@ -201,6 +201,20 @@ class StreamProxy {
   registerCloseHandler(): void {
     if (this.closeHandlerRegistered) return;
     this.closeHandlerRegistered = true;
+    // EPIPE 从底层 socket 的 WriteWrap.onWriteComplete emit，reply.raw.on("error") 无法拦截。
+    // 必须直接在 socket 上注册 error handler 防止冒泡到 process uncaughtException。
+    // Node.js HTTP server 内置的 socketOnError 只处理第一次 socket error，
+    // 如果第一次被其他错误消耗，后续 EPIPE 可能无 handler 导致进程崩溃。
+    const sock = this.reply.raw.socket;
+    if (sock) {
+      sock.on("error", (err: NodeJS.ErrnoException) => {
+        if (err.code === "EPIPE" || err.code === "ECONNRESET") {
+          // 客户端已断开，正常行为
+          return;
+        }
+        console.warn("[stream-proxy] socket error:", err.message);
+      });
+    }
     this.reply.raw.on("close", () => {
       if (this.resolved) return;
       if (this.state === "BUFFERING" || this.state === "STREAMING") {

--- a/router/src/proxy/transport/stream.ts
+++ b/router/src/proxy/transport/stream.ts
@@ -206,16 +206,20 @@ class StreamProxy {
     // Node.js HTTP server 内置的 socketOnError 只处理第一次 socket error，
     // 如果第一次被其他错误消耗，后续 EPIPE 可能无 handler 导致进程崩溃。
     const sock = this.reply.raw.socket;
+    let sockErrorHandler: ((err: NodeJS.ErrnoException) => void) | undefined;
     if (sock) {
-      sock.on("error", (err: NodeJS.ErrnoException) => {
+      sockErrorHandler = (err: NodeJS.ErrnoException) => {
         if (err.code === "EPIPE" || err.code === "ECONNRESET") {
-          // 客户端已断开，正常行为
           return;
         }
         console.warn("[stream-proxy] socket error:", err.message);
-      });
+      };
+      sock.on("error", sockErrorHandler);
     }
     this.reply.raw.on("close", () => {
+      if (sockErrorHandler && sock) {
+        sock.removeListener("error", sockErrorHandler);
+      }
       if (this.resolved) return;
       if (this.state === "BUFFERING" || this.state === "STREAMING") {
         this.transition("ABORTED");

--- a/router/tests/proxy/transform/stream-transform-ant2oa.test.ts
+++ b/router/tests/proxy/transform/stream-transform-ant2oa.test.ts
@@ -128,9 +128,12 @@ describe("AnthropicToOpenAITransform", () => {
     t.write('event: message_stop\ndata: {"type":"message_stop"}\n\n');
     t.end();
     const result = await output;
-    expect(result).toContain("event: message_meta");
+    // provider_meta 合并在 usage chunk 中，不再是独立事件
+    expect(result).toContain('"provider_meta"');
     expect(result).toContain('"thinking_signatures"');
     expect(result).toContain('"signature":"sig_abc"');
+    // 独立的 message_meta 事件不再发送
+    expect(result).not.toContain("event: message_meta");
   });
 
   it("emits message_meta with cache usage", async () => {
@@ -144,9 +147,12 @@ describe("AnthropicToOpenAITransform", () => {
     t.write('event: message_stop\ndata: {"type":"message_stop"}\n\n');
     t.end();
     const result = await output;
-    expect(result).toContain("event: message_meta");
+    // provider_meta 合并在 usage chunk 中，不再是独立事件
+    expect(result).toContain('"provider_meta"');
     expect(result).toContain('"cache_read_input_tokens":100');
     expect(result).toContain('"cache_creation_input_tokens":50');
+    // 独立的 message_meta 事件不再发送
+    expect(result).not.toContain("event: message_meta");
   });
 
   it("no message_meta when no PSF present", async () => {
@@ -160,6 +166,7 @@ describe("AnthropicToOpenAITransform", () => {
     t.write('event: message_stop\ndata: {"type":"message_stop"}\n\n');
     t.end();
     const result = await output;
-    expect(result).not.toContain("event: message_meta");
+    // 没有 PSF 时，不应出现 provider_meta
+    expect(result).not.toContain('"provider_meta"');
   });
 });


### PR DESCRIPTION
## 修复内容

### Bug 1: 复制密钥报错 (`writeText undefined`)

**文件**: `frontend/src/views/RouterKeys.vue`

**原因**: `copyKey()` 直接调用 `navigator.clipboard.writeText()`，在 HTTP（非 HTTPS、非 localhost）环境下 `navigator.clipboard` 为 `undefined`。用户通过 `http://ip:port/admin/` 访问管理后台时触发。

**修复**: 改用项目已有的 `useClipboard` composable，自动降级到 `execCommand('copy')`。

### Bug 2: `provider_meta` 导致客户端 SDK Zod 校验失败

**文件**: `router/src/proxy/transform/stream-ant2oa.ts`

**原因**: `AnthropicToOpenAITransform` 在流末尾发送独立的 `event: message_meta` SSE 事件，数据体为 `{"provider_meta":{...}}`，缺少 `choices` 字段。OpenAI SDK 的 Zod schema 要求每个 chunk 必须有 `choices` 或 `error`，导致校验崩溃。

**触发条件**: 客户端用 OpenAI 格式请求 → 上游是 Anthropic 格式 provider（kimi/minimax/deepseek-anthropic） → 响应走 ant→oa 流转换 → 上游返回 thinking signature。

**修复**: 不再发送独立的 `event: message_meta` 事件，改为将 `provider_meta` 合并到最后一个 usage chunk 中。OpenAI SDK 对 usage chunk 的额外字段使用 passthrough，不会报错。

## 测试

- 全部 1552 个后端测试通过（含更新的 stream-ant2oa 测试）
- 前端 vue-tsc 类型检查通过
- 前后端 ESLint 通过
- Pre-commit hook 全部通过