### PR TITLE
fix: 修复 import/export 中 endpoints 和 proxy_password 敏感字段未加解密的问题

### DIFF
--- a/.pi/skills/merge/SKILL.md
+++ b/.pi/skills/merge/SKILL.md
@@ -15,11 +15,70 @@ description: >-
 
 ## 发布机制
 
-- **构建产物**：`npm run build`（router + frontend）
-- **发布方式**：GitHub Actions（`publish.yml`），tag `v*` 触发
-- **交付物**：npm registry（`llm-simple-router`）+ Docker image + GitHub Release
-- **版本管理**：workspace root `1.0.0`，子包独立版本（router `1.0.1`）
+- **构建产物**：`npm run build`（router + frontend，pi-extension 不构建）
+- **发布方式**：GitHub Actions（`publish.yml`）
+  - **stable 路径**：`workflow_dispatch` 触发（`gh workflow run publish.yml --ref main -f bump_type=patch|minor|major`），由 `scripts/publish.sh` 发起
+  - **beta 路径**（由 `.pi/skills/beta-publish/` 覆盖）：`push: branches: ['beta-*']` 触发，详见末尾"Beta 发布"小节
+- **交付物**（stable 路径）：npm registry（`llm-simple-router` tag=`latest`）+ Docker image（ghcr.io）+ GitHub Release + dist archive asset
+- **版本管理**：workspace root `1.0.3`；子包独立版本（router `1.0.4` / pi-extension `0.1.0` / frontend `0.0.0`）
 - **禁止本地发布**：必须走 GitHub Actions
+
+## 调用方式
+
+### ✅ 优先：workflow tool
+
+本 skill 已注册为 workflow 脚本（`.pi/workflows/merge-worktree.js`），**AI 必须优先调用** `workflow_run` 工具来驱动整个流程：
+
+```javascript
+// 最常用形态（仅传 worktree，其他走默认）
+workflow_run({
+  name: 'merge-worktree',
+  args: { worktreeDir: 'feat-import-export-config' }
+})
+
+// 完整形态
+workflow_run({
+  name: 'merge-worktree',
+  mode: 'auto',                                       // 默认 auto，会让你确认
+  args: {
+    worktreeDir: 'feat-import-export-config',         // 必填
+    versionType: 'patch',                             // 可选，默认 patch
+    // draft: 'true',                                 // 可选，字符串 'true' 开启
+  },
+})
+```
+
+**优势**：
+- `phase('0-init'..'7-cleanup')` 阶段进度可视化管理
+- `$WORKSPACE` / `$ARGS` 自动注入，无需手动 `cd` 与拼参数
+- 阶段 7 前有**硬门禁**（workflow 层 JS `throw` 阻断），对齐 `[MANDATORY]` 标记
+- 失败时 prompt 里已写好"失败处理"段，AI 直接按指引走
+- bash timeout / 重试 / checkpoint 读取由 agent prompt 统一管理
+
+### ⚠️ 降级：直接跑 bash 阶段脚本
+
+**仅在以下情况**使用 bash 路径：
+- 单独重跑某个阶段（如阶段 1 失败、阶段 6 失败）
+- workflow-run 工具不可用
+- 调试某个 stage 脚本
+
+```bash
+cd /Users/zhushanwen/Code/llm-simple-router-workspace
+
+# 阶段 0 入口（带参数）
+bash .pi/skills/merge/stages/0-init.sh <worktree-dir> [patch|minor|major] [--draft]
+
+# 阶段 1-7（位置无关，按需调用）
+bash .pi/skills/merge/stages/1-local-check.sh
+bash .pi/skills/merge/stages/2-pr-merge.sh
+bash .pi/skills/merge/stages/3-post-merge-ci.sh
+bash .pi/skills/merge/stages/4-publish.sh
+bash .pi/skills/merge/stages/5-release.sh
+bash .pi/skills/merge/stages/6-verify.sh
+bash .pi/skills/merge/stages/7-cleanup.sh
+```
+
+> **注意**：bash 路径不经过 workflow 层的硬门禁，阶段 7 的 `[MANDATORY]` 检查**仅依赖 stages/7-cleanup.sh 自身的 `is_checkpoint`**（软门禁）。优先用 workflow-run。
 
 ## 8 阶段流程
 
@@ -53,18 +112,18 @@ bash .pi/skills/merge/stages/3-post-merge-ci.sh
 
 ### 阶段 4: GitHub Actions 发布（项目特化）
 
-此阶段调用项目的 `scripts/publish.sh`，由 GitHub Actions 执行实际发布：
+此阶段调用 skill 的 `stages/4-publish.sh`，由 GitHub Actions 执行实际发布：
 
 ```bash
 cd /Users/zhushanwen/Code/llm-simple-router-workspace
-bash scripts/publish.sh patch
+bash .pi/skills/merge/stages/4-publish.sh patch
 ```
 
-脚本流程：
-1. 检查本地代码状态
-2. 通过 GitHub Actions 触发 publish workflow
-3. 等待并监控 CI 进度
-4. 自动验证 npm/Docker/Release
+脚本流程（`stages/4-publish.sh`）：
+1. 检测仓库根是否有 `scripts/publish.sh`（项目级发布脚本）
+2. 如果存在 → 调用它（通常用于 `gh workflow run` 触发 publish workflow）
+3. 如果不存在 → 自行 bump 版本 + tag + push + 等待 Release CI
+4. 同步主 worktree 版本号、写入 state
 
 **版本类型参数**：`patch`（默认）/ `minor` / `major`
 
@@ -75,7 +134,11 @@ cd /Users/zhushanwen/Code/llm-simple-router-workspace
 bash .pi/skills/merge/stages/5-release.sh
 ```
 
-生成 commit 清单 → release notes → 创建/更新 GitHub Release。
+生成 commit 清单 → release notes → **创建/更新 GitHub Release**（stage 4-publish 之后做这一步是为了给 release 提供 commit 列表）。
+
+> **副作用**：`gh release create` 会触发 `.github/workflows/release.yml`（`on: release` 事件）。该 workflow 在 stage 4 已经把 dist archive 上传为 release asset（见 publish.yml "Release Asset" 步骤），所以 release.yml 会把同一批产物重新打包/处理；**不阻塞**阶段 6 验证。
+>
+> ⚠️ 容易混淆：`release.yml` 不是「4-publish 阶段等待的 CI」——4-publish 阶段等待的是 `publish.yml`（workflow_dispatch 触发）；`release.yml` 是 release 创建后**才**触发的后续 workflow（`on: release` 事件类型）。
 
 ### 阶段 6: 交付物验证——npm + Docker
 
@@ -133,13 +196,14 @@ bash .pi/skills/merge/stages/7-cleanup.sh
 | 2 | 本地验证（1-local-check） | `stages/1-local-check.sh` |
 | 3 | PR CI + 合并（2-pr-merge） | `stages/2-pr-merge.sh` |
 | 4 | Post-merge CI（3-post-merge-ci） | `stages/3-post-merge-ci.sh` |
-| 5 | GitHub Actions 发布（4-publish） | `scripts/publish.sh` |
+| 5 | GitHub Actions 发布（4-publish） | `stages/4-publish.sh` |
 | 6 | 创建 Release（5-release） | `stages/5-release.sh` |
 | 7 | 确认交付物（6-verify） | 阶段 6 手动验证 |
 | 8 | 清理 worktree（7-cleanup） | `stages/7-cleanup.sh` |
 
 ### 2. 执行约束
 
+- **必须优先调用 `workflow-run` 工具**（`name: 'merge-worktree'`），不要手跑 bash 拼 8 个阶段命令
 - 所有阶段脚本必须在 workspace root 或其子目录（非目标 worktree）内执行
 - 阶段 1 和阶段 6 的检查**零容忍**，所有错误必须正面修复
 - 禁止以"不是本次改动引起的"为由跳过检查
@@ -161,11 +225,24 @@ bash .pi/skills/merge/stages/N-name.sh
 ## 文件结构
 
 ```
-merge/
+.pi/skills/merge/
   SKILL.md                    # 本文件
+  lib/common.sh               # 共享 bash 函数（checkpoint / state / log）
+  stages/
+    0-init.sh                 # 阶段 0：解析参数、检测环境、写 state
+    1-local-check.sh          # 阶段 1：lint + test + build
+    2-pr-merge.sh             # 阶段 2：等 PR CI + merge
+    3-post-merge-ci.sh        # 阶段 3：等 main 分支 CI
+    4-publish.sh              # 阶段 4：bump + tag + push + 等 Release CI
+    5-release.sh              # 阶段 5：生成 release notes + 创建/更新 Release
+    6-verify.sh               # 阶段 6：⚠️ 交付物门禁（不可跳过）
+    7-cleanup.sh              # 阶段 7：删除 worktree + 同步其他 worktree
   scripts/
-    publish.sh                # 项目发布脚本（本地触发 GitHub Actions）
+    publish.sh                # 旧发布方式（参考用，stage 4 优先调用项目级脚本）
     release.sh                # 旧发布方式（参考用）
+
+# 仓库根下的项目级发布脚本（可选，stage 4 会优先调用）：
+scripts/publish.sh           # 项目发布脚本（本地触发 GitHub Actions）
 ```
 
 ## 退出码
@@ -176,6 +253,56 @@ merge/
 | 1 | 失败 | 查看错误信息，修复后重跑同一阶段 |
 
 ---
+
+## Beta 发布（已通过独立 skill 覆盖）
+
+> **重要**：本 skill（`merge-worktree`）**不**覆盖 beta 发布，但项目已有专门 skill 在做这件事——**`.pi/skills/beta-publish/`**。
+> AI 收到 "发 beta" / "beta publish" 类指令时，应直接调 `bash .pi/skills/beta-publish/beta-publish.sh`，**不要**走 `merge-worktree`。
+
+### 调用方式
+
+```bash
+# 自动 patch bump（推荐给 AI/CI）
+bash .pi/skills/beta-publish/beta-publish.sh -y
+
+# 指定版本号
+bash .pi/skills/beta-publish/beta-publish.sh -y 0.5.0
+
+# 交互式（带 y/N 确认，给人工用）
+bash .pi/skills/beta-publish/beta-publish.sh 0.5.0
+```
+
+完整 9 步流程见 `.pi/skills/beta-publish/SKILL.md`。
+
+### 能力对比（merge-worktree vs beta-publish）
+
+| 维度 | `merge-worktree`（stable） | `beta-publish.sh`（beta） |
+|------|----------------------------|----------------------------|
+| **触发方式** | PR merge main → `gh workflow run publish.yml --ref main` | `git push origin beta-X.Y.Z`（`on: push: branches: ['beta-*']`） |
+| **路径** | workflow_dispatch | push |
+| **版本号** | patch / minor / major | 显式指定 `X.Y.Z` 或自动 patch bump |
+| **npm tag** | `latest` | `beta` |
+| **commit + tag + Release** | ✅ | ❌ 跳过 |
+| **npm dist-tag** | ✅ latest | ✅ beta |
+| **Docker 镜像** | ✅ ghcr.io 多 tag | ❌ 跳过 |
+| **dist archive asset** | ✅ | ❌ |
+| **本地前置检查** | lint + test + build | gh CLI / 仓库状态 / 当前分支 |
+| **所属 skill** | `.pi/skills/merge/`（本 skill） | `.pi/skills/beta-publish/` |
+
+### 为什么 merge-worktree 自身不覆盖 beta
+
+`merge-worktree` 流程的设计假设是 **"PR → merge main → publish"**，这是 stable 路径的天然设计。但 beta 路径在 `publish.yml` 里是**分支级**机制（`on: push: branches: ['beta-*']`），有 4 条拦截：
+
+1. **`merge-worktree` 假设**：PR → merge main → publish 走 `scripts/publish.sh` → `gh workflow run publish.yml --ref main`（永远走 stable 路径）
+2. **`publish.yml` beta 触发器**：`on: push: branches: ['beta-*']`——**只能**通过 push 触发，不能通过 `workflow_dispatch`
+3. **`scripts/publish.sh` 锁死 main**：`--ref main -f bump_type=patch`——**永远**走 stable 路径
+4. **0-init.sh 拒绝 `beta`**：`VERSION_TYPE` 正则 `^(patch|minor|major)$` 白名单，传入 `beta` 会被 exit 1
+
+这 4 条拦截让 "把 beta 塞进 merge-worktree" 成本高（需重写 0/2/3/4/5/6 全部阶段），所以拆为独立 skill 是更经济的设计。
+
+### 未来 TODO
+
+`beta-publish.sh` 升级为 `beta-publish.js` workflow 形式（与 `merge-worktree.js` 同构），提供 `phase()` / `agent()` / 硬门禁 / checkpoint。**当前 scope 不做**。
 
 ## 标记说明
 

--- a/.pi/workflows/merge-worktree.js
+++ b/.pi/workflows/merge-worktree.js
@@ -132,9 +132,9 @@ bash ${STAGES('3-post-merge-ci')}
   // ─── 阶段 4: Publish ───────────────────────────
   phase('4-publish');
   await agent({
-    description: '4-publish: 版本 bump → tag → push → 等 Release CI',
+    description: '4-publish: push → 调 scripts/publish.sh → 等 publish workflow 完成',
     prompt: `## 任务
-版本 bump、打 tag、推送、等待 Release CI 构建完成。
+触发 publish workflow 并等待其完成，构建 npm 包 + Docker 镜像 + GitHub Release。
 
 ## 执行
 \`\`\`bash
@@ -143,16 +143,17 @@ bash ${STAGES('4-publish')}
 \`\`\`
 
 ## 说明
-- 项目可能使用 scripts/publish.sh（GitHub Actions）或自行 bump
-- 版本号从 package.json 读取
-- 自动同步子项目 package.json 版本
-- 等待 Release CI 构建产物（最多 15 分钟）
+- stages/4-publish.sh 行为：**优先**检测仓库根 \`scripts/publish.sh\`；**有则调用**（它会 \`gh workflow run publish.yml --ref main -f bump_type=<VERSION_TYPE>\`），**没有则自执行** \`npm version\` + tag + push
+- publish.yml 走 **stable 路径**（workflow_dispatch 触发）：bump version → commit + tag + push → 创建 GitHub Release → \`npm publish --tag latest\` → 构建并 push Docker image → 上传 dist archive asset
+- 版本号从 router/package.json 读取（router 是 npm 发布包）；子包（pi-extension / frontend）不参与 npm 发布
+- 等待 publish workflow CI 完成（**不是** release workflow，最长 15 分钟）
 
 ## 失败处理
-- Release CI 失败 → gh run view --log-failed，修复后重跑
+- publish workflow 失败 → \`gh run view --log-failed\`，修复后重跑（重跑用 \`gh workflow run\` 或重跑当前 job）
+- scripts/publish.sh 不存在（说明项目升级过发布机制）→ 自执行路径仍能跑通，AI 继续
 - 版本 bump 冲突 → 检查是否有未提交变更
 
-报告新版本号。`,
+报告新版本号 + publish workflow URL。`,
   });
 
   // ─── 阶段 5: Release ───────────────────────────
@@ -206,6 +207,36 @@ bash ${STAGES('6-verify')}
   });
 
   // ─── 阶段 7: Cleanup ───────────────────────────
+  // ─── 阶段 6.5: 硬门禁（同步 JS 检查，绕过 AI 决策）───
+  // [MANDATORY] 阶段 6 必须通过，否则禁止清理 worktree
+  {
+    const _fs = require('node:fs');
+    const _stateFile = _path.join(WS, '.merge-worktree-state.env');
+    if (!_fs.existsSync(_stateFile)) {
+      throw new Error(
+        '硬门禁阻断: 状态文件不存在 — 必须先完成阶段 0 (stages/0-init.sh)'
+      );
+    }
+    const _state = _fs.readFileSync(_stateFile, 'utf8');
+    const _m = _state.match(/^BRANCH_NAME="([^"]+)"/m);
+    if (!_m) {
+      throw new Error('硬门禁阻断: 状态文件缺少 BRANCH_NAME');
+    }
+    const _branchSafe = _m[1].replace(/\//g, '-');
+    const _gate = _path.join(
+      WS, '.merge-checkpoints', _branchSafe, 'deliverables-verified'
+    );
+    if (!_fs.existsSync(_gate)) {
+      throw new Error(
+        `硬门禁阻断 [MANDATORY]: 阶段 6 交付物确认未通过\n` +
+        `  缺少 checkpoint: ${_gate}\n` +
+        `  必须先运行阶段 6 (stages/6-verify.sh) 并 exit 0。\n` +
+        `  禁止绕过此检查执行清理。`
+      );
+    }
+    log(`硬门禁通过: deliverables-verified (${_gate})`);
+  }
+
   phase('7-cleanup');
   await agent({
     description: '7-cleanup: 删除 worktree + 同步其他 worktree + 清理临时文件',
@@ -218,11 +249,12 @@ cd ${WS}
 bash ${STAGES('7-cleanup')}
 \`\`\`
 
-## 门禁
-阶段 6 必须通过（checkpoint deliverables-verified 存在）。未通过则脚本拒绝执行。
+## 门禁（双重保护）
+1. **Workflow 层硬门禁**（已通过）: merge-worktree.js 在调用本阶段前已同步校验 checkpoint deliverables-verified 存在，缺少则 throw 阻断
+2. **Bash 层软门禁**: stages/7-cleanup.sh 自身也会调用 is_checkpoint 校验，AI agent 不要尝试绕过
 
 ## 失败处理
-- "安全阻断：交付物未确认" → 必须先运行阶段 6
+- "安全阻断：交付物未确认" → 极不可能发生（已在 workflow 层拦截）。如发生说明 checkpoint 被手动删除，需重跑阶段 6
 - worktree 删除失败 → 手动: cd ${WS}/main && git worktree remove ../${WT_DIR}
 
 报告清理完成状态。`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1005,6 +1005,7 @@
       "resolved": "https://registry.npmmirror.com/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1561,6 +1562,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -1584,6 +1586,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -3357,6 +3360,7 @@
       "resolved": "https://registry.npmmirror.com/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
       "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -3438,6 +3442,7 @@
       "resolved": "https://registry.npmmirror.com/@noble/ciphers/-/ciphers-1.3.0.tgz",
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -5221,6 +5226,7 @@
       "integrity": "sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.1",
         "@typescript-eslint/types": "8.59.1",
@@ -5619,6 +5625,7 @@
       "resolved": "https://registry.npmmirror.com/@vue/compiler-dom/-/compiler-dom-3.5.33.tgz",
       "integrity": "sha512-PXq0yrfCLzzL07rbXO4awtXY1Z06LG2eu6Adg3RJFa/j3Cii217XxxLXG22N330gw7GmALCY0Z8RgXEviwgpjA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-core": "3.5.33",
         "@vue/shared": "3.5.33"
@@ -5742,6 +5749,7 @@
       "resolved": "https://registry.npmmirror.com/@vue/server-renderer/-/server-renderer-3.5.33.tgz",
       "integrity": "sha512-0xylq/8/h44lVG0pZFknv1XIdEgymq2E9n59uTWJBG+dIgiT0TMCSsxrN7nO16Z0MU0MPjFcguBbZV8Itk52Hw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-ssr": "3.5.33",
         "@vue/shared": "3.5.33"
@@ -5881,6 +5889,7 @@
       "resolved": "https://registry.npmmirror.com/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6386,6 +6395,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -6594,6 +6604,7 @@
       "resolved": "https://registry.npmmirror.com/chart.js/-/chart.js-4.5.1.tgz",
       "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@kurkle/color": "^0.3.0"
       },
@@ -7732,6 +7743,7 @@
       "resolved": "https://registry.npmmirror.com/eslint/-/eslint-10.3.0.tgz",
       "integrity": "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -9104,6 +9116,7 @@
       "resolved": "https://registry.npmmirror.com/hono/-/hono-4.12.16.tgz",
       "integrity": "sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -9548,6 +9561,7 @@
       "resolved": "https://registry.npmmirror.com/jiti/-/jiti-2.6.1.tgz",
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -9782,6 +9796,7 @@
       "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@asamuzakjp/css-color": "^5.1.11",
         "@asamuzakjp/dom-selector": "^7.1.1",
@@ -9848,6 +9863,7 @@
       "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mdn-data": "2.27.1",
         "source-map-js": "^1.2.1"
@@ -10168,6 +10184,7 @@
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "dev": true,
       "license": "MPL-2.0",
+      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.3"
       },
@@ -11602,6 +11619,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -13371,6 +13389,7 @@
       "resolved": "https://registry.npmmirror.com/stylus/-/stylus-0.57.0.tgz",
       "integrity": "sha512-yOI6G8WYfr0q8v8rRvE91wbxFU+rJPo760Va4MF6K0I6BZjO4r+xSynkvyPBP9tV1CIEUeRsiidjIs2rzb1CnQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "css": "^3.0.0",
         "debug": "^4.3.2",
@@ -13670,6 +13689,7 @@
       "resolved": "https://registry.npmmirror.com/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -14077,6 +14097,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -14098,6 +14119,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14114,6 +14136,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14130,6 +14153,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14146,6 +14170,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14162,6 +14187,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14178,6 +14204,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14194,6 +14221,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14210,6 +14238,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14226,6 +14255,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14242,6 +14272,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14258,6 +14289,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14274,6 +14306,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14290,6 +14323,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14306,6 +14340,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14322,6 +14357,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14338,6 +14374,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14354,6 +14391,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14370,6 +14408,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14386,6 +14425,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14402,6 +14442,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14418,6 +14459,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14434,6 +14476,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14450,6 +14493,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14466,6 +14510,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14482,6 +14527,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14498,6 +14544,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14612,6 +14659,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -14809,6 +14857,7 @@
       "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -16084,6 +16133,7 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -16165,6 +16215,7 @@
       "resolved": "https://registry.npmmirror.com/vue/-/vue-3.5.33.tgz",
       "integrity": "sha512-1AgChhx5w3ALgT4oK3acm2Es/7jyZhWSVUfs3rOBlGQC0rjEDkS7G4lWlJJGGNQD+BV3reCwbQrOe1mPNwKHBQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.33",
         "@vue/compiler-sfc": "3.5.33",
@@ -16702,6 +16753,7 @@
       "integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
       "devOptional": true,
       "license": "ISC",
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -16851,6 +16903,7 @@
       "resolved": "https://registry.npmmirror.com/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/router/src/admin/settings-import-export.ts
+++ b/router/src/admin/settings-import-export.ts
@@ -49,6 +49,22 @@ export const adminImportExportRoutes: FastifyPluginCallback<ImportExportOptions>
         if (typeof row.api_key === "string" && row.api_key) {
           try { row.api_key = decrypt(row.api_key, encryptionKey); } catch { /* eslint-disable-line taste/no-silent-catch -- 无法解密则保留原值 */ }
         }
+        // 解密 endpoints JSON 内嵌套的 api_key
+        if (typeof row.endpoints === "string" && row.endpoints) {
+          try {
+            const eps = JSON.parse(row.endpoints) as Record<string, unknown>[];
+            for (const ep of eps) {
+              if (typeof ep.api_key === "string" && ep.api_key) {
+                ep.api_key = decrypt(ep.api_key, encryptionKey);
+              }
+            }
+            row.endpoints = JSON.stringify(eps);
+          } catch { /* eslint-disable-line taste/no-silent-catch -- 无法解密则保留原值 */ }
+        }
+        // 解密 proxy_password
+        if (typeof row.proxy_password === "string" && row.proxy_password) {
+          try { row.proxy_password = decrypt(row.proxy_password, encryptionKey); } catch { /* eslint-disable-line taste/no-silent-catch -- 无法解密则保留原值 */ }
+        }
       }
       for (const row of (data.router_keys || []) as Record<string, unknown>[]) {
         if (typeof row.key_encrypted === "string") {
@@ -90,6 +106,22 @@ export const adminImportExportRoutes: FastifyPluginCallback<ImportExportOptions>
       for (const row of (importData.providers || []) as Record<string, unknown>[]) {
         if (typeof row.api_key === "string" && row.api_key) {
           row.api_key = encrypt(row.api_key, encryptionKey);
+        }
+        // 重加密 endpoints JSON 内嵌套的 api_key
+        if (typeof row.endpoints === "string" && row.endpoints) {
+          try {
+            const eps = JSON.parse(row.endpoints) as Record<string, unknown>[];
+            for (const ep of eps) {
+              if (typeof ep.api_key === "string" && ep.api_key) {
+                ep.api_key = encrypt(ep.api_key, encryptionKey);
+              }
+            }
+            row.endpoints = JSON.stringify(eps);
+          } catch { /* eslint-disable-line taste/no-silent-catch -- 无法解析则保留原值 */ }
+        }
+        // 重加密 proxy_password
+        if (typeof row.proxy_password === "string" && row.proxy_password) {
+          row.proxy_password = encrypt(row.proxy_password, encryptionKey);
         }
       }
       for (const row of (importData.router_keys || []) as Record<string, unknown>[]) {

--- a/router/tests/admin-import-export.test.ts
+++ b/router/tests/admin-import-export.test.ts
@@ -269,6 +269,118 @@ describe("Config Import/Export API", () => {
       expect(loginRes.statusCode).toBe(200);
     });
 
+    it("decrypts endpoints JSON api_key on export", async () => {
+      const plainApiKey1 = "sk-ep1-plaintext-key";
+      const plainApiKey2 = "sk-ep2-plaintext-key";
+      const encryptedApikey1 = encrypt(plainApiKey1, TEST_ENCRYPTION_KEY);
+      const encryptedApikey2 = encrypt(plainApiKey2, TEST_ENCRYPTION_KEY);
+      const endpoints = JSON.stringify([
+        { api_type: "openai", base_url: "https://ep1.test.com", upstream_path: null, api_key: encryptedApikey1 },
+        { api_type: "anthropic", base_url: "https://ep2.test.com", upstream_path: "/v1", api_key: encryptedApikey2 },
+      ]);
+      const now = new Date().toISOString();
+      db.prepare(
+        "INSERT INTO providers (id, name, api_type, base_url, api_key, is_active, endpoints, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)"
+      ).run("ep-test-id", "EP Provider", "openai", "https://api.test.com", encryptedApikey1, 1, endpoints, now, now);
+
+      const res = await app.inject({
+        method: "GET",
+        url: "/admin/api/settings/export",
+        headers: { cookie },
+      });
+      const body = res.json().data;
+      const provider = body.data.providers.find((p: any) => p.id === "ep-test-id");
+      // 顶层 api_key 应被解密
+      expect(provider.api_key).toBe(plainApiKey1);
+      // endpoints JSON 内的 api_key 也应被解密
+      const exportedEps = JSON.parse(provider.endpoints);
+      expect(exportedEps[0].api_key).toBe(plainApiKey1);
+      expect(exportedEps[1].api_key).toBe(plainApiKey2);
+    });
+
+    it("decrypts proxy_password on export", async () => {
+      const plainProxyPassword = "my-secret-proxy-pass";
+      const encryptedProxyPassword = encrypt(plainProxyPassword, TEST_ENCRYPTION_KEY);
+      const encryptedApiKey = encrypt("sk-test", TEST_ENCRYPTION_KEY);
+      const now = new Date().toISOString();
+      db.prepare(
+        "INSERT INTO providers (id, name, api_type, base_url, api_key, is_active, proxy_type, proxy_url, proxy_password, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+      ).run("proxy-test-id", "Proxy Provider", "openai", "https://api.test.com", encryptedApiKey, 1, "socks5", "socks5://proxy.test.com:1080", encryptedProxyPassword, now, now);
+
+      const res = await app.inject({
+        method: "GET",
+        url: "/admin/api/settings/export",
+        headers: { cookie },
+      });
+      const body = res.json().data;
+      const provider = body.data.providers.find((p: any) => p.id === "proxy-test-id");
+      expect(provider.proxy_password).toBe(plainProxyPassword);
+    });
+
+    it("re-encrypts endpoints JSON api_key on import", async () => {
+      const plainApiKey1 = "sk-import-ep1-key";
+      const plainApiKey2 = "sk-import-ep2-key";
+      const now = new Date().toISOString();
+      const endpoints = JSON.stringify([
+        { api_type: "openai", base_url: "https://ep1.test.com", upstream_path: null, api_key: plainApiKey1 },
+        { api_type: "anthropic", base_url: "https://ep2.test.com", upstream_path: "/v1", api_key: plainApiKey2 },
+      ]);
+      const exportData = {
+        version: 1,
+        data: {
+          providers: [{
+            id: "import-ep-id", name: "Import EP Provider", api_type: "openai",
+            base_url: "https://api.test.com", api_key: plainApiKey1,
+            is_active: 1, endpoints, created_at: now, updated_at: now,
+          }],
+        },
+      };
+
+      await app.inject({
+        method: "POST",
+        url: "/admin/api/settings/import",
+        payload: exportData,
+        headers: { cookie, "content-type": "application/json" },
+      });
+
+      const row = db.prepare("SELECT api_key, endpoints FROM providers WHERE id = ?").get("import-ep-id") as { api_key: string; endpoints: string };
+      // 顶层 api_key 应被重加密
+      expect(decrypt(row.api_key, TEST_ENCRYPTION_KEY)).toBe(plainApiKey1);
+      // endpoints JSON 内的 api_key 也应被重加密
+      const importedEps = JSON.parse(row.endpoints);
+      expect(decrypt(importedEps[0].api_key, TEST_ENCRYPTION_KEY)).toBe(plainApiKey1);
+      expect(decrypt(importedEps[1].api_key, TEST_ENCRYPTION_KEY)).toBe(plainApiKey2);
+    });
+
+    it("re-encrypts proxy_password on import", async () => {
+      const plainProxyPassword = "import-proxy-secret";
+      const plainApiKey = "sk-import-proxy-test";
+      const now = new Date().toISOString();
+      const exportData = {
+        version: 1,
+        data: {
+          providers: [{
+            id: "import-proxy-id", name: "Import Proxy Provider", api_type: "openai",
+            base_url: "https://api.test.com", api_key: plainApiKey,
+            is_active: 1, proxy_type: "socks5", proxy_url: "socks5://proxy.test.com:1080",
+            proxy_password: plainProxyPassword,
+            created_at: now, updated_at: now,
+          }],
+        },
+      };
+
+      await app.inject({
+        method: "POST",
+        url: "/admin/api/settings/import",
+        payload: exportData,
+        headers: { cookie, "content-type": "application/json" },
+      });
+
+      const row = db.prepare("SELECT api_key, proxy_password FROM providers WHERE id = ?").get("import-proxy-id") as { api_key: string; proxy_password: string };
+      expect(decrypt(row.api_key, TEST_ENCRYPTION_KEY)).toBe(plainApiKey);
+      expect(decrypt(row.proxy_password, TEST_ENCRYPTION_KEY)).toBe(plainProxyPassword);
+    });
+
     it("preserves local log_retention_days value from export", async () => {
       const exportRes = await app.inject({
         method: "GET",


### PR DESCRIPTION
## 问题

系统设置页面的导入/导出功能在处理 providers 表时，遗漏了两个新增的敏感字段：

1. **`endpoints` JSON 中嵌套的 `api_key`**（迁移 051 `provider_endpoints` 新增）：导出时未解密，导入时未重加密
2. **`proxy_password`**（迁移 041 `provider_proxy` 新增）：导出时未解密，导入时未重加密

这导致：
- **导出**的 JSON 中，这些字段仍为密文，跨实例导入后无法正确使用
- **导入**时，这些字段以明文写入 DB，而运行时期望密文，导致认证失败

## 修复内容

### `router/src/admin/settings-import-export.ts`
- **导出逻辑**：新增对 `endpoints` JSON 数组内每个 endpoint 的 `api_key` 的解密，以及对 `proxy_password` 的解密
- **导入逻辑**：新增对 `endpoints` JSON 数组内每个 endpoint 的 `api_key` 的重加密，以及对 `proxy_password` 的重加密

### `router/tests/admin-import-export.test.ts`
- 新增 4 个测试用例，覆盖导出时 endpoints api_key 解密、导出时 proxy_password 解密、导入时 endpoints api_key 重加密、导入时 proxy_password 重加密

## 验证

- ✅ Lint: 零警告
- ✅ Test: 142 个测试文件，1767 个测试通过（含新增 4 个）
- ✅ Build: router + frontend 编译成功