### PR TITLE
fix: add 1M context window for MiMo v2.5 models

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -65,8 +65,12 @@ export interface ProviderPreset {
   models: string[];
   /** 模型名 → capabilities 映射（由后端补充） */
   modelCapabilities?: Record<string, string[]>;
-  /** 隐藏 preset，不在 plan 下拉菜单显示，但 endpoints 生成仍遍历 */
-  hidden?: boolean;
+  /** 内嵌多个 endpoint 配置（如同时提供 openai + anthropic） */
+  endpoints?: Array<{
+    apiType: "openai" | "openai-responses" | "anthropic";
+    baseUrl: string;
+    upstreamPath?: string;
+  }>;
 }
 
 export interface ProviderGroup {
@@ -572,4 +576,18 @@ export const api = {
       "/quick-setup",
       data,
     ),
+
+  testConnection: (data: {
+    api_type: "openai" | "openai-responses" | "anthropic";
+    base_url: string;
+    upstream_path?: string | null;
+    api_key: string;
+    model?: string;
+  }) =>
+    request<{
+      ok: boolean;
+      model?: string;
+      latency_ms?: number;
+      error?: string;
+    }>("post", "/test-connection", data),
 };

--- a/frontend/src/components/quick-setup/types.ts
+++ b/frontend/src/components/quick-setup/types.ts
@@ -188,7 +188,8 @@ export function getDefaultContextWindow(modelName: string): number {
     m.includes("v3.2") || // DeepSeek V3.2
     m.includes("r1") || // DeepSeek R1
     m.includes("reasoner") || // OpenAI reasoner
-    m.includes("qwen3.6") // Qwen 3.6 series
+    m.includes("qwen3.6") || // Qwen 3.6 series
+    m.includes("mimo-v2.5") // 小米 MiMo V2.5 系列（Pro / 标准）
   )
     return CONTEXT_1M;
   // 256K context window models

--- a/frontend/src/composables/quick-setup-actions.ts
+++ b/frontend/src/composables/quick-setup-actions.ts
@@ -16,7 +16,6 @@ import {
 import { computeDefaultPatches } from "@/utils/model-patches";
 import { DEFAULT_CONTEXT_WINDOW, DEFAULT_STREAM_TIMEOUT_MS } from "@/constants";
 
-const CONNECTION_DELAY_MS = 800;
 const POST_SAVE_DELAY_MS = 1500;
 import type { Ref, ComputedRef } from "vue";
 import type {
@@ -118,13 +117,8 @@ export function useQuickSetupActions(ctx: ActionCtx) {
           data.modelConfigs,
           data.isNonOpenaiEndpoint,
         );
-        // Generate endpoints from the group's presets
-        const groupData = selection.providerGroups.value.find(
-          (g) => g.group === defaults.group,
-        );
-        if (groupData) {
-          applyPresetEndpoints(data.endpoints, groupData.presets);
-        }
+        // Generate endpoints from the selected preset
+        applyPresetEndpoints(data.endpoints, defaults.preset);
       }
     }
     updateMappings();
@@ -236,16 +230,37 @@ export function useQuickSetupActions(ctx: ActionCtx) {
       ctx.submit.concurrencyConfig.value.max_concurrency =
         DEFAULT_CONCURRENCY_MANUAL_CONFIG.max_concurrency;
   };
-  const testConnection = () => {
+  const testConnection = async () => {
     if (!ctx.data.apiKey.value.trim()) {
       ctx.submit.connectionStatus.value = "error";
       toast.error(ctx.t("quickSetup.messages.fillApiKeyFirst"));
-      return Promise.resolve();
+      return;
+    }
+    // Use first endpoint or provider-level config
+    const ep = ctx.data.endpoints.value[0];
+    const firstModel = ctx.data.modelConfigs.value.find((m) => m.enabled)?.name;
+    if (!ep && !ctx.selection.currentPreset.value) {
+      toast.error(ctx.t("quickSetup.messages.selectProviderAndPlan"));
+      return;
     }
     ctx.submit.connectionStatus.value = "testing";
-    return new Promise((r) => setTimeout(r, CONNECTION_DELAY_MS)).then(() => {
+    try {
+      await api.testConnection({
+        api_type: ep?.api_type ?? ctx.selection.apiType.value,
+        base_url: ep?.base_url ?? ctx.data.baseUrl.value,
+        upstream_path: ep?.upstream_path ?? ctx.data.upstreamPath.value ?? null,
+        api_key: ctx.data.apiKey.value.trim(),
+        model: firstModel,
+      });
       ctx.submit.connectionStatus.value = "ok";
-    });
+      toast.success(ctx.t("quickSetup.messages.connectionOk"));
+    } catch (e: unknown) {
+      ctx.submit.connectionStatus.value = "error";
+      console.error("quickSetup.testConnection:", e);
+      toast.error(
+        getApiMessage(e, ctx.t("quickSetup.messages.connectionFailed")),
+      );
+    }
   };
   const addCustomModel = (name: string, cw = DEFAULT_CONTEXT_WINDOW) => {
     ctx.data.modelConfigs.value.push({

--- a/frontend/src/composables/quick-setup-helpers.ts
+++ b/frontend/src/composables/quick-setup-helpers.ts
@@ -453,8 +453,7 @@ export function applyProviderChange(
       ctx.selectedPlan.value = preset.plan;
       ctx.apiType.value = resolveApiType(client?.format, preset.apiType);
       applyPresetModels(preset, ctx.modelConfigs, ctx.isNonOpenaiEndpoint);
-      // Generate endpoints from all presets in the group (dedup by api_type)
-      applyPresetEndpoints(ctx.endpoints, groupData.presets);
+      applyPresetEndpoints(ctx.endpoints, preset);
     }
   }
   ctx.updateMappings();
@@ -480,26 +479,42 @@ export function applyPlanChange(
   if (!preset) return;
   apiType.value = resolveApiType(currentClient.value?.format, preset.apiType);
   applyPresetModels(preset, modelConfigs, isNonOpenaiEndpoint);
-  applyPresetEndpoints(endpoints, group.presets);
+  applyPresetEndpoints(endpoints, preset);
   updateMappings();
 }
 
-/** Deduplicate presets by api_type and generate endpoint entries */
+/** Generate endpoint entries from a preset.
+ * If the preset has an explicit `endpoints` array, use it directly.
+ * Otherwise fall back to deriving from the preset's own apiType/baseUrl. */
 export function applyPresetEndpoints(
   endpoints: Ref<ProviderEndpoint[]>,
-  presets: Array<{ apiType: string; baseUrl: string; upstreamPath?: string }>,
+  preset: {
+    apiType: string;
+    baseUrl: string;
+    upstreamPath?: string;
+    endpoints?: Array<{
+      apiType: string;
+      baseUrl: string;
+      upstreamPath?: string;
+    }>;
+  },
 ): void {
-  const seen = new Set<string>();
-  const result: ProviderEndpoint[] = [];
-  for (const preset of presets) {
-    if (seen.has(preset.apiType)) continue;
-    seen.add(preset.apiType);
-    result.push({
+  if (preset.endpoints && preset.endpoints.length > 0) {
+    endpoints.value = preset.endpoints.map((ep) => ({
+      api_type: ep.apiType as ProviderEndpoint["api_type"],
+      base_url: ep.baseUrl,
+      upstream_path: ep.upstreamPath || null,
+      api_key: null,
+    }));
+    return;
+  }
+  // Fallback: single endpoint from preset itself
+  endpoints.value = [
+    {
       api_type: preset.apiType as ProviderEndpoint["api_type"],
       base_url: preset.baseUrl,
       upstream_path: preset.upstreamPath || null,
       api_key: null,
-    });
-  }
-  endpoints.value = result;
+    },
+  ];
 }

--- a/frontend/src/composables/useProviderPresets.ts
+++ b/frontend/src/composables/useProviderPresets.ts
@@ -21,9 +21,8 @@ export function useProviderPresets(form: {
   const availablePlans = computed(() => {
     if (!presetGroup.value) return [];
     return (
-      providerPresets.value
-        .find((g) => g.group === presetGroup.value)
-        ?.presets.filter((p) => !p.hidden) ?? []
+      providerPresets.value.find((g) => g.group === presetGroup.value)
+        ?.presets ?? []
     );
   });
 
@@ -40,25 +39,30 @@ export function useProviderPresets(form: {
     const group = providerPresets.value.find(
       (g) => g.group === presetGroup.value,
     );
-    const plans = group?.presets;
-    if (plans?.length) {
-      presetPlan.value = plans[0].plan;
+    const preset = group?.presets[0];
+    if (preset) {
+      presetPlan.value = preset.plan;
       onPresetChange();
-      // Auto-generate endpoints from all presets in the group
-      const seen = new Set<string>();
-      const endpoints: import("@/types/mapping").ProviderEndpoint[] = [];
-      for (const preset of plans) {
-        if (seen.has(preset.apiType)) continue;
-        seen.add(preset.apiType);
-        endpoints.push({
+      // Auto-generate endpoints from preset's embedded endpoints or fallback to single
+      if (preset.endpoints && preset.endpoints.length > 0) {
+        form.value.endpoints = preset.endpoints.map((ep) => ({
           api_type:
-            preset.apiType as import("@/types/mapping").ProviderEndpoint["api_type"],
-          base_url: preset.baseUrl,
-          upstream_path: preset.upstreamPath || null,
+            ep.apiType as import("@/types/mapping").ProviderEndpoint["api_type"],
+          base_url: ep.baseUrl,
+          upstream_path: ep.upstreamPath || null,
           api_key: null,
-        });
+        }));
+      } else {
+        form.value.endpoints = [
+          {
+            api_type:
+              preset.apiType as import("@/types/mapping").ProviderEndpoint["api_type"],
+            base_url: preset.baseUrl,
+            upstream_path: preset.upstreamPath || null,
+            api_key: null,
+          },
+        ];
       }
-      form.value.endpoints = endpoints;
     } else {
       presetPlan.value = "";
     }

--- a/frontend/src/composables/useQuickSetup.ts
+++ b/frontend/src/composables/useQuickSetup.ts
@@ -88,8 +88,9 @@ export function useQuickSetup() {
   const selectedGroup = ref("");
   const selectedPlan = ref("");
   const apiType = ref<"openai" | "openai-responses" | "anthropic">("anthropic");
+  // sharedKey 是页面绑定的 API Key 输入框，同时作为提交和测试连接的 key
   const apiKey = ref("");
-  const sharedKey = ref("");
+  const sharedKey = apiKey;
   const endpoints = ref<ProviderEndpoint[]>([]);
   const modelConfigs = ref<ModelConfig[]>([]);
   const mappingEntries = ref<MappingEntry[]>([]);

--- a/frontend/src/i18n/locales/en/quickSetup.json
+++ b/frontend/src/i18n/locales/en/quickSetup.json
@@ -106,7 +106,9 @@
     "setupCompleteWithErrors": "Quick setup complete! {count} mapping toggle(s) failed",
     "setupComplete": "Quick setup complete!",
     "setupFailed": "Quick setup failed",
-    "loadFailed": "Failed to load recommended configuration"
+    "loadFailed": "Failed to load recommended configuration",
+    "connectionOk": "Connection test passed, AI responded normally",
+    "connectionFailed": "Connection test failed"
   },
   "steps": {
     "selectClient": "Select Client",

--- a/frontend/src/i18n/locales/zh-CN/quickSetup.json
+++ b/frontend/src/i18n/locales/zh-CN/quickSetup.json
@@ -106,7 +106,9 @@
     "setupCompleteWithErrors": "快速配置完成!{count} 个映射状态切换失败",
     "setupComplete": "快速配置完成!",
     "setupFailed": "快速配置失败",
-    "loadFailed": "加载推荐配置失败"
+    "loadFailed": "加载推荐配置失败",
+    "connectionOk": "连接测试成功，AI 已正常响应",
+    "connectionFailed": "连接测试失败"
   },
   "steps": {
     "selectClient": "选择客户端",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1005,6 +1005,7 @@
       "resolved": "https://registry.npmmirror.com/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1561,6 +1562,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -1584,6 +1586,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -3357,6 +3360,7 @@
       "resolved": "https://registry.npmmirror.com/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
       "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -3438,6 +3442,7 @@
       "resolved": "https://registry.npmmirror.com/@noble/ciphers/-/ciphers-1.3.0.tgz",
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -5221,6 +5226,7 @@
       "integrity": "sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.1",
         "@typescript-eslint/types": "8.59.1",
@@ -5619,6 +5625,7 @@
       "resolved": "https://registry.npmmirror.com/@vue/compiler-dom/-/compiler-dom-3.5.33.tgz",
       "integrity": "sha512-PXq0yrfCLzzL07rbXO4awtXY1Z06LG2eu6Adg3RJFa/j3Cii217XxxLXG22N330gw7GmALCY0Z8RgXEviwgpjA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-core": "3.5.33",
         "@vue/shared": "3.5.33"
@@ -5742,6 +5749,7 @@
       "resolved": "https://registry.npmmirror.com/@vue/server-renderer/-/server-renderer-3.5.33.tgz",
       "integrity": "sha512-0xylq/8/h44lVG0pZFknv1XIdEgymq2E9n59uTWJBG+dIgiT0TMCSsxrN7nO16Z0MU0MPjFcguBbZV8Itk52Hw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-ssr": "3.5.33",
         "@vue/shared": "3.5.33"
@@ -5881,6 +5889,7 @@
       "resolved": "https://registry.npmmirror.com/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6386,6 +6395,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -6594,6 +6604,7 @@
       "resolved": "https://registry.npmmirror.com/chart.js/-/chart.js-4.5.1.tgz",
       "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@kurkle/color": "^0.3.0"
       },
@@ -7732,6 +7743,7 @@
       "resolved": "https://registry.npmmirror.com/eslint/-/eslint-10.3.0.tgz",
       "integrity": "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -9104,6 +9116,7 @@
       "resolved": "https://registry.npmmirror.com/hono/-/hono-4.12.16.tgz",
       "integrity": "sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -9548,6 +9561,7 @@
       "resolved": "https://registry.npmmirror.com/jiti/-/jiti-2.6.1.tgz",
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -9782,6 +9796,7 @@
       "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@asamuzakjp/css-color": "^5.1.11",
         "@asamuzakjp/dom-selector": "^7.1.1",
@@ -9848,6 +9863,7 @@
       "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mdn-data": "2.27.1",
         "source-map-js": "^1.2.1"
@@ -10168,6 +10184,7 @@
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "dev": true,
       "license": "MPL-2.0",
+      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.3"
       },
@@ -11602,6 +11619,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -13371,6 +13389,7 @@
       "resolved": "https://registry.npmmirror.com/stylus/-/stylus-0.57.0.tgz",
       "integrity": "sha512-yOI6G8WYfr0q8v8rRvE91wbxFU+rJPo760Va4MF6K0I6BZjO4r+xSynkvyPBP9tV1CIEUeRsiidjIs2rzb1CnQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "css": "^3.0.0",
         "debug": "^4.3.2",
@@ -13670,6 +13689,7 @@
       "resolved": "https://registry.npmmirror.com/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -14077,6 +14097,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -14098,6 +14119,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14114,6 +14136,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14130,6 +14153,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14146,6 +14170,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14162,6 +14187,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14178,6 +14204,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14194,6 +14221,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14210,6 +14238,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14226,6 +14255,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14242,6 +14272,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14258,6 +14289,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14274,6 +14306,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14290,6 +14323,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14306,6 +14340,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14322,6 +14357,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14338,6 +14374,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14354,6 +14391,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14370,6 +14408,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14386,6 +14425,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14402,6 +14442,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14418,6 +14459,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14434,6 +14476,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14450,6 +14493,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14466,6 +14510,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14482,6 +14527,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14498,6 +14544,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14612,6 +14659,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -14809,6 +14857,7 @@
       "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -16084,6 +16133,7 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -16165,6 +16215,7 @@
       "resolved": "https://registry.npmmirror.com/vue/-/vue-3.5.33.tgz",
       "integrity": "sha512-1AgChhx5w3ALgT4oK3acm2Es/7jyZhWSVUfs3rOBlGQC0rjEDkS7G4lWlJJGGNQD+BV3reCwbQrOe1mPNwKHBQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.33",
         "@vue/compiler-sfc": "3.5.33",
@@ -16702,6 +16753,7 @@
       "integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
       "devOptional": true,
       "license": "ISC",
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -16851,6 +16903,7 @@
       "resolved": "https://registry.npmmirror.com/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -16,5 +16,5 @@
   "devDependencies": {
     "eslint-plugin-vue": "^10.9.1"
   },
-  "version": "1.0.3"
+  "version": "1.0.5"
 }

--- a/router/config/recommended-providers.json
+++ b/router/config/recommended-providers.json
@@ -1,383 +1,378 @@
 [
-  {
-    "group": "DeepSeek",
-    "presets": [
-      {
-        "plan": "Anthropic",
-        "presetName": "deepseek",
-        "apiType": "anthropic",
-        "baseUrl": "https://api.deepseek.com/anthropic",
-        "modelsEndpoint": "/v1/models",
-        "models": [
-          "deepseek-v4-flash",
-          "deepseek-v4-pro"
-        ]
-      },
-      {
-        "plan": "OpenAI",
-        "presetName": "deepseek-openai",
-        "apiType": "openai",
-        "baseUrl": "https://api.deepseek.com",
-        "modelsEndpoint": "/v1/models",
-        "models": [
-          "deepseek-v4-flash",
-          "deepseek-v4-pro"
-        ]
-      }
-    ],
-    "shortname": "deepseek"
-  },
-  {
-    "group": "百度千帆",
-    "presets": [
-      {
-        "plan": "API",
-        "presetName": "qianfan",
-        "apiType": "openai",
-        "baseUrl": "https://qianfan.baidubce.com/v2",
-        "modelsEndpoint": "/v1/models",
-        "models": [
-          "ernie-4.0-8k",
-          "ernie-4.0-turbo-8k",
-          "ernie-3.5-8k",
-          "ernie-speed-8k",
-          "ernie-lite-8k",
-          "ernie-x1-32k-preview",
-          "deepseek-v3",
-          "deepseek-r1"
+    {
+        "group": "小米",
+        "presets": [
+            {
+                "plan": "Token Plan",
+                "presetName": "xiaomi-token-plan",
+                "apiType": "anthropic",
+                "baseUrl": "https://token-plan-cn.xiaomimimo.com/anthropic",
+                "modelsEndpoint": "/v1/models",
+                "models": [
+                    "mimo-v2.5-pro",
+                    "mimo-v2.5"
+                ],
+                "endpoints": [
+                    {
+                        "apiType": "anthropic",
+                        "baseUrl": "https://token-plan-cn.xiaomimimo.com/anthropic"
+                    },
+                    {
+                        "apiType": "openai",
+                        "baseUrl": "https://token-plan-cn.xiaomimimo.com/v1"
+                    }
+                ]
+            }
         ],
-        "upstreamPath": "/chat/completions"
-      }
-    ],
-    "shortname": "qianfan"
-  },
-  {
-    "group": "科大讯飞",
-    "presets": [
-      {
-        "plan": "API",
-        "presetName": "iflytek-spark",
-        "apiType": "openai",
-        "baseUrl": "https://spark-api-open.xf-yun.com",
-        "modelsEndpoint": "/v1/models",
-        "models": [
-          "4.0Ultra",
-          "generalv3.5",
-          "max-32k",
-          "generalv3",
-          "pro-128k",
-          "lite"
-        ]
-      }
-    ],
-    "shortname": "iflytek"
-  },
-  {
-    "group": "硅基流动",
-    "presets": [
-      {
-        "plan": "API",
-        "presetName": "siliconflow",
-        "apiType": "openai",
-        "baseUrl": "https://api.siliconflow.cn",
-        "modelsEndpoint": "/v1/models",
-        "models": [
-          "deepseek-ai/DeepSeek-V3.2-Exp",
-          "deepseek-ai/DeepSeek-R1",
-          "Qwen/Qwen3-8B",
-          "Qwen/Qwen2.5-72B-Instruct",
-          "Qwen/Qwen2.5-Coder-32B-Instruct",
-          "moonshotai/Kimi-K2-Instruct",
-          "moonshotai/Kimi-K2.5"
-        ]
-      }
-    ],
-    "shortname": "siliconflow"
-  },
-  {
-    "group": "智谱",
-    "presets": [
-      {
-        "plan": "Coding Plan",
-        "presetName": "zhipu-coding-plan",
-        "apiType": "openai",
-        "baseUrl": "https://open.bigmodel.cn",
-        "upstreamPath": "/api/coding/paas/v4/chat/completions",
-        "modelsEndpoint": "/v1/models",
-        "models": [
-          "glm-5.1",
-          "glm-5",
-          "glm-5-turbo",
-          "glm-4.7",
-          "glm-4.5-air"
-        ]
-      },
-      {
-        "plan": "Coding Plan (Anthropic)",
-        "presetName": "zhipu-coding-plan-anthropic",
-        "apiType": "anthropic",
-        "baseUrl": "https://open.bigmodel.cn",
-        "upstreamPath": "/api/anthropic/v1/messages",
-        "modelsEndpoint": "/api/anthropic/v1/models",
-        "models": [
-          "glm-5.1",
-          "glm-5",
-          "glm-5-turbo",
-          "glm-4.7",
-          "glm-4.5-air"
+        "shortname": "xiaomi"
+    },
+    {
+        "group": "DeepSeek",
+        "presets": [
+            {
+                "plan": "Anthropic",
+                "presetName": "deepseek",
+                "apiType": "anthropic",
+                "baseUrl": "https://api.deepseek.com/anthropic",
+                "modelsEndpoint": "/v1/models",
+                "models": [
+                    "deepseek-v4-flash",
+                    "deepseek-v4-pro"
+                ],
+                "endpoints": [
+                    {
+                        "apiType": "anthropic",
+                        "baseUrl": "https://api.deepseek.com/anthropic"
+                    },
+                    {
+                        "apiType": "openai",
+                        "baseUrl": "https://api.deepseek.com"
+                    }
+                ]
+            }
         ],
-        "hidden": true
-      },
-      {
-        "plan": "API",
-        "presetName": "zhipu",
-        "apiType": "openai",
-        "baseUrl": "https://open.bigmodel.cn/api/paas/v4",
-        "modelsEndpoint": "/models",
-        "models": [
-          "glm-5.1",
-          "glm-5",
-          "glm-5-turbo",
-          "glm-4.7",
-          "glm-4.7-flash",
-          "glm-4.6"
-        ]
-      }
-    ],
-    "shortname": "zhipu"
-  },
-  {
-    "group": "月之暗面",
-    "presets": [
-      {
-        "plan": "Coding Plan",
-        "presetName": "kimi-coding-plan",
-        "apiType": "anthropic",
-        "baseUrl": "https://api.kimi.com/coding",
-        "modelsEndpoint": "/v1/models",
-        "models": [
-          "kimi-for-coding",
-          "kimi-k2.5"
-        ]
-      },
-      {
-        "plan": "API",
-        "presetName": "kimi",
-        "apiType": "openai",
-        "baseUrl": "https://api.moonshot.cn",
-        "modelsEndpoint": "/v1/models",
-        "models": [
-          "kimi-k2.6",
-          "kimi-k2.5",
-          "kimi-k2-turbo-preview",
-          "kimi-k2-thinking",
-          "moonshot-v1-128k"
-        ]
-      }
-    ],
-    "shortname": "moonshot"
-  },
-  {
-    "group": "Minimax",
-    "presets": [
-      {
-        "plan": "Token Plan",
-        "presetName": "minimax-token-plan",
-        "apiType": "anthropic",
-        "baseUrl": "https://api.minimaxi.com/anthropic",
-        "modelsEndpoint": "/v1/models",
-        "models": [
-          "MiniMax-M2.7"
-        ]
-      },
-      {
-        "plan": "API",
-        "presetName": "minimax",
-        "apiType": "openai",
-        "baseUrl": "https://api.minimax.chat",
-        "modelsEndpoint": "/v1/models",
-        "models": [
-          "MiniMax-M2.7",
-          "MiniMax-M2.7-highspeed",
-          "MiniMax-M2.5",
-          "MiniMax-M2.5-highspeed",
-          "MiniMax-M2.1",
-          "MiniMax-M2"
-        ]
-      }
-    ],
-    "shortname": "minimax"
-  },
-  {
-    "group": "火山引擎",
-    "presets": [
-      {
-        "plan": "Coding Plan",
-        "presetName": "volcengine-coding-plan",
-        "apiType": "anthropic",
-        "baseUrl": "https://ark.cn-beijing.volces.com/api/coding",
-        "modelsEndpoint": "/v1/models",
-        "models": [
-          "ark-code-latest",
-          "doubao-seed-2.0-code",
-          "kimi-k2.5",
-          "glm-4.7",
-          "deepseek-v3.2"
-        ]
-      },
-      {
-        "plan": "API",
-        "presetName": "volcengine",
-        "apiType": "openai",
-        "baseUrl": "https://ark.cn-beijing.volces.com/api/v3",
-        "modelsEndpoint": "/models",
-        "models": [
-          "doubao-seed-2-0-pro-260215",
-          "doubao-seed-1-8-251228",
-          "doubao-seed-code-preview-251028"
-        ]
-      }
-    ],
-    "shortname": "volcengine"
-  },
-  {
-    "group": "阿里云",
-    "presets": [
-      {
-        "plan": "Coding Plan",
-        "presetName": "aliyun-coding-plan",
-        "apiType": "anthropic",
-        "baseUrl": "https://coding.dashscope.aliyuncs.com/apps/anthropic",
-        "models": [
-          "qwen3.6-plus",
-          "qwen3-coder-next",
-          "qwen3-coder-plus",
-          "kimi-k2.5",
-          "glm-5",
-          "MiniMax-M2.5"
-        ]
-      },
-      {
-        "plan": "API",
-        "presetName": "aliyun",
-        "apiType": "openai",
-        "baseUrl": "https://dashscope.aliyuncs.com/compatible-mode",
-        "modelsEndpoint": "/v1/models",
-        "models": [
-          "qwen3.6-plus",
-          "qwen3.5-plus",
-          "qwen3-max",
-          "qwen3.5-flash",
-          "qwen3-coder-plus",
-          "qwen3-coder-next"
-        ]
-      }
-    ],
-    "shortname": "aliyun"
-  },
-  {
-    "group": "腾讯云",
-    "presets": [
-      {
-        "plan": "Coding Plan",
-        "presetName": "tencent-coding-plan",
-        "apiType": "anthropic",
-        "baseUrl": "https://api.lkeap.cloud.tencent.com/coding/anthropic",
-        "modelsEndpoint": "/v1/models",
-        "models": [
-          "tc-code-latest",
-          "hunyuan-2.0-instruct",
-          "hunyuan-2.0-thinking",
-          "hunyuan-turbos",
-          "hunyuan-t1",
-          "glm-5",
-          "kimi-k2.5"
-        ]
-      },
-      {
-        "plan": "API",
-        "presetName": "tencent",
-        "apiType": "openai",
-        "baseUrl": "https://api.hunyuan.cloud.tencent.com",
-        "modelsEndpoint": "/v1/models",
-        "models": [
-          "hunyuan-2.0-thinking",
-          "hunyuan-2.0-instruct",
-          "hunyuan-t1-latest",
-          "hunyuan-a13b",
-          "hunyuan-turbos-latest"
-        ]
-      }
-    ],
-    "shortname": "tencent"
-  },
-  {
-    "group": "OpenCode",
-    "presets": [
-      {
-        "plan": "Go OpenAI",
-        "presetName": "opencode-go-openai",
-        "apiType": "openai",
-        "baseUrl": "https://opencode.ai/zen/go/v1/chat/completions",
-        "modelsEndpoint": "/models",
-        "models": [
-          "glm-5.1",
-          "glm-5",
-          "kimi-k2.5",
-          "kimi-k2.6",
-          "deepseek-v4-pro",
-          "deepseek-v4-flash",
-          "mimo-v2-pro",
-          "mimo-v2-omni",
-          "mimo-v2.5-pro",
-          "mimo-v2.5"
-        ]
-      },
-      {
-        "plan": "Go Anthropic",
-        "presetName": "opencode-go-anthropic",
-        "apiType": "anthropic",
-        "baseUrl": "https://opencode.ai/zen/go/v1/messages",
-        "models": [
-          "qwen3.6-plus",
-          "qwen3.5-plus",
-          "minimax-m2.7",
-          "minimax-m2.5"
-        ]
-      }
-    ],
-    "shortname": "opencode"
-  },
-  {
-    "group": "阶跃星辰",
-    "presets": [
-      {
-        "plan": "Step Plan",
-        "presetName": "stepfun-step-plan",
-        "apiType": "anthropic",
-        "baseUrl": "https://api.stepfun.com/step_plan",
-        "modelsEndpoint": "/v1/models",
-        "models": [
-          "step-3.5-flash-2603",
-          "step-3.5-flash"
-        ]
-      },
-      {
-        "plan": "API",
-        "presetName": "stepfun",
-        "apiType": "openai",
-        "baseUrl": "https://api.stepfun.com",
-        "modelsEndpoint": "/v1/models",
-        "models": [
-          "step-3.5-flash",
-          "step-3",
-          "step-2-mini",
-          "step-2-16k",
-          "step-1-8k",
-          "step-1-32k"
-        ]
-      }
-    ],
-    "shortname": "stepfun"
-  }
+        "shortname": "deepseek"
+    },
+    {
+        "group": "百度千帆",
+        "presets": [
+            {
+                "plan": "API",
+                "presetName": "qianfan",
+                "apiType": "openai",
+                "baseUrl": "https://qianfan.baidubce.com/v2",
+                "modelsEndpoint": "/v1/models",
+                "models": [
+                    "ernie-4.0-8k",
+                    "ernie-4.0-turbo-8k",
+                    "ernie-3.5-8k",
+                    "ernie-speed-8k",
+                    "ernie-lite-8k",
+                    "ernie-x1-32k-preview",
+                    "deepseek-v3",
+                    "deepseek-r1"
+                ],
+                "upstreamPath": "/chat/completions"
+            }
+        ],
+        "shortname": "qianfan"
+    },
+    {
+        "group": "科大讯飞",
+        "presets": [
+            {
+                "plan": "API",
+                "presetName": "iflytek-spark",
+                "apiType": "openai",
+                "baseUrl": "https://spark-api-open.xf-yun.com",
+                "modelsEndpoint": "/v1/models",
+                "models": [
+                    "4.0Ultra",
+                    "generalv3.5",
+                    "max-32k",
+                    "generalv3",
+                    "pro-128k",
+                    "lite"
+                ]
+            }
+        ],
+        "shortname": "iflytek"
+    },
+    {
+        "group": "硅基流动",
+        "presets": [
+            {
+                "plan": "API",
+                "presetName": "siliconflow",
+                "apiType": "openai",
+                "baseUrl": "https://api.siliconflow.cn",
+                "modelsEndpoint": "/v1/models",
+                "models": [
+                    "deepseek-ai/DeepSeek-V3.2-Exp",
+                    "deepseek-ai/DeepSeek-R1",
+                    "Qwen/Qwen3-8B",
+                    "Qwen/Qwen2.5-72B-Instruct",
+                    "Qwen/Qwen2.5-Coder-32B-Instruct",
+                    "moonshotai/Kimi-K2-Instruct",
+                    "moonshotai/Kimi-K2.5"
+                ]
+            }
+        ],
+        "shortname": "siliconflow"
+    },
+    {
+        "group": "智谱",
+        "presets": [
+            {
+                "plan": "Coding Plan",
+                "presetName": "zhipu-coding-plan",
+                "apiType": "openai",
+                "baseUrl": "https://open.bigmodel.cn",
+                "upstreamPath": "/api/coding/paas/v4/chat/completions",
+                "modelsEndpoint": "/v1/models",
+                "models": [
+                    "glm-5.1",
+                    "glm-5",
+                    "glm-5-turbo",
+                    "glm-4.7",
+                    "glm-4.5-air"
+                ],
+                "endpoints": [
+                    {
+                        "apiType": "openai",
+                        "baseUrl": "https://open.bigmodel.cn",
+                        "upstreamPath": "/api/coding/paas/v4/chat/completions"
+                    },
+                    {
+                        "apiType": "anthropic",
+                        "baseUrl": "https://open.bigmodel.cn",
+                        "upstreamPath": "/api/anthropic/v1/messages"
+                    }
+                ]
+            },
+            {
+                "plan": "API",
+                "presetName": "zhipu",
+                "apiType": "openai",
+                "baseUrl": "https://open.bigmodel.cn/api/paas/v4",
+                "modelsEndpoint": "/models",
+                "models": [
+                    "glm-5.1",
+                    "glm-5",
+                    "glm-5-turbo",
+                    "glm-4.7",
+                    "glm-4.7-flash",
+                    "glm-4.6"
+                ]
+            }
+        ],
+        "shortname": "zhipu"
+    },
+    {
+        "group": "月之暗面",
+        "presets": [
+            {
+                "plan": "Coding Plan",
+                "presetName": "kimi-coding-plan",
+                "apiType": "anthropic",
+                "baseUrl": "https://api.kimi.com/coding",
+                "modelsEndpoint": "/v1/models",
+                "models": [
+                    "kimi-for-coding",
+                    "kimi-k2.5"
+                ],
+                "endpoints": [
+                    {
+                        "apiType": "anthropic",
+                        "baseUrl": "https://api.kimi.com/coding"
+                    },
+                    {
+                        "apiType": "openai",
+                        "baseUrl": "https://api.moonshot.cn"
+                    }
+                ]
+            }
+        ],
+        "shortname": "moonshot"
+    },
+    {
+        "group": "Minimax",
+        "presets": [
+            {
+                "plan": "Token Plan",
+                "presetName": "minimax-token-plan",
+                "apiType": "anthropic",
+                "baseUrl": "https://api.minimaxi.com/anthropic",
+                "modelsEndpoint": "/v1/models",
+                "models": [
+                    "MiniMax-M2.7"
+                ],
+                "endpoints": [
+                    {
+                        "apiType": "anthropic",
+                        "baseUrl": "https://api.minimaxi.com/anthropic"
+                    },
+                    {
+                        "apiType": "openai",
+                        "baseUrl": "https://api.minimax.chat"
+                    }
+                ]
+            }
+        ],
+        "shortname": "minimax"
+    },
+    {
+        "group": "火山引擎",
+        "presets": [
+            {
+                "plan": "Coding Plan",
+                "presetName": "volcengine-coding-plan",
+                "apiType": "anthropic",
+                "baseUrl": "https://ark.cn-beijing.volces.com/api/coding",
+                "modelsEndpoint": "/v1/models",
+                "models": [
+                    "ark-code-latest",
+                    "doubao-seed-2.0-code",
+                    "kimi-k2.5",
+                    "glm-4.7",
+                    "deepseek-v3.2"
+                ],
+                "endpoints": [
+                    {
+                        "apiType": "anthropic",
+                        "baseUrl": "https://ark.cn-beijing.volces.com/api/coding"
+                    },
+                    {
+                        "apiType": "openai",
+                        "baseUrl": "https://ark.cn-beijing.volces.com/api/v3"
+                    }
+                ]
+            }
+        ],
+        "shortname": "volcengine"
+    },
+    {
+        "group": "阿里云",
+        "presets": [
+            {
+                "plan": "Coding Plan",
+                "presetName": "aliyun-coding-plan",
+                "apiType": "anthropic",
+                "baseUrl": "https://coding.dashscope.aliyuncs.com/apps/anthropic",
+                "models": [
+                    "qwen3.6-plus",
+                    "qwen3-coder-next",
+                    "qwen3-coder-plus",
+                    "kimi-k2.5",
+                    "glm-5",
+                    "MiniMax-M2.5"
+                ],
+                "endpoints": [
+                    {
+                        "apiType": "anthropic",
+                        "baseUrl": "https://coding.dashscope.aliyuncs.com/apps/anthropic"
+                    },
+                    {
+                        "apiType": "openai",
+                        "baseUrl": "https://dashscope.aliyuncs.com/compatible-mode"
+                    }
+                ]
+            }
+        ],
+        "shortname": "aliyun"
+    },
+    {
+        "group": "腾讯云",
+        "presets": [
+            {
+                "plan": "Coding Plan",
+                "presetName": "tencent-coding-plan",
+                "apiType": "anthropic",
+                "baseUrl": "https://api.lkeap.cloud.tencent.com/coding/anthropic",
+                "modelsEndpoint": "/v1/models",
+                "models": [
+                    "tc-code-latest",
+                    "hunyuan-2.0-instruct",
+                    "hunyuan-2.0-thinking",
+                    "hunyuan-turbos",
+                    "hunyuan-t1",
+                    "glm-5",
+                    "kimi-k2.5"
+                ],
+                "endpoints": [
+                    {
+                        "apiType": "anthropic",
+                        "baseUrl": "https://api.lkeap.cloud.tencent.com/coding/anthropic"
+                    },
+                    {
+                        "apiType": "openai",
+                        "baseUrl": "https://api.hunyuan.cloud.tencent.com"
+                    }
+                ]
+            }
+        ],
+        "shortname": "tencent"
+    },
+    {
+        "group": "OpenCode",
+        "presets": [
+            {
+                "plan": "Go OpenAI",
+                "presetName": "opencode-go-openai",
+                "apiType": "openai",
+                "baseUrl": "https://opencode.ai/zen/go/v1/chat/completions",
+                "modelsEndpoint": "/models",
+                "models": [
+                    "glm-5.1",
+                    "glm-5",
+                    "kimi-k2.5",
+                    "kimi-k2.6",
+                    "deepseek-v4-pro",
+                    "deepseek-v4-flash",
+                    "mimo-v2-pro",
+                    "mimo-v2-omni",
+                    "mimo-v2.5-pro",
+                    "mimo-v2.5"
+                ],
+                "endpoints": [
+                    {
+                        "apiType": "openai",
+                        "baseUrl": "https://opencode.ai/zen/go/v1/chat/completions"
+                    },
+                    {
+                        "apiType": "anthropic",
+                        "baseUrl": "https://opencode.ai/zen/go/v1/messages"
+                    }
+                ]
+            }
+        ],
+        "shortname": "opencode"
+    },
+    {
+        "group": "阶跃星辰",
+        "presets": [
+            {
+                "plan": "Step Plan",
+                "presetName": "stepfun-step-plan",
+                "apiType": "anthropic",
+                "baseUrl": "https://api.stepfun.com/step_plan",
+                "modelsEndpoint": "/v1/models",
+                "models": [
+                    "step-3.5-flash-2603",
+                    "step-3.5-flash"
+                ],
+                "endpoints": [
+                    {
+                        "apiType": "anthropic",
+                        "baseUrl": "https://api.stepfun.com/step_plan"
+                    },
+                    {
+                        "apiType": "openai",
+                        "baseUrl": "https://api.stepfun.com"
+                    }
+                ]
+            }
+        ],
+        "shortname": "stepfun"
+    }
 ]

--- a/router/src/admin/quick-setup.ts
+++ b/router/src/admin/quick-setup.ts
@@ -1,13 +1,15 @@
 import { FastifyPluginCallback } from "fastify";
 import Database from "better-sqlite3";
 import { Type, Static } from "@sinclair/typebox";
+import { request as httpRequest } from "http";
+import { request as httpsRequest } from "https";
 import { createProvider, PROVIDER_CONCURRENCY_DEFAULTS } from "../db/providers.js";
 import { createMappingGroup, updateMappingGroup } from "../db/mappings.js";
 import { createRetryRule } from "../db/retry-rules.js";
 import { upsertTransformRule } from "../db/transform-rules.js";
 import { encrypt } from "../utils/crypto.js";
 import { getSetting } from "../db/settings.js";
-import { HTTP_CREATED, HTTP_BAD_REQUEST, HTTP_CONFLICT } from "./constants.js";
+import { HTTP_CREATED, HTTP_BAD_REQUEST, HTTP_BAD_GATEWAY, HTTP_CONFLICT } from "./constants.js";
 import { API_CODE, apiError } from "./api-response.js";
 import type { StateRegistry } from "../core/registry.js";
 import type { RequestTracker } from "../core/monitor/index.js";
@@ -257,5 +259,177 @@ export const adminQuickSetupRoutes: FastifyPluginCallback<QuickSetupRoutesOption
     return reply.code(HTTP_CREATED).send({ success: true, provider_id: providerId });
   });
 
+  // ---------- Test Connection ----------
+
+  const TestConnectionSchema = Type.Object({
+    api_type: Type.Union([Type.Literal("openai"), Type.Literal("openai-responses"), Type.Literal("anthropic")]),
+    base_url: Type.String({ minLength: 1 }),
+    upstream_path: Type.Optional(Type.Union([Type.String({ minLength: 1 }), Type.Null()])),
+    api_key: Type.String({ minLength: 1 }),
+    model: Type.Optional(Type.String()),
+  });
+
+  app.post("/admin/api/test-connection", { schema: { body: TestConnectionSchema } }, async (request, reply) => {
+    const body = request.body as Static<typeof TestConnectionSchema>;
+    const apiType = body.api_type;
+    const baseUrl = body.base_url.replace(/\/+$/, "");
+    const upstreamPath = body.upstream_path ?? null;
+    const apiKey = body.api_key;
+
+    // Determine model and path based on api_type
+    let targetPath: string;
+    let reqBody: Record<string, unknown>;
+    let authHeader: string;
+
+    if (apiType === "anthropic") {
+      targetPath = upstreamPath ?? "/v1/messages";
+      reqBody = {
+        model: body.model ?? "claude-3-5-haiku-20241022",
+        max_tokens: 32,
+        messages: [{ role: "user", content: "Hi" }],
+      };
+      authHeader = `x-api-key`;
+    } else {
+      // openai or openai-responses
+      targetPath = upstreamPath ?? "/v1/chat/completions";
+      reqBody = {
+        model: body.model ?? "gpt-4o-mini",
+        max_tokens: 32,
+        messages: [
+          { role: "system", content: "You are a helpful assistant." },
+          { role: "user", content: "Say hi in one word." },
+        ],
+      };
+      authHeader = "authorization";
+    }
+
+    // Build full URL with dedup logic
+    const fullUrl = buildTestUrl(baseUrl, targetPath);
+
+    try {
+      const result = await sendTestRequest(fullUrl, apiType, apiKey, authHeader, reqBody);
+      return reply.send({ ok: true, model: body.model, latency_ms: result.latencyMs });
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : JSON.stringify(err);
+      return reply.code(HTTP_BAD_GATEWAY).send({ ok: false, error: message });
+    }
+  });
+
   done();
 };
+
+// ---------- Test Connection Helpers ----------
+
+const TEST_REQUEST_TIMEOUT_MS = 15_000;
+
+const HTTPS_DEFAULT_PORT = 443;
+const HTTP_DEFAULT_PORT = 80;
+const HTTP_SUCCESS_MIN = 200;
+const HTTP_SUCCESS_MAX = 300;
+
+/** Build full URL, applying dedup logic for base_url already containing the path */
+function buildTestUrl(baseUrl: string, upstreamPath: string): string {
+  const KNOWN_SUFFIXES = ["/chat/completions", "/messages", "/responses"];
+  const normalized = baseUrl.replace(/\/+$/, "");
+  if (normalized.endsWith(upstreamPath)) return normalized;
+  for (const suffix of KNOWN_SUFFIXES) {
+    if (normalized.endsWith(suffix)) return normalized;
+  }
+  // Check for /v1 prefix overlap
+  const versionMatch = upstreamPath.match(/^(\/v\d+)(.*)/);
+  if (versionMatch) {
+    const [, prefix, rest] = versionMatch;
+    if (normalized.endsWith(prefix)) return `${normalized}${rest}`;
+  }
+  // Generic overlap detection
+  const segments = upstreamPath.split("/");
+  const MIN_OVERLAP_SEGMENTS = 2;
+  for (let len = segments.length - 1; len >= MIN_OVERLAP_SEGMENTS; len--) {
+    const candidate = segments.slice(0, len).join("/");
+    if (candidate.length > 0 && normalized.endsWith(candidate)) {
+      return `${normalized}${upstreamPath.slice(candidate.length)}`;
+    }
+  }
+  if (!upstreamPath.startsWith("/")) return `${normalized}/${upstreamPath}`;
+  return `${normalized}${upstreamPath}`;
+}
+
+interface TestResult {
+  latencyMs: number;
+}
+
+/** Send a real test request to the upstream provider */
+function sendTestRequest(
+  fullUrl: string,
+  apiType: string,
+  apiKey: string,
+  authHeaderKey: string,
+  reqBody: Record<string, unknown>,
+): Promise<TestResult> {
+  return new Promise((resolve, reject) => {
+    const start = Date.now();
+    const url = new URL(fullUrl);
+    const payload = JSON.stringify(reqBody);
+
+    const headers: Record<string, string> = {
+      "content-type": "application/json",
+      "accept": "application/json",
+      "user-agent": "llm-simple-router/test-connection",
+    };
+    if (authHeaderKey === "x-api-key") {
+      headers["x-api-key"] = apiKey;
+      headers["anthropic-version"] = "2023-06-01";
+      headers["content-type"] = "application/json";
+    } else {
+      headers["authorization"] = `Bearer ${apiKey}`;
+    }
+
+    const options = {
+      hostname: url.hostname,
+      port: url.port || (url.protocol === "https:" ? HTTPS_DEFAULT_PORT : HTTP_DEFAULT_PORT),
+      path: url.pathname + url.search,
+      method: "POST",
+      headers: { ...headers, "content-length": `${Buffer.byteLength(payload)}` },
+    };
+
+    const mod = url.protocol === "https:" ? httpsRequest : httpRequest;
+    const req = mod(options, (res: import("http").IncomingMessage) => {
+      const chunks: Buffer[] = [];
+      res.on("data", (chunk: Buffer) => chunks.push(chunk));
+      res.on("end", () => {
+        const statusCode = res.statusCode ?? 0;
+        const body = Buffer.concat(chunks).toString("utf-8");
+        const latencyMs = Date.now() - start;
+
+        if (statusCode >= HTTP_SUCCESS_MIN && statusCode < HTTP_SUCCESS_MAX) {
+          resolve({ latencyMs });
+        } else {
+          // Try to extract error message from response
+          let errMsg = `HTTP ${statusCode}`;
+          try {
+            const parsed = JSON.parse(body) as Record<string, unknown>;
+            const error = parsed.error as Record<string, unknown> | undefined;
+            if (error?.message) {
+              errMsg = typeof error.message === "string" ? error.message : JSON.stringify(error.message);
+            } else if (parsed.message) {
+              errMsg = typeof parsed.message === "string" ? parsed.message : JSON.stringify(parsed.message);
+            }
+          } catch {
+            // response body is not valid JSON, keep default HTTP error
+            void 0;
+          }
+          reject(new Error(errMsg));
+        }
+      });
+      res.on("error", (err: Error) => reject(err));
+    });
+
+    req.setTimeout(TEST_REQUEST_TIMEOUT_MS, () => {
+      req.destroy();
+      reject(new Error("Connection timed out"));
+    });
+    req.on("error", (err: Error) => reject(err));
+    req.write(payload);
+    req.end();
+  });
+}

--- a/router/src/config/model-context.ts
+++ b/router/src/config/model-context.ts
@@ -90,6 +90,11 @@ export const MODEL_CONTEXT_WINDOWS: Record<string, number> = {
   "step-2-16k": 16000,
   "step-1-8k": 8000,
   "step-1-32k": 32000,
+  // 小米 MiMo
+  "mimo-v2.5-pro": 1000000,
+  "mimo-v2.5": 1000000,
+  "mimo-v2-omni": 128000,
+  "mimo-v2-pro": 128000,
   // 硅基流动
   "deepseek-ai/DeepSeek-V3.2-Exp": 128000,
   "deepseek-ai/DeepSeek-R1": 128000,

--- a/router/src/config/model-context.ts
+++ b/router/src/config/model-context.ts
@@ -148,9 +148,11 @@ export const MODEL_CAPABILITIES: Record<string, string[]> = {
   "qwen3.5-flash": ["text", "image"],
   // ── 火山引擎 ── Doubao Seed 2.0 Pro 规格：Input Text, Images, Video
   "doubao-seed-2-0-pro-260215": ["text", "image", "video"],
-  // ── 小米 MiMo ── 只有 omni 版本支持图片，pro 版本是纯文本
+  // ── 小米 MiMo ──
+  "mimo-v2.5-pro": ["text", "image"],
+  "mimo-v2.5": ["text", "image"],
   "mimo-v2-omni": ["text", "image", "audio", "video"],
-  "mimo-v2.5": ["text", "image", "audio", "video"],
+  "mimo-v2-pro": ["text"],
 }
 
 export const DEFAULT_CONTEXT_WINDOW = 200000

--- a/router/src/config/recommended.ts
+++ b/router/src/config/recommended.ts
@@ -12,8 +12,12 @@ export interface ProviderPreset {
   models: string[]
   /** 由 API handler 补充：模型名 → capabilities 映射 */
   modelCapabilities?: Record<string, string[]>
-  /** 隐藏 preset，不在 plan 下拉菜单显示，但 endpoints 生成仍遍历 */
-  hidden?: boolean
+  /** 内嵌多个 endpoint 配置（如同时提供 openai + anthropic） */
+  endpoints?: Array<{
+    apiType: 'openai' | 'openai-responses' | 'anthropic'
+    baseUrl: string
+    upstreamPath?: string
+  }>
 }
 
 export interface ProviderGroup {

--- a/router/src/proxy/proxy-core.ts
+++ b/router/src/proxy/proxy-core.ts
@@ -78,14 +78,69 @@ export function createErrorFormatter(
 // ---------- URL utilities ----------
 
 /**
- * 拼接上游 URL，自动处理 base_url 已包含 API 路径的情况。
- * 用户可能将 base_url 配置为 `https://host/v1/messages`，
- * 此时不应再追加 upstreamPath（`/v1/messages`），否则路径重复。
+ * 已知上游 API 路径后缀（不含 /v1 等版本前缀）。
+ * 用于检测 base_url 中是否已包含完整路径。
+ */
+const KNOWN_API_SUFFIXES = [
+  "/chat/completions",
+  "/messages",
+  "/responses",
+] as const;
+
+/**
+ * 拼接上游 URL，自动处理 base_url 已包含部分或完整 API 路径的情况。
+ *
+ * 兼容场景：
+ * - base_url = `https://host/v1`, upstreamPath = `/v1/chat/completions` → `https://host/v1/chat/completions`
+ * - base_url = `https://host/v1/chat/completions`, upstreamPath = `/v1/chat/completions` → `https://host/v1/chat/completions`
+ * - base_url = `https://host/chat/completions`, upstreamPath = `/v1/chat/completions` → `https://host/chat/completions`
+ * - base_url = `https://host/v1/`, upstreamPath = `/v1/chat/completions` → `https://host/v1/chat/completions`
+ * - base_url = `https://host/api/paas/v4`, upstreamPath = `/api/paas/v4/chat/completions` → `https://host/api/paas/v4/chat/completions`
  */
 export function buildUpstreamUrl(baseUrl: string, upstreamPath: string): string {
   const normalized = baseUrl.replace(/\/+$/, "");
+
+  // 1) 完全匹配：base_url 已包含完整 upstreamPath
   if (normalized.endsWith(upstreamPath)) return normalized;
+
+  // 2) 检测 base_url 是否已包含已知 API 路径后缀
+  //    例如 `https://host/v1/chat/completions` → 已包含，直接返回
+  for (const suffix of KNOWN_API_SUFFIXES) {
+    if (normalized.endsWith(suffix)) return normalized;
+  }
+
+  // 3) 从 upstreamPath 中找到 base_url 的重叠部分，只追加非重叠尾部
+  //    例如 base_url = `https://host/api/paas/v4`, upstreamPath = `/api/paas/v4/chat/completions`
+  //    → 重叠 `/api/paas/v4`，追加 `/chat/completions`
+  //    例如 base_url = `https://host/v1`, upstreamPath = `/v1/chat/completions`
+  //    → 重叠 `/v1`，追加 `/chat/completions`
+  const overlap = findPathOverlap(normalized, upstreamPath);
+  if (overlap.length > 0) {
+    const rest = upstreamPath.slice(overlap.length);
+    return `${normalized}${rest}`;
+  }
+
+  // 4) 确保拼接处有且仅有一个 /
+  if (!upstreamPath.startsWith("/")) return `${normalized}/${upstreamPath}`;
   return `${normalized}${upstreamPath}`;
+}
+
+/**
+ * 找出 base_url 末尾与 upstreamPath 开头的最长重叠路径段。
+ * 例如 base_url = `https://host/api/v4`, upstreamPath = `/api/v4/chat/completions` → 返回 `/api/v4`
+ */
+function findPathOverlap(baseUrl: string, upstreamPath: string): string {
+  // 将 upstreamPath 按 / 拆分，逐段检查是否与 baseUrl 末尾匹配
+  const segments = upstreamPath.split("/");
+  // segments[0] 是空字符串（因为 upstreamPath 以 / 开头），至少需要 2 段才有意义
+  const MIN_OVERLAP_SEGMENTS = 2;
+  for (let len = segments.length - 1; len >= MIN_OVERLAP_SEGMENTS; len--) {
+    const candidate = segments.slice(0, len).join("/");
+    if (candidate.length > 0 && baseUrl.endsWith(candidate)) {
+      return candidate;
+    }
+  }
+  return "";
 }
 
 // ---------- Header utilities ----------

--- a/router/tests/build-upstream-url.test.ts
+++ b/router/tests/build-upstream-url.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from "vitest";
+import { buildUpstreamUrl } from "../src/proxy/proxy-core.js";
+
+describe("buildUpstreamUrl", () => {
+  // --- Basic: clean base_url + standard upstreamPath ---
+  it("concatenates clean base_url with upstream path", () => {
+    expect(
+      buildUpstreamUrl("https://api.openai.com", "/v1/chat/completions"),
+    ).toBe("https://api.openai.com/v1/chat/completions");
+  });
+
+  it("concatenates clean base_url with anthropic path", () => {
+    expect(
+      buildUpstreamUrl("https://api.anthropic.com", "/v1/messages"),
+    ).toBe("https://api.anthropic.com/v1/messages");
+  });
+
+  // --- Trailing slash normalization ---
+  it("strips trailing slashes from base_url", () => {
+    expect(
+      buildUpstreamUrl("https://api.deepseek.com/", "/v1/chat/completions"),
+    ).toBe("https://api.deepseek.com/v1/chat/completions");
+  });
+
+  it("strips multiple trailing slashes", () => {
+    expect(
+      buildUpstreamUrl("https://api.deepseek.com///", "/v1/chat/completions"),
+    ).toBe("https://api.deepseek.com/v1/chat/completions");
+  });
+
+  // --- Exact match: base_url already contains full upstreamPath ---
+  it("returns base_url as-is when it ends with full upstreamPath", () => {
+    expect(
+      buildUpstreamUrl(
+        "https://api.deepseek.com/v1/chat/completions",
+        "/v1/chat/completions",
+      ),
+    ).toBe("https://api.deepseek.com/v1/chat/completions");
+  });
+
+  it("returns base_url as-is for anthropic exact match", () => {
+    expect(
+      buildUpstreamUrl(
+        "https://api.anthropic.com/v1/messages",
+        "/v1/messages",
+      ),
+    ).toBe("https://api.anthropic.com/v1/messages");
+  });
+
+  // --- /v1 prefix dedup: base_url ends with /v1 ---
+  it("deduplicates /v1 prefix when base_url ends with /v1", () => {
+    expect(
+      buildUpstreamUrl("https://api.deepseek.com/v1", "/v1/chat/completions"),
+    ).toBe("https://api.deepseek.com/v1/chat/completions");
+  });
+
+  it("deduplicates /v1 prefix for anthropic path", () => {
+    expect(
+      buildUpstreamUrl("https://api.anthropic.com/v1", "/v1/messages"),
+    ).toBe("https://api.anthropic.com/v1/messages");
+  });
+
+  // --- Known API suffix detection ---
+  it("recognizes base_url already ending with /chat/completions", () => {
+    expect(
+      buildUpstreamUrl(
+        "https://api.example.com/chat/completions",
+        "/v1/chat/completions",
+      ),
+    ).toBe("https://api.example.com/chat/completions");
+  });
+
+  it("recognizes base_url already ending with /messages", () => {
+    expect(
+      buildUpstreamUrl(
+        "https://api.example.com/v1/messages",
+        "/v1/chat/completions", // different path, but /messages already there
+      ),
+    ).toBe("https://api.example.com/v1/messages");
+  });
+
+  it("recognizes base_url already ending with /responses", () => {
+    expect(
+      buildUpstreamUrl(
+        "https://api.example.com/v1/responses",
+        "/v1/responses",
+      ),
+    ).toBe("https://api.example.com/v1/responses");
+  });
+
+  // --- Trailing slash + exact path match ---
+  it("handles trailing slash with exact path match", () => {
+    expect(
+      buildUpstreamUrl(
+        "https://api.deepseek.com/v1/chat/completions/",
+        "/v1/chat/completions",
+      ),
+    ).toBe("https://api.deepseek.com/v1/chat/completions");
+  });
+
+  // --- Custom upstream path (not standard API) ---
+  it("handles custom upstream paths", () => {
+    expect(
+      buildUpstreamUrl(
+        "https://open.bigmodel.cn/api/paas/v4",
+        "/api/paas/v4/chat/completions",
+      ),
+    ).toBe("https://open.bigmodel.cn/api/paas/v4/chat/completions");
+  });
+
+  // --- /v1 without trailing slash + standard path ---
+  it("handles /v1 trailing with slash in upstreamPath", () => {
+    expect(
+      buildUpstreamUrl("https://host/v1/", "/v1/chat/completions"),
+    ).toBe("https://host/v1/chat/completions");
+  });
+});


### PR DESCRIPTION
## Changes

- Add `mimo-v2.5-pro` and `mimo-v2.5` to `MODEL_CONTEXT_WINDOWS` (backend) with 1M context
- Add `mimo-v2-omni` and `mimo-v2-pro` context windows (128K) for completeness
- Add `mimo-v2.5` pattern to `getDefaultContextWindow()` (frontend) so presets auto-fill 1M