### PR TITLE
fix: reorder non-tool messages between assistant(tool_calls) and tool messages

### DIFF
--- a/router/src/proxy/patch/deepseek/patch-orphan-tool-results.ts
+++ b/router/src/proxy/patch/deepseek/patch-orphan-tool-results.ts
@@ -112,20 +112,50 @@ export function patchOrphanToolResultsOA(body: Record<string, unknown>): void {
     }
   }
 
-  if (!removedAny) return;
+  if (removedAny) {
+    // Step 3: 合并连续 user 消息
+    let i = 1;
+    while (i < messages.length) {
+      if (messages[i].role === "user" && messages[i - 1].role === "user") {
+        const prev = messages[i - 1];
+        const curr = messages[i];
+        const prevContent = typeof prev.content === "string" ? prev.content : JSON.stringify(prev.content ?? "") as string;
+        const currContent = typeof curr.content === "string" ? curr.content : JSON.stringify(curr.content ?? "") as string;
+        prev.content = prevContent + "\n" + currContent;
+        messages.splice(i, 1);
+      } else {
+        i++;
+      }
+    }
+  }
 
-  // Step 3: 合并连续 user 消息
-  let i = 1;
-  while (i < messages.length) {
-    if (messages[i].role === "user" && messages[i - 1].role === "user") {
-      const prev = messages[i - 1];
-      const curr = messages[i];
-      const prevContent = typeof prev.content === "string" ? prev.content : JSON.stringify(prev.content ?? "") as string;
-      const currContent = typeof curr.content === "string" ? curr.content : JSON.stringify(curr.content ?? "") as string;
-      prev.content = prevContent + "\n" + currContent;
-      messages.splice(i, 1);
-    } else {
-      i++;
+  // Step 4: 修复 tool_calls 消息顺序——将插在 assistant(tool_calls) 与 tool 之间的
+  // 非 tool 消息（如用户中断、系统提醒）挪到 tool 消息之后
+  // 例如: [assistant(tool_calls=[A,B]), user(中断), tool(B), tool(A)]
+  //   →  [assistant(tool_calls=[A,B]), tool(B), tool(A), user(中断)]
+  for (let i = 0; i < messages.length; i++) {
+    const msg = messages[i] as Record<string, unknown>;
+    if (msg.role !== "assistant" || !msg.tool_calls || !(msg.tool_calls as unknown[]).length)
+      continue;
+    const toolCalls = msg.tool_calls as Array<Record<string, unknown>>;
+    const expectedIds = new Set<string>(toolCalls.map(tc => tc.id as string));
+    const intervening: Record<string, unknown>[] = [];
+    const toolMsgs: Record<string, unknown>[] = [];
+    const scanLimit = i + 1 + expectedIds.size * 2 + 3;
+    let j = i + 1;
+    for (; j < messages.length && j <= scanLimit; j++) {
+      const next = messages[j] as Record<string, unknown>;
+      if (next.role === "tool" && expectedIds.has(next.tool_call_id as string)) {
+        toolMsgs.push(next);
+        expectedIds.delete(next.tool_call_id as string);
+        if (expectedIds.size === 0) break;
+      } else {
+        intervening.push(next);
+      }
+    }
+    if (intervening.length > 0 && toolMsgs.length > 0 && expectedIds.size === 0) {
+      const count = intervening.length + toolMsgs.length;
+      messages.splice(i + 1, count, ...toolMsgs, ...intervening);
     }
   }
 }


### PR DESCRIPTION
## 问题

当 Claude Code 转发请求到 DeepSeek（或经 opengo 代理）时，如果用户在工具调用期间按 Esc / 继续操作，Claude Code 会在 assistant(tool_calls) 消息和对应的 tool 消息之间插入一条 role: user 消息（如 [Request interrupted by user]继续）。

DeepSeek 严格校验要求 tool_calls 后面必须紧跟对应的 tool 消息，导致报错：

An assistant message with tool_calls must be followed by tool messages responding to each tool_call_id. (insufficient tool messages following tool_calls message)

## 日志验证

分析了 router 本地日志，发现 100% 相关性：
- 所有失败的请求（13/13）：assistant(tool_calls) 后紧跟的是 user 消息而非 tool 消息
- 所有成功的请求（15/15）：assistant(tool_calls) 后紧跟的是 tool 消息

## 修复方案

在 patchOrphanToolResultsOA 中新增 Step 4 消息重排逻辑：

1. 扫描每个带 tool_calls 的 assistant 消息
2. 收集紧跟其后的非 tool 消息（intervening）和对应的 tool 消息
3. 如果所有预期的 tool 消息都找到了，将 intervening 消息挪到 tool 消息之后

重排示例：
[assistant(tool_calls=[A,B]), user(中断), tool(B), tool(A)]
→ [assistant(tool_calls=[A,B]), tool(B), tool(A), user(中断)]

## 安全措施

- scanLimit：限制扫描范围，避免扫描到消息列表末尾
- expectedIds.size === 0 守卫：只有所有预期 tool 消息都找到时才执行重排
- 不删除任何消息，仅调整顺序

## 与 PR #169 的关系

- PR #169 处理的是反向孤儿：tool_calls 存在但完全没有对应的 tool 消息（删除无匹配的 tool_calls）
- 本 PR 处理的是消息排序：tool 消息存在但位置不对（重排到正确位置）
- 两者互补，不冲突

## 额外改动

将 if (!removedAny) return; 改为 if (removedAny) { ... }，使 Step 4 无论 Step 2 是否移除了孤儿消息都能执行。