### PR TITLE
feat(frontend): disable password-manager for admin api-key fields

### DIFF
--- a/frontend/src/components/providers/EndpointEditor.vue
+++ b/frontend/src/components/providers/EndpointEditor.vue
@@ -167,6 +167,7 @@ function updateField<K extends keyof ProviderEndpoint>(
           <Input
             :model-value="ep.api_key ?? ''"
             type="password"
+            autocomplete="new-password"
             :disabled="readonly"
             :placeholder="
               sharedKey

--- a/frontend/src/components/providers/ModelCapabilitiesEditor.vue
+++ b/frontend/src/components/providers/ModelCapabilitiesEditor.vue
@@ -201,6 +201,7 @@ function isOfficialOpenai(url: string): boolean {
         <Input
           :model-value="props.modelValue.apiKey"
           type="password"
+          autocomplete="new-password"
           :required="!props.editingId"
           :placeholder="
             props.editingId ? t('providers.fields.apiKeyPlaceholder') : ''

--- a/frontend/src/components/shared/ProxyConfigForm.vue
+++ b/frontend/src/components/shared/ProxyConfigForm.vue
@@ -114,6 +114,7 @@ function onTypeChange(val: unknown) {
         <Input
           :model-value="proxyPassword"
           type="password"
+          autocomplete="new-password"
           class="mt-1"
           :placeholder="t('providers.fields.proxyAuthOptional')"
           @update:model-value="patch({ proxyPassword: $event as string })"

--- a/frontend/src/views/QuickSetup.vue
+++ b/frontend/src/views/QuickSetup.vue
@@ -159,6 +159,7 @@
             <Input
               v-model="sharedKey"
               type="password"
+              autocomplete="new-password"
               :placeholder="t('quickSetup.provider.apiKeyPlaceholder')"
               class="md:text-xs h-7"
             />


### PR DESCRIPTION
## 变更内容

在 Provider 编辑弹窗和 ProxyConfigForm 中添加 `autocomplete` 属性，阻止浏览器密码管理器误弹。

**问题：** 浏览器启发式密码管理器（Chrome/Edge/Firefox）检测到任何包含 `type=password` 且前有 `type=text` 字段的 `<form>` 时，会提示用户保存凭据。Provider 编辑弹窗中 Name (text) + ApiKey (password) 的组合触发此行为。

**修复：**
- Name / proxyUsername (text)：`autocomplete=off`
- ApiKey / proxyPassword (password)：`autocomplete=new-password`

**涉及文件：**
- `EndpointEditor.vue` — api_key 输入框
- `ModelCapabilitiesEditor.vue` — name + apiKey 输入框
- `ProxyConfigForm.vue` — proxyUsername + proxyPassword
- `QuickSetup.vue` — sharedKey 输入框

> 注意：Login/Setup 页面保持不变，它们是真实的认证表单。