### PR TITLE
fix(frontend): improve mapping layout and model capability icons

### DIFF
--- a/frontend/src/components/providers/ModelCapabilitiesEditor.vue
+++ b/frontend/src/components/providers/ModelCapabilitiesEditor.vue
@@ -11,7 +11,14 @@ import {
   SelectContent,
   SelectItem,
 } from "@/components/ui/select";
-import { ChevronRight, RotateCw } from "lucide-vue-next";
+import {
+  ChevronRight,
+  RotateCw,
+  Type,
+  ImageIcon,
+  Volume2,
+  Video,
+} from "lucide-vue-next";
 import ModelCard from "@/components/quick-setup/ModelCard.vue";
 import TransformRulesForm from "@/components/shared/TransformRulesForm.vue";
 import ProxyConfigForm from "@/components/shared/ProxyConfigForm.vue";
@@ -31,10 +38,10 @@ const advancedOpen = ref(false);
 const newCapabilities = ref<string[]>(["text"]);
 
 const capabilityIcons = [
-  { key: "text", icon: "T", label: "text" },
-  { key: "image", icon: "IMG", label: "image" },
-  { key: "audio", icon: "AUD", label: "audio" },
-  { key: "video", icon: "VID", label: "video" },
+  { key: "text", icon: Type, label: "text" },
+  { key: "image", icon: ImageIcon, label: "image" },
+  { key: "audio", icon: Volume2, label: "audio" },
+  { key: "video", icon: Video, label: "video" },
 ] as const;
 
 function toggleNewCapability(key: string) {
@@ -331,7 +338,7 @@ function isOfficialOpenai(url: string): boolean {
             :title="cap.label"
             @click="toggleNewCapability(cap.key)"
           >
-            {{ cap.icon }}
+            <component :is="cap.icon" class="size-[11px]" />
           </Button>
         </div>
         <Button

--- a/frontend/src/components/shared/QuickSetupMappingList.vue
+++ b/frontend/src/components/shared/QuickSetupMappingList.vue
@@ -4,7 +4,7 @@ import { useI18n } from "vue-i18n";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
-import { ArrowRight, Plus } from "lucide-vue-next";
+import { ArrowRight, Plus, Grid3x3 } from "lucide-vue-next";
 import MappingEntryEditor from "@/components/mappings/MappingEntryEditor.vue";
 import CascadingModelSelect from "@/components/mappings/CascadingModelSelect.vue";
 import type {
@@ -32,7 +32,11 @@ const emit = defineEmits<{
   ];
   "update:client-model": [index: number, clientModel: string];
   "toggle-active": [index: number];
-  add: [clientModel: string, targetModel: string];
+  add: [
+    clientModel: string,
+    targetModel: string,
+    multimodalFallback?: MultimodalFallback,
+  ];
   remove: [clientModel: string];
 }>();
 
@@ -46,18 +50,31 @@ function toggleExpand(clientModel: string) {
 
 const newFrom = ref("");
 const newToValue = ref<SelectedValue | undefined>();
+const newMultimodalValue = ref<SelectedValue | undefined>();
+const showMultimodal = ref(false);
 
 function canAdd(): boolean {
   return newFrom.value.trim().length > 0 && !!newToValue.value?.model;
+}
+
+function buildMultimodalFallback(): MultimodalFallback | undefined {
+  if (!showMultimodal.value || !newMultimodalValue.value?.model)
+    return undefined;
+  return {
+    provider_id: newMultimodalValue.value.provider_id,
+    backend_model: newMultimodalValue.value.model,
+  };
 }
 
 function addMapping() {
   const from = newFrom.value.trim();
   const to = newToValue.value;
   if (from && to) {
-    emit("add", from, to.model);
+    emit("add", from, to.model, buildMultimodalFallback());
     newFrom.value = "";
     newToValue.value = undefined;
+    newMultimodalValue.value = undefined;
+    showMultimodal.value = false;
   }
 }
 
@@ -109,39 +126,81 @@ function handleKeydown(e: KeyboardEvent) {
 
     <!-- Add new mapping row -->
     <div
-      class="flex items-center gap-3 rounded-md border border-dashed border-border px-3 py-2"
+      class="rounded-md border border-dashed border-border px-3 py-2 space-y-1.5"
     >
-      <Input
-        v-model="newFrom"
-        :placeholder="t('providers.shared.clientModel')"
-        class="h-7 min-w-[140px] text-xs font-mono border-border"
-        @keydown="handleKeydown"
-      />
-      <ArrowRight class="size-3.5 shrink-0 text-muted-foreground/30" />
-      <div class="flex-1 min-w-0">
-        <CascadingModelSelect
-          :providers="providerGroups"
-          :model-value="newToValue"
-          compact
-          :placeholder="t('providers.shared.selectModel')"
-          @update:model-value="(v: SelectedValue) => (newToValue = v)"
+      <div class="flex items-center gap-2">
+        <Input
+          v-model="newFrom"
+          :placeholder="t('providers.shared.clientModel')"
+          class="h-7 flex-1 min-w-0 text-xs font-mono border-border"
+          @keydown="handleKeydown"
         />
+        <ArrowRight class="size-3.5 shrink-0 text-muted-foreground/30" />
+        <div class="flex-[2] min-w-0">
+          <CascadingModelSelect
+            :providers="providerGroups"
+            :model-value="newToValue"
+            compact
+            :placeholder="t('providers.shared.selectModel')"
+            @update:model-value="(v: SelectedValue) => (newToValue = v)"
+          />
+        </div>
+        <Badge
+          variant="outline"
+          class="text-[10px] shrink-0 text-muted-foreground/50"
+        >
+          {{ t("providers.shared.tagCustom") }}
+        </Badge>
+        <Button
+          variant="outline"
+          size="icon-xs"
+          class="shrink-0"
+          :disabled="!canAdd()"
+          @click="addMapping"
+        >
+          <Plus class="size-3" />
+        </Button>
       </div>
-      <Badge
-        variant="outline"
-        class="text-[10px] shrink-0 text-muted-foreground/50"
-      >
-        {{ t("providers.shared.tagCustom") }}
-      </Badge>
-      <Button
-        variant="outline"
-        size="icon-xs"
-        class="shrink-0"
-        :disabled="!canAdd()"
-        @click="addMapping"
-      >
-        <Plus class="size-3" />
-      </Button>
+
+      <!-- Multimodal fallback (optional) -->
+      <div class="flex items-center gap-2">
+        <Button
+          type="button"
+          variant="ghost"
+          size="xs"
+          class="text-[10px] text-blue-500/60 hover:text-blue-500"
+          @click="showMultimodal = !showMultimodal"
+        >
+          <Grid3x3 class="size-3 mr-1" />
+          {{
+            showMultimodal
+              ? t("mappings.multimodalFallback.collapse")
+              : t("mappings.multimodalFallback.add")
+          }}
+        </Button>
+        <div
+          v-if="showMultimodal"
+          class="flex items-center gap-2 flex-1 min-w-0"
+        >
+          <span class="text-[10px] text-blue-500/50 shrink-0">
+            <Grid3x3 class="size-2.5" />
+          </span>
+          <div class="flex-1 min-w-0">
+            <CascadingModelSelect
+              :providers="providerGroups"
+              :model-value="newMultimodalValue"
+              compact
+              dashed
+              :placeholder="
+                t('mappings.multimodalFallback.selectProviderModel')
+              "
+              @update:model-value="
+                (v: SelectedValue) => (newMultimodalValue = v)
+              "
+            />
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 </template>

--- a/frontend/src/composables/quick-setup-actions.ts
+++ b/frontend/src/composables/quick-setup-actions.ts
@@ -192,7 +192,11 @@ export function useQuickSetupActions(ctx: ActionCtx) {
       i === index ? { ...e, multimodalFallback: fb } : e,
     );
   };
-  const addMappingEntry = (clientModel: string, targetModel: string) => {
+  const addMappingEntry = (
+    clientModel: string,
+    targetModel: string,
+    multimodalFallback?: MultimodalFallback,
+  ) => {
     ctx.data.mappingEntries.value = [
       ...ctx.data.mappingEntries.value.filter(
         (m) => m.clientModel !== clientModel,
@@ -200,6 +204,7 @@ export function useQuickSetupActions(ctx: ActionCtx) {
       {
         clientModel,
         targets: [{ backend_model: targetModel, provider_id: "__new__" }],
+        ...(multimodalFallback ? { multimodalFallback } : {}),
         existing: false,
         tag: "cust" as const,
         active: true,

--- a/frontend/src/i18n/locales/en/mappings.json
+++ b/frontend/src/i18n/locales/en/mappings.json
@@ -67,6 +67,7 @@
   "multimodalFallback": {
   "title": "Multimodal Fallback",
   "add": "Add Multimodal Fallback",
+  "collapse": "Collapse multimodal",
   "configured": "Configured",
   "selectProvider": "Select Provider",
   "modelPlaceholder": "Model name (e.g. gpt-4o)",

--- a/frontend/src/i18n/locales/zh-CN/mappings.json
+++ b/frontend/src/i18n/locales/zh-CN/mappings.json
@@ -67,6 +67,7 @@
   "multimodalFallback": {
   "title": "多模态 Fallback",
   "add": "添加多模态 Fallback",
+  "collapse": "收起多模态",
   "configured": "已配置",
   "selectProvider": "选择供应商",
   "modelPlaceholder": "模型名称（如 gpt-4o）",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1005,6 +1005,7 @@
       "resolved": "https://registry.npmmirror.com/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1561,6 +1562,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -1584,6 +1586,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -3357,6 +3360,7 @@
       "resolved": "https://registry.npmmirror.com/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
       "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -3438,6 +3442,7 @@
       "resolved": "https://registry.npmmirror.com/@noble/ciphers/-/ciphers-1.3.0.tgz",
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -5221,6 +5226,7 @@
       "integrity": "sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.1",
         "@typescript-eslint/types": "8.59.1",
@@ -5619,6 +5625,7 @@
       "resolved": "https://registry.npmmirror.com/@vue/compiler-dom/-/compiler-dom-3.5.33.tgz",
       "integrity": "sha512-PXq0yrfCLzzL07rbXO4awtXY1Z06LG2eu6Adg3RJFa/j3Cii217XxxLXG22N330gw7GmALCY0Z8RgXEviwgpjA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-core": "3.5.33",
         "@vue/shared": "3.5.33"
@@ -5742,6 +5749,7 @@
       "resolved": "https://registry.npmmirror.com/@vue/server-renderer/-/server-renderer-3.5.33.tgz",
       "integrity": "sha512-0xylq/8/h44lVG0pZFknv1XIdEgymq2E9n59uTWJBG+dIgiT0TMCSsxrN7nO16Z0MU0MPjFcguBbZV8Itk52Hw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-ssr": "3.5.33",
         "@vue/shared": "3.5.33"
@@ -5881,6 +5889,7 @@
       "resolved": "https://registry.npmmirror.com/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6386,6 +6395,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -6594,6 +6604,7 @@
       "resolved": "https://registry.npmmirror.com/chart.js/-/chart.js-4.5.1.tgz",
       "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@kurkle/color": "^0.3.0"
       },
@@ -7732,6 +7743,7 @@
       "resolved": "https://registry.npmmirror.com/eslint/-/eslint-10.3.0.tgz",
       "integrity": "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -9104,6 +9116,7 @@
       "resolved": "https://registry.npmmirror.com/hono/-/hono-4.12.16.tgz",
       "integrity": "sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -9548,6 +9561,7 @@
       "resolved": "https://registry.npmmirror.com/jiti/-/jiti-2.6.1.tgz",
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -9782,6 +9796,7 @@
       "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@asamuzakjp/css-color": "^5.1.11",
         "@asamuzakjp/dom-selector": "^7.1.1",
@@ -9848,6 +9863,7 @@
       "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mdn-data": "2.27.1",
         "source-map-js": "^1.2.1"
@@ -10168,6 +10184,7 @@
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "dev": true,
       "license": "MPL-2.0",
+      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.3"
       },
@@ -11602,6 +11619,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -13371,6 +13389,7 @@
       "resolved": "https://registry.npmmirror.com/stylus/-/stylus-0.57.0.tgz",
       "integrity": "sha512-yOI6G8WYfr0q8v8rRvE91wbxFU+rJPo760Va4MF6K0I6BZjO4r+xSynkvyPBP9tV1CIEUeRsiidjIs2rzb1CnQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "css": "^3.0.0",
         "debug": "^4.3.2",
@@ -13670,6 +13689,7 @@
       "resolved": "https://registry.npmmirror.com/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -14077,6 +14097,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -14098,6 +14119,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14114,6 +14136,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14130,6 +14153,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14146,6 +14170,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14162,6 +14187,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14178,6 +14204,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14194,6 +14221,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14210,6 +14238,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14226,6 +14255,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14242,6 +14272,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14258,6 +14289,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14274,6 +14306,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14290,6 +14323,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14306,6 +14340,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14322,6 +14357,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14338,6 +14374,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14354,6 +14391,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14370,6 +14408,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14386,6 +14425,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14402,6 +14442,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14418,6 +14459,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14434,6 +14476,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14450,6 +14493,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14466,6 +14510,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14482,6 +14527,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14498,6 +14544,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14612,6 +14659,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -14809,6 +14857,7 @@
       "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -16084,6 +16133,7 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -16165,6 +16215,7 @@
       "resolved": "https://registry.npmmirror.com/vue/-/vue-3.5.33.tgz",
       "integrity": "sha512-1AgChhx5w3ALgT4oK3acm2Es/7jyZhWSVUfs3rOBlGQC0rjEDkS7G4lWlJJGGNQD+BV3reCwbQrOe1mPNwKHBQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.33",
         "@vue/compiler-sfc": "3.5.33",
@@ -16702,6 +16753,7 @@
       "integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
       "devOptional": true,
       "license": "ISC",
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -16851,6 +16903,7 @@
       "resolved": "https://registry.npmmirror.com/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
## 修复内容

### 1. 添加映射行布局优化
- 客户端模型 Input 从 min-w-[140px] 改为 flex-1 min-w-0
- 目标模型 CascadingModelSelect 从 flex-1 改为 flex-[2]
- 两者比例更均衡，Select 不再被 Input 挤压

### 2. 添加映射行内置多模态 Fallback
- 新增可展开的 Grid3x3 按钮，展开后显示多模态 fallback 选择器
- add 事件新增第三个可选参数 multimodalFallback
- quick-setup-actions.ts 的 addMappingEntry 同步支持

### 3. 供应商编辑 Modal 能力按钮改用图标
- ModelCapabilitiesEditor 的能力按钮从文字 T/IMG/AUD/VID 改为 lucide 图标
- 与 ModelCard 组件的视觉风格保持一致

### 变更文件
- frontend/src/components/shared/QuickSetupMappingList.vue
- frontend/src/components/providers/ModelCapabilitiesEditor.vue
- frontend/src/composables/quick-setup-actions.ts
- frontend/src/i18n/locales/zh-CN/mappings.json
- frontend/src/i18n/locales/en/mappings.json
