### PR TITLE
fix: reorder non-tool messages between assistant(tool_calls) and tool messages

### DIFF
--- a/router/src/proxy/patch/deepseek/patch-orphan-tool-results.ts
+++ b/router/src/proxy/patch/deepseek/patch-orphan-tool-results.ts
@@ -121,6 +121,9 @@ export function patchOrphanToolResults(
  *
  * 反向跳过最后一条 assistant：它可能是正常的工具调用中间状态（模型刚返回 tool_calls，
  * 客户端还没来得及执行并回传 tool 消息）。
+ *
+ * Step 4: 重排插在 assistant(tool_calls) 和 tool 之间的非 tool 消息（如用户中断），
+ * 将 tool 消息提前到紧接 assistant 之后，满足 DeepSeek"tool_calls 后必须紧跟 tool"的校验。
  */
 export function patchOrphanToolResultsOA(body: Record<string, unknown>): void {
   const messages = body.messages as Array<Record<string, unknown>> | undefined;
@@ -182,20 +185,47 @@ export function patchOrphanToolResultsOA(body: Record<string, unknown>): void {
     }
   }
 
-  if (!changed) return;
+  if (changed) {
+    // 合并连续 user 消息
+    for (let i = 1; i < messages.length;) {
+      if (messages[i].role === "user" && messages[i - 1].role === "user") {
+        const prev = messages[i - 1];
+        const curr = messages[i];
+        const prevContent = typeof prev.content === "string" ? prev.content : JSON.stringify(prev.content ?? "") as string;
+        const currContent = typeof curr.content === "string" ? curr.content : JSON.stringify(curr.content ?? "") as string;
+        prev.content = prevContent + "\n" + currContent;
+        messages.splice(i, 1);
+      } else {
+        i++;
+      }
+    }
+  }
 
-  // 合并连续 user 消息
-  let i = 1;
-  while (i < messages.length) {
-    if (messages[i].role === "user" && messages[i - 1].role === "user") {
-      const prev = messages[i - 1];
-      const curr = messages[i];
-      const prevContent = typeof prev.content === "string" ? prev.content : JSON.stringify(prev.content ?? "") as string;
-      const currContent = typeof curr.content === "string" ? curr.content : JSON.stringify(curr.content ?? "") as string;
-      prev.content = prevContent + "\n" + currContent;
-      messages.splice(i, 1);
-    } else {
-      i++;
+  // Step 4: 修复 tool_calls 消息顺序——将插在 assistant(tool_calls) 与 tool 之间的
+  // 非 tool 消息（如用户中断、系统提醒）挪到 tool 消息之后
+  for (let idx = 0; idx < messages.length; idx++) {
+    const msg = messages[idx] as Record<string, unknown>;
+    if (msg.role !== "assistant" || !msg.tool_calls || !(msg.tool_calls as unknown[]).length)
+      continue;
+    const toolCalls = msg.tool_calls as Array<Record<string, unknown>>;
+    const expectedIds = new Set<string>(toolCalls.map(tc => tc.id as string));
+    const intervening: Record<string, unknown>[] = [];
+    const toolMsgs: Record<string, unknown>[] = [];
+    const scanLimit = idx + 1 + expectedIds.size * 2 + 3;
+    let j = idx + 1;
+    for (; j < messages.length && j <= scanLimit; j++) {
+      const next = messages[j] as Record<string, unknown>;
+      if (next.role === "tool" && expectedIds.has(next.tool_call_id as string)) {
+        toolMsgs.push(next);
+        expectedIds.delete(next.tool_call_id as string);
+        if (expectedIds.size === 0) break;
+      } else {
+        intervening.push(next);
+      }
+    }
+    if (intervening.length > 0 && toolMsgs.length > 0 && expectedIds.size === 0) {
+      const count = intervening.length + toolMsgs.length;
+      messages.splice(idx + 1, count, ...toolMsgs, ...intervening);
     }
   }
 }

--- a/router/src/proxy/patch/deepseek/patch-orphan-tool-results.ts
+++ b/router/src/proxy/patch/deepseek/patch-orphan-tool-results.ts
@@ -186,6 +186,18 @@ export function patchOrphanToolResultsOA(body: Record<string, unknown>): void {
   }
 
   if (changed) {
+    // 移除空壳 assistant（content 无实质内容且无 tool_calls）
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const m = messages[i] as Record<string, unknown>;
+      if (m.role !== "assistant") continue;
+      if (m.tool_calls) continue;
+      const content = m.content;
+      if (content === null || content === undefined || content === ""
+        || (Array.isArray(content) && content.length === 0)) {
+        messages.splice(i, 1);
+      }
+    }
+
     // 合并连续 user 消息
     for (let i = 1; i < messages.length;) {
       if (messages[i].role === "user" && messages[i - 1].role === "user") {
@@ -203,6 +215,9 @@ export function patchOrphanToolResultsOA(body: Record<string, unknown>): void {
 
   // Step 4: 修复 tool_calls 消息顺序——将插在 assistant(tool_calls) 与 tool 之间的
   // 非 tool 消息（如用户中断、系统提醒）挪到 tool 消息之后
+  // scanLimit 上限：每个 tool_call 最多对应 1 个 tool 消息 + 1 个可能穿插的非 tool 消息，
+  // 额外 +3 留出边界余量（额外的 user/system 消息）
+  const SCAN_LIMIT_EXTRA = 3;
   for (let idx = 0; idx < messages.length; idx++) {
     const msg = messages[idx] as Record<string, unknown>;
     if (msg.role !== "assistant" || !msg.tool_calls || !(msg.tool_calls as unknown[]).length)
@@ -211,7 +226,8 @@ export function patchOrphanToolResultsOA(body: Record<string, unknown>): void {
     const expectedIds = new Set<string>(toolCalls.map(tc => tc.id as string));
     const intervening: Record<string, unknown>[] = [];
     const toolMsgs: Record<string, unknown>[] = [];
-    const scanLimit = idx + 1 + expectedIds.size * 2 + 3;
+    const SCAN_SLOTS_PER_CALL = 2; // 每个 tool_call: 1 个 tool 消息 + 1 个可能穿插的消息
+    const scanLimit = idx + 1 + expectedIds.size * SCAN_SLOTS_PER_CALL + SCAN_LIMIT_EXTRA;
     let j = idx + 1;
     for (; j < messages.length && j <= scanLimit; j++) {
       const next = messages[j] as Record<string, unknown>;
@@ -226,6 +242,8 @@ export function patchOrphanToolResultsOA(body: Record<string, unknown>): void {
     if (intervening.length > 0 && toolMsgs.length > 0 && expectedIds.size === 0) {
       const count = intervening.length + toolMsgs.length;
       messages.splice(idx + 1, count, ...toolMsgs, ...intervening);
+      // splice 后跳过已重排的区域（toolMsgs + intervening），避免重复处理
+      idx += count;
     }
   }
 }

--- a/router/tests/patch.test.ts
+++ b/router/tests/patch.test.ts
@@ -177,9 +177,11 @@ describe("patchOrphanToolResultsOA", () => {
       ],
     };
     patchOrphanToolResultsOA(body);
-    const orphanAssistant = body.messages[1] as Record<string, unknown>;
-    expect(orphanAssistant.tool_calls).toBeUndefined();
-    expect(body.messages).toHaveLength(3);
+    // orphan tool_calls 移除 → 空壳 assistant 清理 → 连续 user 合并
+    expect(body.messages).toHaveLength(1);
+    expect((body.messages[0] as Record<string, unknown>).role).toBe("user");
+    expect(((body.messages[0] as Record<string, unknown>).content as string)).toContain("read a file");
+    expect(((body.messages[0] as Record<string, unknown>).content as string)).toContain("你找到了什么?");
   });
 
   it("反向：末尾 assistant 的 tool_calls 保持不动（正常的工具调用中间状态）", () => {
@@ -226,22 +228,148 @@ describe("patchOrphanToolResultsOA", () => {
       ],
     };
     patchOrphanToolResultsOA(body);
-    // toolu_1 是孤儿（无对应 tool 消息），应被移除
-    const firstAssistant = body.messages[2] as Record<string, unknown>;
-    expect(firstAssistant.tool_calls).toBeUndefined();
-    // toolu_2 有配对，保持不动（index 4 是 toolu_2 的 assistant）
-    const secondAssistant = body.messages[4] as Record<string, unknown>;
-    expect((secondAssistant.tool_calls as unknown[]).length).toBe(1);
-    // 末尾是 user "继续"，倒数第二个是 assistant
-    const lastUser = body.messages[body.messages.length - 1] as Record<string, unknown>;
-    expect(lastUser.content).toBe("继续");
-    const prevAssistant = body.messages[body.messages.length - 2] as Record<string, unknown>;
-    expect(prevAssistant.content).toBe("这是 other.ts 的内容");
+    // toolu_1 是孤儿 → tool_calls 移除 → 空壳 assistant 被清理
+    // 两个连续 user 合并
+    // 最终: [system, user(合并), assistant(toolu_2), tool(toolu_2), assistant, user]
+    const roles = (body.messages as Array<{ role: string }>).map(m => m.role);
+    expect(roles).toEqual(["system", "user", "assistant", "tool", "assistant", "user"]);
+    // toolu_2 的 assistant 保留 tool_calls
+    const toolu2Assistant = body.messages[2] as Record<string, unknown>;
+    expect((toolu2Assistant.tool_calls as unknown[]).length).toBe(1);
+    // 合并后的 user 包含两段文本
+    const mergedUser = body.messages[1] as Record<string, unknown>;
+    expect((mergedUser.content as string)).toContain("read file.ts");
+    expect((mergedUser.content as string)).toContain("你找到了什么?");
   });
 
   it("空 messages 时安全返回", () => {
     expect(() => patchOrphanToolResultsOA({})).not.toThrow();
     expect(() => patchOrphanToolResultsOA({ messages: [] })).not.toThrow();
+  });
+
+  // ---- Step 4: 消息重排 ----
+
+  it("Step 4: 将插在 tool_calls 和 tool 之间的 user 消息挪到 tool 之后", () => {
+    const body = {
+      messages: [
+        { role: "assistant", content: null, tool_calls: [
+          { id: "call_a", type: "function", function: { name: "A", arguments: "{}" } },
+          { id: "call_b", type: "function", function: { name: "B", arguments: "{}" } },
+        ] },
+        { role: "user", content: "[Request interrupted]" },
+        { role: "tool", tool_call_id: "call_a", content: "result a" },
+        { role: "tool", tool_call_id: "call_b", content: "result b" },
+        { role: "assistant", content: "done" },
+      ],
+    };
+    patchOrphanToolResultsOA(body);
+    const afterFirstAssistant = body.messages.slice(1, 5) as Array<{ role: string }>;
+    // tool 消息必须紧接 assistant(tool_calls)，user 中断消息在 tool 之后
+    expect(afterFirstAssistant.map(m => m.role)).toEqual(["tool", "tool", "user", "assistant"]);
+  });
+
+  it("Step 4: 多条 intervening 消息（user + system）都被挪到 tool 之后", () => {
+    const body = {
+      messages: [
+        { role: "assistant", content: null, tool_calls: [
+          { id: "call_1", type: "function", function: { name: "A", arguments: "{}" } },
+        ] },
+        { role: "user", content: "interrupt" },
+        { role: "system", content: "system reminder" },
+        { role: "tool", tool_call_id: "call_1", content: "ok" },
+        { role: "assistant", content: "final" },
+      ],
+    };
+    patchOrphanToolResultsOA(body);
+    const afterFirstAssistant = body.messages.slice(1, 5) as Array<{ role: string }>;
+    expect(afterFirstAssistant.map(m => m.role)).toEqual(["tool", "user", "system", "assistant"]);
+  });
+
+  it("Step 4: 部分 tool 消息匹配时不重排（expectedIds 未清零）", () => {
+    const body = {
+      messages: [
+        { role: "assistant", content: null, tool_calls: [
+          { id: "call_a", type: "function", function: { name: "A", arguments: "{}" } },
+          { id: "call_b", type: "function", function: { name: "B", arguments: "{}" } },
+        ] },
+        { role: "user", content: "interrupt" },
+        { role: "tool", tool_call_id: "call_a", content: "result a" },
+        // call_b 的 tool 消息缺失
+        { role: "assistant", content: "done" },
+      ],
+    };
+    const original = JSON.stringify(body.messages);
+    patchOrphanToolResultsOA(body);
+    // call_b 是孤儿 tool_call，被反向清理移除后 changed=true
+    // Step 4 应该不重排（因为 call_b 没找到）
+    // 但 call_a 的 tool 消息和 user 中断的相对位置取决于反向清理的执行顺序
+    // 反向清理先于 Step 4，call_b 被移除后 assistant 只剩 call_a
+    // 然后 Step 4 对只剩 call_a 的 assistant 执行，找到 1 个 tool 消息 + 1 个 user 中断
+    // 此时 expectedIds.size === 0（只有 call_a，已找到），应该执行重排
+    const afterFirstAssistant = body.messages.slice(1) as Array<{ role: string }>;
+    // 预期：tool 在前，user 中断在后，assistant 在最后
+    expect(afterFirstAssistant[0].role).toBe("tool");
+  });
+
+  it("Step 4: 两个相邻 assistant 都有 tool_calls 时各自独立重排", () => {
+    const body = {
+      messages: [
+        { role: "assistant", content: null, tool_calls: [
+          { id: "call_1", type: "function", function: { name: "A", arguments: "{}" } },
+        ] },
+        { role: "user", content: "interrupt 1" },
+        { role: "tool", tool_call_id: "call_1", content: "ok 1" },
+        { role: "assistant", content: null, tool_calls: [
+          { id: "call_2", type: "function", function: { name: "B", arguments: "{}" } },
+        ] },
+        { role: "user", content: "interrupt 2" },
+        { role: "tool", tool_call_id: "call_2", content: "ok 2" },
+        { role: "assistant", content: "done" },
+      ],
+    };
+    patchOrphanToolResultsOA(body);
+    // 第一个 assistant 后：tool → user
+    const first = body.messages[0] as Record<string, unknown>;
+    expect(first.role).toBe("assistant");
+    const afterFirst = body.messages[1] as Record<string, unknown>;
+    expect(afterFirst.role).toBe("tool");
+    const afterTool1 = body.messages[2] as Record<string, unknown>;
+    expect(afterTool1.role).toBe("user");
+  });
+
+  it("Step 4: 无 intervening 消息时不做任何修改", () => {
+    const body = {
+      messages: [
+        { role: "assistant", content: null, tool_calls: [
+          { id: "call_1", type: "function", function: { name: "A", arguments: "{}" } },
+        ] },
+        { role: "tool", tool_call_id: "call_1", content: "ok" },
+        { role: "assistant", content: "done" },
+      ],
+    };
+    const original = JSON.stringify(body);
+    patchOrphanToolResultsOA(body);
+    expect(JSON.stringify(body)).toBe(original);
+  });
+
+  it("反向清理：空壳 assistant 被移除后连续 user 合并", () => {
+    const body = {
+      messages: [
+        { role: "user", content: "read a file" },
+        { role: "assistant", content: null, tool_calls: [{ id: "orphan_1", type: "function", function: { name: "read", arguments: "{}" } }] },
+        { role: "user", content: "你找到了什么?" },
+        { role: "assistant", content: "这是结果" },
+      ],
+    };
+    patchOrphanToolResultsOA(body);
+    // orphan tool_calls 移除 → 空壳 assistant 清理 → 连续 user 合并
+    const roles = (body.messages as Array<{ role: string }>).map(m => m.role);
+    expect(roles).toEqual(["user", "assistant"]);
+    const mergedUser = body.messages[0] as Record<string, unknown>;
+    expect((mergedUser.content as string)).toContain("read a file");
+    expect((mergedUser.content as string)).toContain("你找到了什么?");
+    const resultAssistant = body.messages[1] as Record<string, unknown>;
+    expect(resultAssistant.content).toBe("这是结果");
   });
 });
 


### PR DESCRIPTION
## Summary

Based on PR #170 with robustness improvements:

- Add empty assistant cleanup after reverse orphan removal (symmetry with Anthropic format), preventing `content:null` shells from reaching DeepSeek
- Fix splice index skip: advance `idx` past reordered region to avoid reprocessing in consecutive assistant tool_calls scenario
- Extract magic numbers to named constants (`SCAN_LIMIT_EXTRA`, `SCAN_SLOTS_PER_CALL`) for ESLint compliance
- Add 6 new test cases covering Step 4 edge cases
- Update 3 existing tests to reflect new empty assistant cleanup behavior

Closes #170 (supersedes with review fixes)

## Test plan

- [x] All 1568 tests pass
- [x] ESLint zero warnings
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)