### PR TITLE
fix(providers): 修复自定义模板保存按钮无响应问题

### DIFF
--- a/frontend/src/composables/__tests__/useProviderForm.test.ts
+++ b/frontend/src/composables/__tests__/useProviderForm.test.ts
@@ -1,0 +1,255 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { ref } from "vue";
+
+// ---------- Mock dependencies ----------
+
+vi.mock("vue-i18n", () => ({
+  useI18n: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock("@/composables/useTransformRules", () => ({
+  useTransformRules: () => ({
+    transformConfig: ref({ rules: [] }),
+    loadTransformRules: vi.fn(),
+    saveTransformRules: vi.fn(),
+  }),
+}));
+
+vi.mock("@/composables/useProviderPresets", () => ({
+  useProviderPresets: () => ({
+    providerPresets: ref([]),
+    presetGroup: ref(""),
+    presetPlan: ref(""),
+    availablePlans: ref([]),
+    onGroupChange: vi.fn(),
+    onPresetChange: vi.fn(),
+    getCurrentModelsEndpoint: vi.fn(() => undefined),
+    getCurrentPresetModels: vi.fn(() => []),
+    loadPresets: vi.fn(),
+    resetPreset: vi.fn(),
+  }),
+}));
+
+import { useProviderForm } from "@/composables/useProviderForm";
+
+describe("useProviderForm - validate()", () => {
+  let form: ReturnType<typeof useProviderForm>;
+
+  beforeEach(() => {
+    form = useProviderForm();
+    // Default valid state (preset mode)
+    form.form.value.name = "test-provider";
+    form.form.value.base_url = "https://api.test.com/v1";
+    form.form.value.api_key = "sk-test123";
+    form.form.value.endpoints = [];
+    form.form.value.models = [];
+    form.editingId.value = null;
+    // Reset errors
+    form.errors.value = {};
+  });
+
+  it("should pass validation with valid preset-mode data", () => {
+    expect(form.validate()).toBe(true);
+    expect(form.errors.value).toEqual({});
+  });
+
+  it("should pass validation with valid custom-mode data (endpoints)", () => {
+    form.form.value.base_url = "";
+    form.form.value.endpoints = [
+      {
+        api_type: "openai",
+        base_url: "https://api.custom.com/v1",
+        upstream_path: null,
+        api_key: null,
+      },
+    ];
+    expect(form.validate()).toBe(true);
+    expect(form.errors.value).toEqual({});
+  });
+
+  it("should fail when name is empty", () => {
+    form.form.value.name = "";
+    expect(form.validate()).toBe(false);
+    expect(form.errors.value.name).toBe("providers.validation.nameRequired");
+  });
+
+  it("should fail when name has invalid characters", () => {
+    form.form.value.name = "test provider!";
+    expect(form.validate()).toBe(false);
+    expect(form.errors.value.name).toBe("providers.validation.namePattern");
+  });
+
+  it("should fail when no endpoints and base_url is empty", () => {
+    form.form.value.base_url = "";
+    expect(form.validate()).toBe(false);
+    expect(form.errors.value.base_url).toBe(
+      "providers.validation.baseUrlRequired",
+    );
+  });
+
+  it("should fail when no endpoints and base_url is invalid", () => {
+    form.form.value.base_url = "not-a-url";
+    expect(form.validate()).toBe(false);
+    expect(form.errors.value.base_url).toBe(
+      "providers.validation.baseUrlInvalid",
+    );
+  });
+
+  it("should pass when endpoints exist and base_url is empty", () => {
+    form.form.value.base_url = "";
+    form.form.value.endpoints = [
+      {
+        api_type: "openai",
+        base_url: "https://api.custom.com/v1",
+        upstream_path: null,
+        api_key: null,
+      },
+    ];
+    expect(form.validate()).toBe(true);
+  });
+
+  it("should fail when endpoint has empty base_url", () => {
+    form.form.value.base_url = "";
+    form.form.value.endpoints = [
+      {
+        api_type: "openai",
+        base_url: "",
+        upstream_path: null,
+        api_key: null,
+      },
+    ];
+    expect(form.validate()).toBe(false);
+    expect(form.errors.value["endpoint_0_base_url"]).toBe(
+      "providers.validation.baseUrlRequired",
+    );
+  });
+
+  it("should fail when endpoints have duplicate api_types", () => {
+    form.form.value.base_url = "";
+    form.form.value.endpoints = [
+      {
+        api_type: "openai",
+        base_url: "https://api.test.com/v1",
+        upstream_path: null,
+        api_key: null,
+      },
+      {
+        api_type: "openai",
+        base_url: "https://api.test.com/v2",
+        upstream_path: null,
+        api_key: null,
+      },
+    ];
+    expect(form.validate()).toBe(false);
+    expect(form.errors.value.endpoints).toBe(
+      "providers.validation.duplicateApiType",
+    );
+  });
+
+  it("should fail when api_key is missing in create mode", () => {
+    form.form.value.api_key = "";
+    expect(form.validate()).toBe(false);
+    expect(form.errors.value.api_key).toBe(
+      "providers.validation.apiKeyRequired",
+    );
+  });
+
+  it("should skip api_key check in edit mode", () => {
+    form.editingId.value = "provider-123";
+    form.form.value.api_key = "";
+    expect(form.validate()).toBe(true);
+    expect(form.errors.value.api_key).toBeUndefined();
+  });
+
+  it("should pass when both endpoints and top-level base_url exist", () => {
+    form.form.value.base_url = "https://api.top.com/v1";
+    form.form.value.endpoints = [
+      {
+        api_type: "openai",
+        base_url: "https://api.endpoint.com/v1",
+        upstream_path: null,
+        api_key: null,
+      },
+    ];
+    expect(form.validate()).toBe(true);
+  });
+
+  it("should fail when concurrency is out of range", () => {
+    form.form.value.max_concurrency = 0;
+    expect(form.validate()).toBe(false);
+    expect(form.errors.value.max_concurrency).toBe(
+      "providers.validation.concurrencyRange",
+    );
+  });
+});
+
+describe("useProviderForm - buildPayload()", () => {
+  let form: ReturnType<typeof useProviderForm>;
+
+  beforeEach(() => {
+    form = useProviderForm();
+    form.form.value.name = "test-provider";
+    form.form.value.base_url = "";
+    form.form.value.api_key = "sk-test123";
+    form.form.value.endpoints = [];
+    form.form.value.models = [];
+  });
+
+  it("should use endpoints[0].base_url when base_url is empty and endpoints exist", () => {
+    form.form.value.endpoints = [
+      {
+        api_type: "openai",
+        base_url: "https://api.custom.com/v1",
+        upstream_path: null,
+        api_key: null,
+      },
+    ];
+    const payload = form.buildPayload();
+    expect(payload.base_url).toBe("https://api.custom.com/v1");
+  });
+
+  it("should keep original base_url when it is non-empty", () => {
+    form.form.value.base_url = "https://api.original.com/v1";
+    form.form.value.endpoints = [
+      {
+        api_type: "openai",
+        base_url: "https://api.custom.com/v1",
+        upstream_path: null,
+        api_key: null,
+      },
+    ];
+    const payload = form.buildPayload();
+    expect(payload.base_url).toBe("https://api.original.com/v1");
+  });
+
+  it("should use base_url as-is when no endpoints exist", () => {
+    form.form.value.base_url = "https://api.standalone.com/v1";
+    const payload = form.buildPayload();
+    expect(payload.base_url).toBe("https://api.standalone.com/v1");
+  });
+
+  it("should serialize endpoints correctly", () => {
+    form.form.value.endpoints = [
+      {
+        api_type: "openai",
+        base_url: "https://api.openai.com/v1",
+        upstream_path: null,
+        api_key: null,
+      },
+      {
+        api_type: "anthropic",
+        base_url: "https://api.anthropic.com/v1",
+        upstream_path: "/custom",
+        api_key: "sk-ant-test",
+      },
+    ];
+    const payload = form.buildPayload();
+    expect(payload.endpoints).toHaveLength(2);
+    expect(payload.endpoints![0].api_type).toBe("openai");
+    expect(payload.endpoints![0].base_url).toBe("https://api.openai.com/v1");
+    expect(payload.endpoints![1].api_type).toBe("anthropic");
+    expect(payload.endpoints![1].upstream_path).toBe("/custom");
+  });
+});

--- a/frontend/src/composables/useProviderForm.ts
+++ b/frontend/src/composables/useProviderForm.ts
@@ -1,6 +1,5 @@
 import { ref, computed } from "vue";
 import { useI18n } from "vue-i18n";
-import * as z from "zod";
 import type { ProviderPayload } from "@/api/client";
 import type { Provider, ModelInfo, ProviderEndpoint } from "@/types/mapping";
 import { DEFAULT_CONTEXT_WINDOW, DEFAULT_STREAM_TIMEOUT_MS } from "@/constants";
@@ -117,31 +116,34 @@ export function useProviderForm() {
   const presetHook = useProviderPresets(form);
 
   function validate(): boolean {
-    const schema = z.object({
-      name: z
-        .string()
-        .min(1, t("providers.validation.nameRequired"))
-        .regex(/^[a-zA-Z0-9_-]+$/, t("providers.validation.namePattern")),
-      base_url: z
-        .string()
-        .min(1, t("providers.validation.baseUrlRequired"))
-        .url(t("providers.validation.baseUrlInvalid")),
-    });
     const errs: Record<string, string> = {};
-    const result = schema.safeParse({
-      name: form.value.name.trim(),
-      base_url: form.value.base_url.trim(),
-    });
-    if (!result.success) {
-      for (const issue of result.error.issues) {
-        const field = issue.path[0] as string;
-        if (!errs[field]) errs[field] = issue.message;
+
+    // Name validation (always required)
+    if (!form.value.name.trim()) {
+      errs.name = t("providers.validation.nameRequired");
+    } else if (!/^[a-zA-Z0-9_-]+$/.test(form.value.name.trim())) {
+      errs.name = t("providers.validation.namePattern");
+    }
+
+    // Base URL or endpoints: 当有 endpoints 时通过 endpoint level 校验，否则校验顶层 base_url
+    const hasEndpoints = form.value.endpoints.length > 0;
+    if (!hasEndpoints) {
+      if (!form.value.base_url.trim()) {
+        errs.base_url = t("providers.validation.baseUrlRequired");
+      } else {
+        try {
+          new URL(form.value.base_url.trim());
+        } catch {
+          errs.base_url = t("providers.validation.baseUrlInvalid");
+        }
       }
     }
+
     if (!editingId.value && !form.value.api_key.trim())
       errs.api_key = t("providers.validation.apiKeyRequired");
+
     // endpoints 校验
-    if (form.value.endpoints.length > 0) {
+    if (hasEndpoints) {
       const eps = form.value.endpoints;
       for (let i = 0; i < eps.length; i++) {
         if (!eps[i].base_url.trim()) {
@@ -179,7 +181,10 @@ export function useProviderForm() {
     const payload: ProviderFormPayload = {
       name: form.value.name,
       api_type: form.value.api_type,
-      base_url: form.value.base_url,
+      base_url:
+        form.value.endpoints.length > 0 && !form.value.base_url
+          ? form.value.endpoints[0].base_url
+          : form.value.base_url,
       upstream_path: form.value.upstream_path || undefined,
       endpoints:
         form.value.endpoints.length > 0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1005,6 +1005,7 @@
       "resolved": "https://registry.npmmirror.com/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1561,6 +1562,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -1584,6 +1586,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -3357,6 +3360,7 @@
       "resolved": "https://registry.npmmirror.com/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
       "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -3438,6 +3442,7 @@
       "resolved": "https://registry.npmmirror.com/@noble/ciphers/-/ciphers-1.3.0.tgz",
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -5221,6 +5226,7 @@
       "integrity": "sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.1",
         "@typescript-eslint/types": "8.59.1",
@@ -5619,6 +5625,7 @@
       "resolved": "https://registry.npmmirror.com/@vue/compiler-dom/-/compiler-dom-3.5.33.tgz",
       "integrity": "sha512-PXq0yrfCLzzL07rbXO4awtXY1Z06LG2eu6Adg3RJFa/j3Cii217XxxLXG22N330gw7GmALCY0Z8RgXEviwgpjA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-core": "3.5.33",
         "@vue/shared": "3.5.33"
@@ -5742,6 +5749,7 @@
       "resolved": "https://registry.npmmirror.com/@vue/server-renderer/-/server-renderer-3.5.33.tgz",
       "integrity": "sha512-0xylq/8/h44lVG0pZFknv1XIdEgymq2E9n59uTWJBG+dIgiT0TMCSsxrN7nO16Z0MU0MPjFcguBbZV8Itk52Hw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-ssr": "3.5.33",
         "@vue/shared": "3.5.33"
@@ -5881,6 +5889,7 @@
       "resolved": "https://registry.npmmirror.com/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6386,6 +6395,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -6594,6 +6604,7 @@
       "resolved": "https://registry.npmmirror.com/chart.js/-/chart.js-4.5.1.tgz",
       "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@kurkle/color": "^0.3.0"
       },
@@ -7732,6 +7743,7 @@
       "resolved": "https://registry.npmmirror.com/eslint/-/eslint-10.3.0.tgz",
       "integrity": "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -9104,6 +9116,7 @@
       "resolved": "https://registry.npmmirror.com/hono/-/hono-4.12.16.tgz",
       "integrity": "sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -9548,6 +9561,7 @@
       "resolved": "https://registry.npmmirror.com/jiti/-/jiti-2.6.1.tgz",
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -9782,6 +9796,7 @@
       "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@asamuzakjp/css-color": "^5.1.11",
         "@asamuzakjp/dom-selector": "^7.1.1",
@@ -9848,6 +9863,7 @@
       "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mdn-data": "2.27.1",
         "source-map-js": "^1.2.1"
@@ -10168,6 +10184,7 @@
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "dev": true,
       "license": "MPL-2.0",
+      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.3"
       },
@@ -11602,6 +11619,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -13371,6 +13389,7 @@
       "resolved": "https://registry.npmmirror.com/stylus/-/stylus-0.57.0.tgz",
       "integrity": "sha512-yOI6G8WYfr0q8v8rRvE91wbxFU+rJPo760Va4MF6K0I6BZjO4r+xSynkvyPBP9tV1CIEUeRsiidjIs2rzb1CnQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "css": "^3.0.0",
         "debug": "^4.3.2",
@@ -13670,6 +13689,7 @@
       "resolved": "https://registry.npmmirror.com/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -14077,6 +14097,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -14098,6 +14119,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14114,6 +14136,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14130,6 +14153,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14146,6 +14170,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14162,6 +14187,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14178,6 +14204,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14194,6 +14221,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14210,6 +14238,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14226,6 +14255,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14242,6 +14272,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14258,6 +14289,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14274,6 +14306,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14290,6 +14323,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14306,6 +14340,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14322,6 +14357,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14338,6 +14374,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14354,6 +14391,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14370,6 +14408,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14386,6 +14425,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14402,6 +14442,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14418,6 +14459,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14434,6 +14476,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14450,6 +14493,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14466,6 +14510,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14482,6 +14527,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14498,6 +14544,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14612,6 +14659,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -14809,6 +14857,7 @@
       "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -16084,6 +16133,7 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -16165,6 +16215,7 @@
       "resolved": "https://registry.npmmirror.com/vue/-/vue-3.5.33.tgz",
       "integrity": "sha512-1AgChhx5w3ALgT4oK3acm2Es/7jyZhWSVUfs3rOBlGQC0rjEDkS7G4lWlJJGGNQD+BV3reCwbQrOe1mPNwKHBQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.33",
         "@vue/compiler-sfc": "3.5.33",
@@ -16702,6 +16753,7 @@
       "integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
       "devOptional": true,
       "license": "ISC",
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -16851,6 +16903,7 @@
       "resolved": "https://registry.npmmirror.com/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -16,5 +16,5 @@
   "devDependencies": {
     "eslint-plugin-vue": "^10.9.1"
   },
-  "version": "1.0.2"
+  "version": "1.0.3"
 }


### PR DESCRIPTION
## 问题

选择「自定义」模板添加 Provider 时，填好所有端点后点击保存按钮无反应。

## 根因

PR #177 (multi-api-type 支持) 移除了表单中的顶层 `base_url` 输入框，用户通过 EndpointEditor 填写端点级别的 Base URL。但 `validate()` 函数未同步更新，仍强制要求 `form.value.base_url` 非空。自定义模式下该值为 `""`，导致验证失败、`handleSave()` 静默 return。

## 修复

`frontend/src/composables/useProviderForm.ts`

1. **`validate()`**：当 `endpoints.length > 0` 时跳过顶层 base_url 校验，由各 endpoint 自行校验其 base_url；无 endpoints 时保留原逻辑
2. **`buildPayload()`**：endpoints 存在且 base_url 为空时，自动取 `endpoints[0].base_url` 填入顶层字段，避免后端 Typebox schema（`minLength: 1`）拒绝请求
3. 移除不再使用的 `import * as z from "zod"`

## 验证

- ✅ `npm test`: 142/142 files, 1763 tests passed
- ✅ `npm run build`: Router + Frontend 编译成功
- ✅ Prettier / ESLint / vue-tsc 全部通过

## 相关

- 原始 PR #177 移除了顶层 base_url 字段，但未同步更新 validate()
- 后端 `CreateProviderSchema` 中 `base_url` 已是 `Optional`，兼容本次修复