### PR TITLE
fix: handle orphan tool_calls (reverse direction) in DeepSeek patch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1003,6 +1003,7 @@
       "resolved": "https://registry.npmmirror.com/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1559,6 +1560,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -1582,6 +1584,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -3355,6 +3358,7 @@
       "resolved": "https://registry.npmmirror.com/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
       "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -3436,6 +3440,7 @@
       "resolved": "https://registry.npmmirror.com/@noble/ciphers/-/ciphers-1.3.0.tgz",
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -5219,6 +5224,7 @@
       "integrity": "sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.1",
         "@typescript-eslint/types": "8.59.1",
@@ -5617,6 +5623,7 @@
       "resolved": "https://registry.npmmirror.com/@vue/compiler-dom/-/compiler-dom-3.5.33.tgz",
       "integrity": "sha512-PXq0yrfCLzzL07rbXO4awtXY1Z06LG2eu6Adg3RJFa/j3Cii217XxxLXG22N330gw7GmALCY0Z8RgXEviwgpjA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-core": "3.5.33",
         "@vue/shared": "3.5.33"
@@ -5740,6 +5747,7 @@
       "resolved": "https://registry.npmmirror.com/@vue/server-renderer/-/server-renderer-3.5.33.tgz",
       "integrity": "sha512-0xylq/8/h44lVG0pZFknv1XIdEgymq2E9n59uTWJBG+dIgiT0TMCSsxrN7nO16Z0MU0MPjFcguBbZV8Itk52Hw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-ssr": "3.5.33",
         "@vue/shared": "3.5.33"
@@ -5879,6 +5887,7 @@
       "resolved": "https://registry.npmmirror.com/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6384,6 +6393,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -6592,6 +6602,7 @@
       "resolved": "https://registry.npmmirror.com/chart.js/-/chart.js-4.5.1.tgz",
       "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@kurkle/color": "^0.3.0"
       },
@@ -7730,6 +7741,7 @@
       "resolved": "https://registry.npmmirror.com/eslint/-/eslint-10.3.0.tgz",
       "integrity": "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -9103,6 +9115,7 @@
       "resolved": "https://registry.npmmirror.com/hono/-/hono-4.12.16.tgz",
       "integrity": "sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -9547,6 +9560,7 @@
       "resolved": "https://registry.npmmirror.com/jiti/-/jiti-2.6.1.tgz",
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -9781,6 +9795,7 @@
       "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@asamuzakjp/css-color": "^5.1.11",
         "@asamuzakjp/dom-selector": "^7.1.1",
@@ -9847,6 +9862,7 @@
       "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mdn-data": "2.27.1",
         "source-map-js": "^1.2.1"
@@ -10167,6 +10183,7 @@
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "dev": true,
       "license": "MPL-2.0",
+      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.3"
       },
@@ -11601,6 +11618,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -13370,6 +13388,7 @@
       "resolved": "https://registry.npmmirror.com/stylus/-/stylus-0.57.0.tgz",
       "integrity": "sha512-yOI6G8WYfr0q8v8rRvE91wbxFU+rJPo760Va4MF6K0I6BZjO4r+xSynkvyPBP9tV1CIEUeRsiidjIs2rzb1CnQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "css": "^3.0.0",
         "debug": "^4.3.2",
@@ -13669,6 +13688,7 @@
       "resolved": "https://registry.npmmirror.com/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -14076,6 +14096,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -14097,6 +14118,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14113,6 +14135,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14129,6 +14152,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14145,6 +14169,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14161,6 +14186,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14177,6 +14203,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14193,6 +14220,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14209,6 +14237,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14225,6 +14254,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14241,6 +14271,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14257,6 +14288,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14273,6 +14305,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14289,6 +14322,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14305,6 +14339,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14321,6 +14356,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14337,6 +14373,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14353,6 +14390,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14369,6 +14407,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14385,6 +14424,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14401,6 +14441,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14417,6 +14458,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14433,6 +14475,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14449,6 +14492,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14465,6 +14509,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14481,6 +14526,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14497,6 +14543,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14611,6 +14658,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -14808,6 +14856,7 @@
       "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -16083,6 +16132,7 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -16164,6 +16214,7 @@
       "resolved": "https://registry.npmmirror.com/vue/-/vue-3.5.33.tgz",
       "integrity": "sha512-1AgChhx5w3ALgT4oK3acm2Es/7jyZhWSVUfs3rOBlGQC0rjEDkS7G4lWlJJGGNQD+BV3reCwbQrOe1mPNwKHBQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.33",
         "@vue/compiler-sfc": "3.5.33",
@@ -16702,6 +16753,7 @@
       "integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
       "devOptional": true,
       "license": "ISC",
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -16851,6 +16903,7 @@
       "resolved": "https://registry.npmmirror.com/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/router/src/proxy/patch/deepseek/patch-orphan-tool-results.ts
+++ b/router/src/proxy/patch/deepseek/patch-orphan-tool-results.ts
@@ -1,17 +1,19 @@
 import { type ContentBlock, type Message, mergeConsecutive, mergeAssistantContent } from "./utils.js";
 
 /**
- * 修复孤儿 tool_result 块——Claude Code 的 context management 截断历史消息时
- * 可能丢失 tool_use 块但保留对应的 tool_result，导致 DeepSeek 严格校验失败。
+ * 修复 Anthropic 格式消息中的 tool_use / tool_result 配对断裂。
  *
- * 算法：
- * 1. 收集所有 assistant 消息中的 tool_use ID
- * 2. 移除 tool_use_id 不在集合中的 tool_result 块
+ * Claude Code 的 context management 截断历史消息时可能产生两种方向的不匹配：
+ * - 正向：tool_result 存在但对应的 tool_use 被截断（孤儿 tool_result）
+ * - 反向：tool_use 存在但对应的 tool_result 被截断（孤儿 tool_use）
+ *
+ * 两种都会导致 DeepSeek Anthropic 端点校验失败。
+ *
+ * 算法（正向 + 反向）：
+ * 1. 正向：收集所有 tool_use ID，移除无主的 tool_result 块
+ * 2. 反向：收集所有 tool_result ID，从非末尾 assistant 中移除无主的 tool_use 块
  * 3. 移除清空后的空 user 消息
- * 4. 合并相邻的 user 消息（Anthropic API 不允许连续 user 消息）
- * 5. 合并相邻的 assistant 消息（带 tool_use 去重）
- * 6. 移除 content 为空数组的 assistant 消息
- * 7. 最终合并连续同角色消息
+ * 4-7. 合并/清理消息链
  */
 export function patchOrphanToolResults(
   body: Record<string, unknown>,
@@ -20,7 +22,9 @@ export function patchOrphanToolResults(
   const messages = body.messages as Message[];
   if (!Array.isArray(messages) || messages.length === 0) return;
 
-  // Step 1: 收集所有已知的 tool_use ID
+  let changed = false;
+
+  // ---- 正向：移除孤儿 tool_result（tool_result 无对应 tool_use）----
   const knownToolUseIds = new Set<string>();
   for (const msg of messages) {
     if (msg.role !== "assistant" || !Array.isArray(msg.content)) continue;
@@ -30,8 +34,6 @@ export function patchOrphanToolResults(
       }
     }
   }
-  // Step 2: 移除孤儿 tool_result 块
-  let removedAny = false;
   for (const msg of messages) {
     if (msg.role !== "user" || !Array.isArray(msg.content)) continue;
     const blocks = msg.content as ContentBlock[];
@@ -44,12 +46,45 @@ export function patchOrphanToolResults(
     });
     if (filtered.length < before) {
       msg.content = filtered;
-      removedAny = true;
+      changed = true;
     }
   }
-  if (!removedAny) return;
 
-  // Step 3: 移除清空后的空 user 消息（向后遍历避免索引错乱）
+  // ---- 反向：移除孤儿 tool_use（非末尾 assistant 的 tool_use 无对应 tool_result）----
+  const knownToolResultIds = new Set<string>();
+  for (const msg of messages) {
+    if (msg.role !== "user" || !Array.isArray(msg.content)) continue;
+    for (const block of msg.content as ContentBlock[]) {
+      if (block?.type === "tool_result" && typeof block.tool_use_id === "string") {
+        knownToolResultIds.add(block.tool_use_id);
+      }
+    }
+  }
+  const lastMsgIdx = messages.length - 1;
+  for (let i = 0; i <= lastMsgIdx; i++) {
+    const msg = messages[i];
+    if (msg.role !== "assistant" || !Array.isArray(msg.content)) continue;
+    // 跳过最后一条 assistant：它可能是正常的工具调用中间状态
+    if (i === lastMsgIdx) break;
+    const blocks = msg.content as ContentBlock[];
+    const hasToolUse = blocks.some(b => b?.type === "tool_use");
+    if (!hasToolUse) continue;
+    const before = blocks.length;
+    const filtered = blocks.filter(block => {
+      if (block?.type === "tool_use" && typeof block.id === "string") {
+        return knownToolResultIds.has(block.id);
+      }
+      return true;
+    });
+    if (filtered.length < before) {
+      msg.content = filtered;
+      changed = true;
+    }
+  }
+
+  if (!changed) return;
+
+  // 移除清空后的空 user 消息（向后遍历避免索引错乱）
   for (let i = messages.length - 1; i >= 0; i--) {
     const msg = messages[i];
     if (msg.role !== "user") continue;
@@ -60,13 +95,11 @@ export function patchOrphanToolResults(
     }
   }
 
-  // Step 4: 合并相邻的 user 消息
+  // 合并相邻的 user 消息
   mergeConsecutive(messages, "user");
 
-  // Step 5: 合并相邻的 assistant 消息（带 tool_use 去重）
+  // 合并相邻的 assistant 消息（带 tool_use 去重）+ 移除空 assistant
   mergeConsecutive(messages, "assistant", mergeAssistantContent);
-
-  // Step 6: 移除 content 为空数组的 assistant 消息
   for (let i = messages.length - 1; i >= 0; i--) {
     const msg = messages[i];
     if (msg.role === "assistant" && Array.isArray(msg.content) && msg.content.length === 0) {
@@ -74,22 +107,27 @@ export function patchOrphanToolResults(
     }
   }
 
-  // Step 7: 删除空 assistant 后可能产生连续同角色消息，再合并一次
+  // 删除空 assistant 后可能产生连续同角色消息，再合并一次
   mergeConsecutive(messages, "user");
   mergeConsecutive(messages, "assistant", mergeAssistantContent);
 }
 
 /**
- * OpenAI 格式版本的孤儿 tool 消息清理。
+ * OpenAI 格式版本的 tool_calls / tool 消息配对修复。
  *
- * 检测 role:"tool" 消息的 tool_call_id 是否有对应的 assistant tool_calls[].id。
- * 移除孤儿 tool 消息后合并连续 user 消息。
+ * 检测两种方向的不匹配：
+ * - 正向：role:"tool" 消息的 tool_call_id 无对应 assistant tool_calls[].id → 移除孤儿 tool 消息
+ * - 反向：非末尾 assistant 的 tool_calls[].id 无对应 tool 消息 → 移除该 tool_call 条目
+ *
+ * 反向跳过最后一条 assistant：它可能是正常的工具调用中间状态（模型刚返回 tool_calls，
+ * 客户端还没来得及执行并回传 tool 消息）。
  */
 export function patchOrphanToolResultsOA(body: Record<string, unknown>): void {
   const messages = body.messages as Array<Record<string, unknown>> | undefined;
   if (!messages || !Array.isArray(messages) || messages.length === 0) return;
 
-  // Step 1: 收集所有 assistant tool_calls IDs
+  // ---- 正向：移除孤儿 tool 消息 ----
+  // 收集所有 assistant tool_calls IDs
   const knownToolCallIds = new Set<string>();
   for (const msg of messages) {
     if (msg.role !== "assistant") continue;
@@ -100,21 +138,53 @@ export function patchOrphanToolResultsOA(body: Record<string, unknown>): void {
     }
   }
 
-  // Step 2: 移除孤儿 tool 消息（逆序遍历避免索引偏移）
-  let removedAny = false;
+  // 移除无主 tool 消息（逆序遍历避免索引偏移）
+  let changed = false;
   for (let i = messages.length - 1; i >= 0; i--) {
     const msg = messages[i];
     if (msg.role !== "tool") continue;
     const toolCallId = (msg.tool_call_id ?? "") as string;
     if (!knownToolCallIds.has(toolCallId)) {
       messages.splice(i, 1);
-      removedAny = true;
+      changed = true;
     }
   }
 
-  if (!removedAny) return;
+  // ---- 反向：移除孤儿 tool_calls 条目（非末尾 assistant）----
+  // 收集所有 tool 消息的 ID
+  const knownToolMsgIds = new Set<string>();
+  for (const msg of messages) {
+    if (msg.role !== "tool") continue;
+    const toolCallId = (msg.tool_call_id ?? "") as string;
+    if (toolCallId) knownToolMsgIds.add(toolCallId);
+  }
 
-  // Step 3: 合并连续 user 消息
+  const lastMsgIdx = messages.length - 1;
+  for (let i = 0; i <= lastMsgIdx; i++) {
+    const msg = messages[i];
+    if (msg.role !== "assistant") continue;
+    // 跳过最后一条 assistant：它可能是正常的工具调用中间状态
+    if (i === lastMsgIdx) break;
+    const toolCalls = msg.tool_calls as Array<Record<string, unknown>> | undefined;
+    if (!toolCalls || toolCalls.length === 0) continue;
+    const before = toolCalls.length;
+    const filtered = toolCalls.filter(tc => {
+      const id = tc.id as string | undefined;
+      return !id || knownToolMsgIds.has(id);
+    });
+    if (filtered.length < before) {
+      if (filtered.length === 0) {
+        delete msg.tool_calls;
+      } else {
+        msg.tool_calls = filtered;
+      }
+      changed = true;
+    }
+  }
+
+  if (!changed) return;
+
+  // 合并连续 user 消息
   let i = 1;
   while (i < messages.length) {
     if (messages[i].role === "user" && messages[i - 1].role === "user") {

--- a/router/tests/patch.test.ts
+++ b/router/tests/patch.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { patchThinkingConsistency, _internals } from "../src/proxy/patch/deepseek/patch-thinking.js";
-import { patchOrphanToolResultsOA } from "../src/proxy/patch/deepseek/patch-orphan-tool-results.js";
+import { patchOrphanToolResultsOA, patchOrphanToolResults } from "../src/proxy/patch/deepseek/patch-orphan-tool-results.js";
 import { applyProviderPatches } from "../src/proxy/patch/index.js";
 
 // ---------- patchMissingReasoningContent ----------
@@ -120,7 +120,7 @@ describe("patchThinkingConsistency", () => {
 
 // ---------- patchOrphanToolResults（OpenAI 格式）----------
 
-describe("patchOrphanToolResults", () => {
+describe("patchOrphanToolResultsOA", () => {
   it("移除没有对应 tool_calls 的 tool 消息", () => {
     const body = {
       messages: [
@@ -166,9 +166,174 @@ describe("patchOrphanToolResults", () => {
     expect(roles).toEqual(["assistant", "tool", "assistant", "user"]);
   });
 
+  // ---- 反向：移除孤儿 tool_calls ----
+
+  it("反向：移除非末尾 assistant 中无对应 tool 消息的 tool_call 条目", () => {
+    const body = {
+      messages: [
+        { role: "user", content: "read a file" },
+        { role: "assistant", content: null, tool_calls: [{ id: "orphan_1", type: "function", function: { name: "read", arguments: "{}" } }] },
+        { role: "user", content: "你找到了什么?" },
+      ],
+    };
+    patchOrphanToolResultsOA(body);
+    const orphanAssistant = body.messages[1] as Record<string, unknown>;
+    expect(orphanAssistant.tool_calls).toBeUndefined();
+    expect(body.messages).toHaveLength(3);
+  });
+
+  it("反向：末尾 assistant 的 tool_calls 保持不动（正常的工具调用中间状态）", () => {
+    const body = {
+      messages: [
+        { role: "user", content: "read a file" },
+        { role: "assistant", content: null, tool_calls: [{ id: "call_1", type: "function", function: { name: "read", arguments: "{}" } }] },
+      ],
+    };
+    patchOrphanToolResultsOA(body);
+    const lastAssistant = body.messages[1] as Record<string, unknown>;
+    expect(lastAssistant.tool_calls).toHaveLength(1);
+  });
+
+  it("反向：部分配对时只移除未配对的 tool_call，保留已配对的", () => {
+    const body = {
+      messages: [
+        { role: "assistant", content: null, tool_calls: [
+          { id: "matched", type: "function", function: { name: "A", arguments: "{}" } },
+          { id: "orphan", type: "function", function: { name: "B", arguments: "{}" } },
+        ] },
+        { role: "tool", tool_call_id: "matched", content: "ok" },
+        { role: "assistant", content: "done" },
+      ],
+    };
+    patchOrphanToolResultsOA(body);
+    const firstAssistant = body.messages[0] as Record<string, unknown>;
+    const calls = firstAssistant.tool_calls as Array<Record<string, unknown>>;
+    expect(calls).toHaveLength(1);
+    expect(calls[0].id).toBe("matched");
+  });
+
+  it("反向：Claude Code 截断场景的完整消息链修复", () => {
+    const body = {
+      messages: [
+        { role: "system", content: "You are helpful." },
+        { role: "user", content: "read file.ts" },
+        { role: "assistant", content: null, tool_calls: [{ id: "toolu_1", type: "function", function: { name: "read", arguments: "{\"path\":\"file.ts\"}" } }] },
+        { role: "user", content: "你找到了什么?" },
+        { role: "assistant", content: null, tool_calls: [{ id: "toolu_2", type: "function", function: { name: "read", arguments: "{\"path\":\"other.ts\"}" } }] },
+        { role: "tool", tool_call_id: "toolu_2", content: "other file content" },
+        { role: "assistant", content: "这是 other.ts 的内容" },
+        { role: "user", content: "继续" },
+      ],
+    };
+    patchOrphanToolResultsOA(body);
+    // toolu_1 是孤儿（无对应 tool 消息），应被移除
+    const firstAssistant = body.messages[2] as Record<string, unknown>;
+    expect(firstAssistant.tool_calls).toBeUndefined();
+    // toolu_2 有配对，保持不动（index 4 是 toolu_2 的 assistant）
+    const secondAssistant = body.messages[4] as Record<string, unknown>;
+    expect((secondAssistant.tool_calls as unknown[]).length).toBe(1);
+    // 末尾是 user "继续"，倒数第二个是 assistant
+    const lastUser = body.messages[body.messages.length - 1] as Record<string, unknown>;
+    expect(lastUser.content).toBe("继续");
+    const prevAssistant = body.messages[body.messages.length - 2] as Record<string, unknown>;
+    expect(prevAssistant.content).toBe("这是 other.ts 的内容");
+  });
+
   it("空 messages 时安全返回", () => {
     expect(() => patchOrphanToolResultsOA({})).not.toThrow();
     expect(() => patchOrphanToolResultsOA({ messages: [] })).not.toThrow();
+  });
+});
+
+// ---------- patchOrphanToolResults（Anthropic 格式）----------
+
+describe("patchOrphanToolResults", () => {
+  it("正向：移除无主 tool_result 块", () => {
+    const body = {
+      messages: [
+        { role: "user", content: [{ type: "text", text: "hi" }] },
+        { role: "user", content: [{ type: "tool_result", tool_use_id: "ghost_id", content: "orphan" }] },
+        { role: "assistant", content: [{ type: "text", text: "done" }] },
+      ],
+    };
+    patchOrphanToolResults(body);
+    expect(body.messages).toHaveLength(2);
+  });
+
+  it("反向：移除非末尾 assistant 中无对应 tool_result 的 tool_use 块", () => {
+    const body = {
+      messages: [
+        { role: "user", content: [{ type: "text", text: "read a file" }] },
+        { role: "assistant", content: [
+          { type: "tool_use", id: "orphan_use", name: "read", input: { path: "a.ts" } },
+        ] },
+        { role: "user", content: [{ type: "text", text: "你找到了什么?" }] },
+      ],
+    };
+    patchOrphanToolResults(body);
+    // tool_use 被移除后 assistant content 为空，空 assistant 被清理
+    // 两个 user 消息合并（Anthropic 不允许连续 user）
+    const roles = (body.messages as Array<{ role: string }>).map(m => m.role);
+    expect(roles).toEqual(["user"]);
+    // 合并后的 user content 包含两段文本
+    const userMsg = body.messages[0] as { content: Array<{ type: string; text?: string }> };
+    const texts = userMsg.content.filter(b => b.type === "text").map(b => b.text);
+    expect(texts).toContain("read a file");
+    expect(texts).toContain("你找到了什么?");
+  });
+
+  it("反向：末尾 assistant 的 tool_use 保持不动", () => {
+    const body = {
+      messages: [
+        { role: "user", content: [{ type: "text", text: "read a file" }] },
+        { role: "assistant", content: [
+          { type: "tool_use", id: "toolu_1", name: "read", input: {} },
+        ] },
+      ],
+    };
+    patchOrphanToolResults(body);
+    const lastMsg = body.messages[1] as { content: Array<{ type: string }> };
+    expect(lastMsg.content.some(b => b.type === "tool_use")).toBe(true);
+  });
+
+  it("反向：部分配对时只移除未配对的 tool_use", () => {
+    const body = {
+      messages: [
+        { role: "user", content: [{ type: "text", text: "go" }] },
+        { role: "assistant", content: [
+          { type: "text", text: "let me check" },
+          { type: "tool_use", id: "matched_id", name: "A", input: {} },
+          { type: "tool_use", id: "orphan_id", name: "B", input: {} },
+        ] },
+        { role: "user", content: [{ type: "tool_result", tool_use_id: "matched_id", content: "ok" }] },
+        { role: "assistant", content: [{ type: "text", text: "done" }] },
+      ],
+    };
+    patchOrphanToolResults(body);
+    const assistant = body.messages[1] as { content: Array<{ type: string; id?: string }> };
+    const toolUses = assistant.content.filter(b => b.type === "tool_use");
+    expect(toolUses).toHaveLength(1);
+    expect(toolUses[0].id).toBe("matched_id");
+    expect(assistant.content.some(b => b.type === "text")).toBe(true);
+  });
+
+  it("正常配对的消息链不做任何修改", () => {
+    const body = {
+      messages: [
+        { role: "user", content: [{ type: "text", text: "go" }] },
+        { role: "assistant", content: [{ type: "tool_use", id: "t1", name: "read", input: {} }] },
+        { role: "user", content: [{ type: "tool_result", tool_use_id: "t1", content: "ok" }] },
+        { role: "assistant", content: [{ type: "text", text: "done" }] },
+      ],
+    };
+    const original = JSON.stringify(body);
+    patchOrphanToolResults(body);
+    expect(JSON.stringify(body)).toBe(original);
+  });
+
+  it("空 messages 时安全返回", () => {
+    expect(() => patchOrphanToolResults({})).not.toThrow();
+    expect(() => patchOrphanToolResults({ messages: [] })).not.toThrow();
   });
 });
 


### PR DESCRIPTION
## 问题

Claude Code 的 context compression 截断历史消息时，可能移除 `tool_result` / `role:"tool"` 消息但保留前面的 `tool_use` / `tool_calls`。现有的 orphan patch 只处理了一个方向：

| 方向 | 修复前 | 修复后 |
|------|--------|--------|
| tool 消息无对应 tool_calls | 已处理（删除孤儿 tool 消息） | 不变 |
| tool_calls 无对应 tool 消息 | **未处理** | **已修复** |

通过 opengo 等非 DeepSeek 官方端点转发时，`needsDeepSeekPatch` 可能不触发（URL 不含 "deepseek"），加剧了问题。但即使触发，反向孤儿也未处理。

## 修复

在 `patchOrphanToolResultsOA`（OpenAI 格式）和 `patchOrphanToolResults`（Anthropic 格式）中新增反向孤儿清理逻辑：

- 收集所有 tool 消息的 ID 集合
- 遍历**非末尾** assistant 消息的 tool_calls / tool_use
- 移除没有配对的条目
- **跳过最后一条 assistant**：它可能是正常的工具调用中间状态

## 安全保障

- 正常配对的消息链不做任何修改（ID 精确匹配）
- 末尾 assistant 的 tool_calls 不受影响
- 只在 DeepSeek patch 路径触发，不影响其他 provider
- 部分 tool_calls 配对时只移除未配对的，保留已配对的

## 测试

新增 8 个测试用例（OpenAI 4 + Anthropic 4），覆盖：
- 反向孤儿移除
- 末尾 assistant 保护
- 部分配对场景
- Claude Code 截断完整场景
- 正常配对不修改

全部 1562 测试通过。