### PR TITLE
fix(proxy): stream timeout error SSE writes before pipe destruction

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,12 @@
 {
   "name": "llm-simple-router-workspace",
+  "version": "0.11.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "llm-simple-router-workspace",
+      "version": "0.11.29",
       "workspaces": [
         "router",
         "pi-extension",
@@ -1003,6 +1005,7 @@
       "resolved": "https://registry.npmmirror.com/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1559,6 +1562,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -1582,6 +1586,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -3355,6 +3360,7 @@
       "resolved": "https://registry.npmmirror.com/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
       "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -3436,6 +3442,7 @@
       "resolved": "https://registry.npmmirror.com/@noble/ciphers/-/ciphers-1.3.0.tgz",
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -5219,6 +5226,7 @@
       "integrity": "sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.1",
         "@typescript-eslint/types": "8.59.1",
@@ -5617,6 +5625,7 @@
       "resolved": "https://registry.npmmirror.com/@vue/compiler-dom/-/compiler-dom-3.5.33.tgz",
       "integrity": "sha512-PXq0yrfCLzzL07rbXO4awtXY1Z06LG2eu6Adg3RJFa/j3Cii217XxxLXG22N330gw7GmALCY0Z8RgXEviwgpjA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-core": "3.5.33",
         "@vue/shared": "3.5.33"
@@ -5740,6 +5749,7 @@
       "resolved": "https://registry.npmmirror.com/@vue/server-renderer/-/server-renderer-3.5.33.tgz",
       "integrity": "sha512-0xylq/8/h44lVG0pZFknv1XIdEgymq2E9n59uTWJBG+dIgiT0TMCSsxrN7nO16Z0MU0MPjFcguBbZV8Itk52Hw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-ssr": "3.5.33",
         "@vue/shared": "3.5.33"
@@ -5879,6 +5889,7 @@
       "resolved": "https://registry.npmmirror.com/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6384,6 +6395,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -6592,6 +6604,7 @@
       "resolved": "https://registry.npmmirror.com/chart.js/-/chart.js-4.5.1.tgz",
       "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@kurkle/color": "^0.3.0"
       },
@@ -7730,6 +7743,7 @@
       "resolved": "https://registry.npmmirror.com/eslint/-/eslint-10.3.0.tgz",
       "integrity": "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -9102,6 +9116,7 @@
       "resolved": "https://registry.npmmirror.com/hono/-/hono-4.12.16.tgz",
       "integrity": "sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -9546,6 +9561,7 @@
       "resolved": "https://registry.npmmirror.com/jiti/-/jiti-2.6.1.tgz",
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -9780,6 +9796,7 @@
       "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@asamuzakjp/css-color": "^5.1.11",
         "@asamuzakjp/dom-selector": "^7.1.1",
@@ -9846,6 +9863,7 @@
       "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mdn-data": "2.27.1",
         "source-map-js": "^1.2.1"
@@ -10166,6 +10184,7 @@
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "dev": true,
       "license": "MPL-2.0",
+      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.3"
       },
@@ -11600,6 +11619,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -13369,6 +13389,7 @@
       "resolved": "https://registry.npmmirror.com/stylus/-/stylus-0.57.0.tgz",
       "integrity": "sha512-yOI6G8WYfr0q8v8rRvE91wbxFU+rJPo760Va4MF6K0I6BZjO4r+xSynkvyPBP9tV1CIEUeRsiidjIs2rzb1CnQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "css": "^3.0.0",
         "debug": "^4.3.2",
@@ -13668,6 +13689,7 @@
       "resolved": "https://registry.npmmirror.com/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -14075,6 +14097,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -14096,6 +14119,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14112,6 +14136,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14128,6 +14153,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14144,6 +14170,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14160,6 +14187,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14176,6 +14204,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14192,6 +14221,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14208,6 +14238,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14224,6 +14255,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14240,6 +14272,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14256,6 +14289,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14272,6 +14306,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14288,6 +14323,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14304,6 +14340,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14320,6 +14357,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14336,6 +14374,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14352,6 +14391,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14368,6 +14408,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14384,6 +14425,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14400,6 +14442,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14416,6 +14459,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14432,6 +14476,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14448,6 +14493,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14464,6 +14510,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14480,6 +14527,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14496,6 +14544,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14610,6 +14659,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -14807,6 +14857,7 @@
       "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -16082,6 +16133,7 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -16163,6 +16215,7 @@
       "resolved": "https://registry.npmmirror.com/vue/-/vue-3.5.33.tgz",
       "integrity": "sha512-1AgChhx5w3ALgT4oK3acm2Es/7jyZhWSVUfs3rOBlGQC0rjEDkS7G4lWlJJGGNQD+BV3reCwbQrOe1mPNwKHBQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.33",
         "@vue/compiler-sfc": "3.5.33",
@@ -16700,6 +16753,7 @@
       "integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
       "devOptional": true,
       "license": "ISC",
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -16849,6 +16903,7 @@
       "resolved": "https://registry.npmmirror.com/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -15,5 +15,6 @@
   },
   "devDependencies": {
     "eslint-plugin-vue": "^10.9.1"
-  }
+  },
+  "version": "0.11.29"
 }

--- a/router/src/proxy/handler/failover-loop.ts
+++ b/router/src/proxy/handler/failover-loop.ts
@@ -430,17 +430,6 @@ export async function processResilienceResult(params: {
     // flush tool errors
     flushCurrentErrors();
 
-    // Stream timeout
-    if (resilienceResult.result.kind === "stream_abort" && resilienceResult.result.timeoutContext) {
-      const { modelId, providerId } = resilienceResult.result.timeoutContext;
-      const msg = `Stream timeout: no data received for ${resilienceResult.result.timeoutMs}ms (model: ${modelId}, provider: ${providerId})`;
-      const errBody = clientApiType === "anthropic"
-        ? { type: "error", error: { type: "api_error", message: msg } }
-        : { error: { message: msg, type: "server_error", code: "stream_timeout" } };
-      try { reply.raw.write(`data: ${JSON.stringify(errBody)}\n\n`); } catch (e: unknown) { /* client disconnected */ void e; }
-      try { reply.raw.end(); } catch (e: unknown) { /* client disconnected */ void e; }
-    }
-
     const tr = resilienceResult.result;
     const succeeded = tr.kind === "success" || tr.kind === "stream_success" || tr.kind === "stream_abort";
     if (succeeded) usageWindowTracker?.recordRequest(provider.id, routerKeyId ?? undefined);

--- a/router/src/proxy/transport/stream.ts
+++ b/router/src/proxy/transport/stream.ts
@@ -53,7 +53,7 @@ class StreamProxy {
     private readonly loopGuard: StreamLoopGuard | undefined,
     formatTransform?: Transform,
     private readonly timeoutContext?: { modelId: string; providerId: string },
-    private readonly onTimeoutAbort?: () => void,
+    private readonly onTimeoutAbort?: (timeoutMs: number) => void,
   ) {
     this.formatTransform = formatTransform;
     this.sseHeaders = filterHeaders(rawUpstreamHeaders);
@@ -114,9 +114,9 @@ class StreamProxy {
         this.pendingResult = result;
       }
     } else {
-      // stream_abort 且 headers 已发送时，必须 end reply 避免客户端挂起
-      // 但如果有 timeoutContext，让 handler 层负责写入错误 SSE 后再 end
-      if (kind === "stream_abort" && this.headersSent && !extra.timeoutContext) {
+      // stream_abort（非 deferred）且 headers 已发送时，立即 end reply 避免客户端挂起
+      // idle_timeout 使用 deferred 模式，由 resetIdleTimer 的 setImmediate 负责 end reply
+      if (kind === "stream_abort" && this.headersSent) {
         // eslint-disable-next-line taste/no-silent-catch -- reply may already be destroyed, warn is sufficient
         try { this.reply.raw.end(); } catch { console.warn("[stream-proxy] reply.raw.end() failed, likely already destroyed"); }
       }
@@ -151,12 +151,19 @@ class StreamProxy {
     if (!isFinite(this.timeoutMs) || this.timeoutMs <= 0) return; // 0 或 Infinity 表示禁用超时
     this.idleTimer = setTimeout(() => {
       if (this.resolved) return;
-      // 在 terminal() 调用 reply.raw.end() 之前，同步写入超时错误 SSE
-      // 必须同步执行，确保 inject() 能正确收集响应体
+      // 在 terminal() 之前同步写入超时错误 SSE，确保 inject() 能正确收集响应体
       if (this.onTimeoutAbort) {
-        try { this.onTimeoutAbort(); } catch { /* reply may be destroyed */ } // eslint-disable-line taste/no-silent-catch
+        try { this.onTimeoutAbort(this.timeoutMs); } catch { /* reply may be destroyed */ } // eslint-disable-line taste/no-silent-catch
       }
-      this.terminal("stream_abort", { metrics: this.collectMetrics(false), timeoutContext: this.timeoutContext, timeoutMs: this.timeoutMs, abortReason: "idle_timeout" as const });
+      // deferred 模式：先 resolve 让 handler 链路（日志写入等）在 microtask 中完成，
+      // reply.raw.end() 延迟到 setImmediate（macrotask），保证 inject() 返回时日志已写入。
+      this.terminal("stream_abort", { metrics: this.collectMetrics(false), timeoutContext: this.timeoutContext, timeoutMs: this.timeoutMs, abortReason: "idle_timeout" as const }, true);
+      setImmediate(() => {
+        if (this.headersSent) {
+          try { this.reply.raw.end(); } catch { /* reply may be destroyed */ } // eslint-disable-line taste/no-silent-catch
+        }
+        this.cleanup();
+      });
     }, this.timeoutMs);
   }
 
@@ -386,7 +393,7 @@ export function callStream(
   loopGuard?: StreamLoopGuard,
   formatTransform?: import("stream").Transform,
   timeoutContext?: { modelId: string; providerId: string },
-  onTimeoutAbort?: () => void,
+  onTimeoutAbort?: (timeoutMs: number) => void,
   agent?: Agent,
 ): Promise<TransportResult> {
   return new Promise((resolve) => {

--- a/router/src/proxy/transport/transport-fn.ts
+++ b/router/src/proxy/transport/transport-fn.ts
@@ -107,10 +107,23 @@ export function buildTransportFn(p: TransportFnParams): (target: Target) => Prom
         });
       }
       const checkEarlyError = p.matcher ? (data: string) => p.matcher!.test(UPSTREAM_SUCCESS, data, p.provider.id) : undefined;
+      // 在 pipe 销毁前同步写入超时错误 SSE，避免 handler 层异步写入时与残留 chunk 拼接
+      const onTimeoutAbort = p.timeoutContext
+        ? (actualTimeoutMs: number) => {
+          const { modelId, providerId } = p.timeoutContext!;
+          const msg = `Stream timeout: no data received for ${actualTimeoutMs}ms (model: ${modelId}, provider: ${providerId})`;
+          const errBody = p.apiType === "anthropic"
+            ? { type: "error", error: { type: "api_error", message: msg } }
+            : { error: { message: msg, type: "server_error", code: "stream_timeout" } };
+          try {
+            p.reply.raw.write(`data: ${JSON.stringify(errBody)}\n\n`);
+          } catch { /* reply may be destroyed */ } // eslint-disable-line taste/no-silent-catch
+        }
+        : undefined;
       const streamResult = await callStream(
         p.provider, p.apiKey, p.body, p.cliHdrs, p.reply, p.streamTimeoutMs,
         p.upstreamPath, buildHeaders, metricsTransform, checkEarlyError, undefined, streamLoopGuard, p.formatTransform,
-        p.timeoutContext, undefined, agent,
+        p.timeoutContext, onTimeoutAbort, agent,
       );
       const m = (streamResult.kind === "stream_success" || streamResult.kind === "stream_abort")
         ? streamResult.metrics : undefined;


### PR DESCRIPTION
## Problem

Stream timeout error SSE was constructed and written in the handler layer (`failover-loop.ts`) after the pipe was already destroyed by `StreamProxy.terminal()`. This caused the error SSE to be concatenated with residual upstream chunks, producing invalid JSON that clients could not parse:

```
{"id":"6bdaeafc-1465-data: {"error":{"message":"Stream timeout: no data received for 30000ms..."}}
```

## Solution

Move timeout error SSE construction and writing into the transport layer via the existing `onTimeoutAbort` callback mechanism:

1. **`onTimeoutAbort` receives `timeoutMs` parameter** — uses actual timeout value instead of hardcoded config value
2. **`transport-fn.ts` constructs the callback** — API-type-aware error format (OpenAI/Anthropic), writes error SSE before pipe destruction
3. **`resetIdleTimer` uses deferred mode** — same pattern as `onEnd()` for `stream_success`, ensuring DB logs are written before `inject()` resolves
4. **Remove timeout SSE block from `failover-loop.ts`** — handler layer no longer responsible for transport-level error formatting

## Test Results

- 1743 tests passed (including `stream-timeout.test.ts` and `diagnostic-fields.test.ts` idle_timeout cases)
- ESLint zero errors/warnings (including 10 taste custom rules)
- Build passes