### PR TITLE
fix(merge-skill): fix --repo flag and --from variable scoping

### DIFF
--- a/.pi/skills/merge/merge.sh
+++ b/.pi/skills/merge/merge.sh
@@ -190,6 +190,23 @@ generate_auto_release_notes() {
 }
 
 # ════════════════════════════════════════════════════
+# 脚本级变量（phase_init 中赋值，--from 跳过时需有默认值）
+# ════════════════════════════════════════════════════
+WS_ROOT=""
+MAIN_WT=""
+BRANCH_NAME=""
+PR_NUMBER=""
+PR_TITLE=""
+PR_STATE=""
+GH_REPO="${GH_REPO:-}"
+GH_REMOTE="origin"
+LOG_FILE="${LOG_FILE:-}"
+NEW_VERSION=""
+TAG=""
+RELEASE_URL=""
+COMMIT_FILE=""
+
+# ════════════════════════════════════════════════════
 # 参数解析
 # ════════════════════════════════════════════════════
 
@@ -264,7 +281,6 @@ phase_init() {
     # 环境检测
     BRANCH_NAME=$(git -C "$WORKTREE_DIR" branch --show-current)
     WS_ROOT=$(find_workspace_root "$WORKTREE_DIR")
-
     if [[ -z "$WS_ROOT" ]]; then
         echo -e "${RED}Error: 未找到 workspace root（向上查找 .bare/ 或 .git/）${NC}"
         exit 1
@@ -277,7 +293,6 @@ phase_init() {
     fi
 
     # 自动检测 GitHub repo
-    GH_REPO="${GH_REPO:-}"
     if [[ -z "$GH_REPO" ]]; then
         local _remote_url
         _remote_url=$(git -C "$WORKTREE_DIR" remote get-url github 2>/dev/null \

--- a/.pi/skills/merge/merge.sh
+++ b/.pi/skills/merge/merge.sh
@@ -460,7 +460,8 @@ phase_post_merge_ci() {
     main_sha=$(git -C "$MAIN_WT" rev-parse "$GH_REMOTE/main")
     echo "  main SHA: $main_sha"
 
-    bash "$SCRIPT_DIR/wait-for-ci.sh" "$main_sha" || {
+    local gh_flag="${GH_REPO:+--repo $GH_REPO}"
+    bash "$SCRIPT_DIR/wait-for-ci.sh" "$main_sha" $gh_flag || {
         local wait_exit=$?
         if [[ $wait_exit -eq 3 ]]; then
             echo -e "  ${GREEN}项目无 CI workflow，跳过等待${NC}"


### PR DESCRIPTION
## Changes

- **Bug 1**: Phase 3 `wait-for-ci.sh` call missing `--repo $GH_REPO` — `gh` CLI fails when cwd is not a git repo (workspace root)
- **Bug 2**: `--from N` skips phase_init but shared variables (WS_ROOT, MAIN_WT, GH_REPO, etc.) were `local` to phase_init — unbound variable errors in subsequent phases

Both fixes are in `.pi/skills/merge/merge.sh` only.