### PR TITLE
perf: request_logs 增加 backend_model 列 + 日志页面模型筛选性能优化

### DIFF
--- a/.pi/skills/pull-request/SKILL.md
+++ b/.pi/skills/pull-request/SKILL.md
@@ -69,14 +69,23 @@ else
 fi
 ```
 
-### 6. 确认 PR 状态
+### 6. 等待 CI 并确认结果 [MANDATORY]
+
+PR 创建后必须等待 CI 全部完成并确认通过。使用轮询脚本：
 
 ```bash
-gh pr view --json statusCheckRollup \
-  --jq '[.statusCheckRollup[] | .name + ": " + (.conclusion // "pending")] | .[]'
+# 用法: PR 编号作为参数，或省略则自动检测当前分支的 PR
+bash .pi/skills/pull-request/wait-ci.sh [PR_NUMBER]
 ```
 
-如有 check 立即失败（非 pending/queued），分析原因并修复。
+脚本行为：
+- 每 30 秒轮询一次 CI 状态
+- 所有 check 都达到终态（success/failure/cancelled/timed_out）后退出
+- 全部 success → 退出码 0
+- 任一失败 → 退出码 1，并打印失败项
+- 超时 10 分钟 → 退出码 2
+
+如有 check 失败，分析原因并修复后重新 push。
 
 ## Pre-merge 验证详情
 

--- a/.pi/skills/pull-request/wait-ci.sh
+++ b/.pi/skills/pull-request/wait-ci.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# 等待 PR 的 CI checks 全部完成
+# 用法: bash wait-ci.sh [PR_NUMBER]
+# 退出码: 0=全部成功, 1=有失败, 2=超时
+set -euo pipefail
+
+POLL_INTERVAL=30
+MAX_WAIT=600  # 10 分钟
+
+# 获取 PR 编号
+if [ $# -ge 1 ]; then
+  PR_NUMBER="$1"
+else
+  BRANCH=$(git branch --show-current)
+  PR_NUMBER=$(gh pr list --head "$BRANCH" --json number --jq '.[0].number' 2>/dev/null || true)
+  if [ -z "$PR_NUMBER" ]; then
+    echo "❌ 未找到当前分支 ($BRANCH) 对应的 PR"
+    exit 1
+  fi
+fi
+
+echo "⏳ 等待 PR #$PR_NUMBER 的 CI checks（每 ${POLL_INTERVAL}s 轮询，超时 ${MAX_WAIT}s）"
+
+elapsed=0
+while [ $elapsed -lt $MAX_WAIT ]; do
+  # 获取所有 check 的 name|conclusion 对（conclusion 为 null 时输出 "pending"）
+  checks=$(gh pr view "$PR_NUMBER" --json statusCheckRollup \
+    --jq '[.statusCheckRollup[]? | .name + "|" + ((.conclusion // "pending") | tostring)] | join("\n")' 2>/dev/null || echo "")
+
+  if [ -z "$checks" ]; then
+    echo "[${elapsed}s] 无 CI checks，可能尚未触发，继续等待..."
+    sleep "$POLL_INTERVAL"
+    elapsed=$((elapsed + POLL_INTERVAL))
+    continue
+  fi
+
+  total=$(echo "$checks" | wc -l | tr -d ' ')
+
+  # 用 awk 统计各状态
+  stats=$(echo "$checks" | awk -F'|' '
+    {
+      total++
+      if ($2 == "success" || $2 == "SUCCESS") ok++
+      else if ($2 == "skipped" || $2 == "SKIPPED" || $2 == "cancelled" || $2 == "CANCELLED") ok++
+      else if ($2 == "pending" || $2 == "queued" || $2 == "in_progress" || $2 == "null" || $2 == "") wait++
+      else fail++
+    }
+    END {
+      printf "%d %d %d %d", total, (ok+0), (wait+0), (fail+0)
+    }')
+  read -r ok_count wait_count fail_count _ <<< "$(echo "$stats" | awk '{print $2, $3, $4}')"
+  # 重新计算：stats 格式是 "total ok wait fail"
+  read -r total_count ok_count wait_count fail_count <<< "$stats"
+
+  echo "[${elapsed}s] 总计: $total_count, 通过: $ok_count, 等待中: $wait_count, 失败: $fail_count"
+
+  # 还有未完成的 check
+  if [ "$wait_count" -gt 0 ] 2>/dev/null; then
+    echo "$checks" | awk -F'|' '$2 ~ /pending|queued|in_progress|null/' | while IFS='|' read -r name status; do
+      echo "  ⏳ $name: $status"
+    done
+    sleep "$POLL_INTERVAL"
+    elapsed=$((elapsed + POLL_INTERVAL))
+    continue
+  fi
+
+  # 所有 check 都已完成
+  if [ "$fail_count" -eq 0 ] 2>/dev/null; then
+    echo "✅ 所有 CI checks 通过 ($ok_count/$total_count)"
+    exit 0
+  else
+    echo "❌ 部分 CI checks 失败:"
+    echo "$checks" | awk -F'|' '$2 !~ /success|pending|queued|in_progress|null/' | while IFS='|' read -r name status; do
+      echo "  ✗ $name: $status"
+    done
+    echo ""
+    echo "查看详情: gh pr view $PR_NUMBER --web"
+    exit 1
+  fi
+done
+
+echo "❌ 等待超时 (${MAX_WAIT}s)，CI 未完成"
+echo "手动查看: gh pr view $PR_NUMBER --json statusCheckRollup --jq '.statusCheckRollup[] | .name + \": \" + (.conclusion // .status // \"pending\")'"
+exit 2

--- a/docs/api-performance-analysis.md
+++ b/docs/api-performance-analysis.md
@@ -1,0 +1,279 @@
+# Admin API 性能分析
+
+测试日期：2026-06-08
+环境：NUC5 Docker, SQLite
+数据规模：request_logs ~1480 行, request_metrics ~216K 行, usage_windows ~240 行
+
+## request_logs.backend_model 两阶段迁移
+
+### 第一阶段（当前版本 v1.x）：写入
+
+- DB 迁移 `054`：`ALTER TABLE request_logs ADD COLUMN backend_model TEXT`
+- 所有 `insertRequestLog` 调用点传入 `backend_model`（从 `resolved.backend_model` 或 `attempt.target.backend_model`）
+- **读取路径不变**：
+  - 日志列表 `LOG_LIST_SELECT` 仍通过 `JOIN request_metrics` 获取 `backend_model`
+  - 日志筛选 `buildLogWhereClause` 仍通过子查询 `request_metrics` 过滤（已改为 `= ?` 精确匹配 + 索引）
+  - 前端 `loadModelOptions` 从 `mapping_groups` 获取 client_model / backend_model
+
+### 第二阶段（下一版本 v2.x）：读取
+
+**触发条件**：部署后运行 ≥7 天，确保历史日志的 `request_logs.backend_model` 大部分已填充。
+
+待完成项：
+1. `LOG_LIST_SELECT` 去掉 `JOIN request_metrics`，改为 `rl.backend_model`
+2. `buildLogWhereClause` 的 backend_model 过滤改为 `WHERE rl.backend_model = ?`
+3. `LOG_LIST_JOIN` 可考虑去掉 `LEFT JOIN request_metrics rm`（如果其他字段如 input_tokens 等也迁到 request_logs）
+4. 前端 `loadModelOptions` 改为从 `SELECT DISTINCT backend_model FROM request_logs` 取（或专用 API）
+5. 性能对比测试确认无回退
+
+## 风险排名
+
+| 优先级 | 风险 | 端点 | 耗时 | 根因 |
+|--------|------|------|------|------|
+| **P0** | HIGH | `GET /admin/api/usage/windows` | 597ms | N+1：240 窗口 × request_metrics 聚合 |
+| **P0** | HIGH | `GET /admin/api/metrics/summary?period=7d` | 486ms | 两次全表扫描串行（summary + breakdown） |
+| **P0** | HIGH | `GET /admin/api/metrics/timeseries?period=30d` | 1760ms | 179K 行回表计算 AVG(ttft) |
+| **P0** | HIGH | `GET /admin/api/metrics/summary?period=30d` | 1760ms | 同上，已修复前端调用侧 |
+| **P1** | MEDIUM | `GET /admin/api/monitor/active` | 317ms | 2.7MB JSON（携带完整请求体） |
+| **P1** | MEDIUM | `GET /admin/api/monitor/recent` | 67ms | 1.2MB JSON（同上） |
+| **P1** | MEDIUM | `GET /admin/api/settings/db-size` | 350-560ms | calcDirSize 遍历 12500 个文件 |
+| **P2** | MEDIUM | `GET /admin/api/metrics/timeseries?period=7d` | 79-143ms | 46K 行扫描 + 计算列 GROUP BY |
+| **P2** | MEDIUM | `GET /admin/api/usage/monthly` | 163ms | 46K 行 + GROUP BY date() |
+| **P2** | MEDIUM | `GET /admin/api/logs?backend_model=xxx` | 391ms | LIKE '%xxx%' 全表扫描 metrics |
+| **P2** | MEDIUM | `GET /admin/api/stats?period=weekly` | 103ms | 46K 行聚合 |
+| **P3** | MEDIUM | `GET /admin/api/providers` (偶发) | 340ms 抖动 | N+1 provider_model_info |
+| LOW | — | 其余所有 CRUD 端点 | 5-25ms | 无问题 |
+
+## 核心结论
+
+1. **request_metrics (21.6万行) 是唯一的大表**，所有 HIGH 风险都源于它
+2. **增长速度**：~5000 行/天，6 个月后约 110 万行，MEDIUM 级问题会升级为 HIGH
+3. **根本解决方案**：新建 `metrics_daily` 预聚合表，>7天查询走聚合表
+
+---
+
+## 1. 日志与监控类
+
+### [LOW] GET /admin/api/logs（flat 视图）
+
+- 耗时：16ms（curl 端到端）
+- SQL：`SELECT ... FROM request_logs rl LEFT JOIN providers p LEFT JOIN request_metrics rm WHERE 1=1 ORDER BY rl.created_at DESC LIMIT 20`
+- 索引：`idx_request_logs_created_at`（DESC SCAN，LIMIT 20 早停）
+- 无问题
+
+### [LOW] GET /admin/api/logs（grouped 视图）
+
+- 耗时：13ms（curl 端到端）
+- SQL：CTE `page_ids` + 子查询 `child_count`
+- 索引：`idx_logs_original_time`（original_request_id + created_at DESC）
+- 无问题
+
+### [MEDIUM] GET /admin/api/logs?backend_model=xxx
+
+- 耗时：391ms（curl 端到端），COUNT 查询 235ms
+- SQL：`WHERE rl.id IN (SELECT request_log_id FROM request_metrics WHERE backend_model LIKE '%xxx%')`
+- EXPLAIN：`SCAN request_metrics`（全表扫描 216K 行）
+- 问题：`backend_model LIKE '%xxx%'` 前缀通配符无法利用 B-tree 索引，且子查询执行两次（COUNT + 数据）
+- 建议：前端改为精确匹配（下拉选择具体值），或加 `request_metrics(backend_model)` 索引配合前缀匹配
+
+### [LOW] GET /admin/api/logs/:id
+
+- 耗时：<1ms，主键查询
+- 无问题
+
+### [LOW] GET /admin/api/logs/:id/children
+
+- 走 `idx_logs_original_time` 索引，无问题
+
+### [LOW] DELETE /admin/api/logs/before
+
+- 分批删除 + incremental_vacuum，日志量小无问题
+
+### [LOW] GET /admin/api/stats?period=window
+
+- 耗时：8ms，COVERING INDEX 命中
+- 无问题
+
+### [MEDIUM] GET /admin/api/stats?period=weekly
+
+- 耗时：103ms
+- 扫描 ~46421 行，5 个聚合值
+- 当前可接受，随 metrics 增长会线性恶化
+
+### [LOW] GET /admin/api/stats?period=monthly
+
+- 耗时：72ms，COVERING INDEX 效率更高
+- 无问题
+
+### [HIGH] GET /admin/api/metrics/summary?period=7d
+
+- 耗时：486ms（curl），其中 summary 查询 349ms + client_type_breakdown 149ms
+- 两个查询串行执行，合计扫描 ~92K 行，条件完全相同
+- EXPLAIN：`idx_metrics_created_at_router_key` 不覆盖 GROUP BY 列，需 TEMP B-TREE
+- 建议：合并为单次查询，JS 层聚合 client_type_breakdown，省掉第二次全表扫描
+
+### [HIGH] GET /admin/api/metrics/summary?period=30d
+
+- 耗时：1760ms（curl），扫描 179K 行
+- 前端已修复：Logs 页面改用 `getMappingGroups()` 提取 model 列表
+
+### [HIGH] GET /admin/api/metrics/timeseries?period=30d
+
+- 耗时：1760ms（SQL 层）
+- SQL：`AVG(rm.ttft_ms)` 需回表取 ttft_ms，索引不覆盖
+- 建议：预聚合表或限制前端最大查询范围
+
+### [MEDIUM] GET /admin/api/metrics/timeseries?period=7d
+
+- 耗时：79-143ms
+- COVERING INDEX 命中但数据量仍大（46K 行）
+
+### [MEDIUM] GET /admin/api/monitor/active
+
+- 耗时：317ms，响应体 2.7MB
+- 数据来源：内存 Map，无 DB 查询
+- 问题：每个 active request 携带完整 clientRequest（263KB）、upstreamRequest（285KB）、streamContent（49KB）
+- 建议：列表 API 剥离大字段，详情 API `/monitor/request/:id` 保留
+
+### [MEDIUM] GET /admin/api/monitor/recent
+
+- 耗时：67ms，响应体 1.2MB
+- 同 active，建议剥离大字段
+
+### [LOW] GET /admin/api/monitor/stats|concurrency|runtime
+
+- 耗时：4-6ms，内存操作
+- 无问题
+
+---
+
+## 2. 仪表盘与用量类
+
+### [HIGH] GET /admin/api/usage/windows（无参数）
+
+- 耗时：597ms
+- N+1 查询：先取 240 个窗口，再对每个窗口执行 `SELECT COUNT(*), SUM(...) FROM request_metrics WHERE provider_id = ? AND created_at >= ? AND created_at < ?`
+- 240 次 × ~2ms = ~486ms
+- 无参数时 `resolveTimeRange` 走 startTime="1970-01-01", endTime="2099-12-31"，拉出全部窗口
+- 建议：
+  1. 限制默认范围（最近 24 个窗口）
+  2. 改为窗口内嵌子查询或 CTE，消除 N+1
+
+### [MEDIUM] GET /admin/api/metrics/timeseries?period=weekly&metric=input_tokens
+
+- 耗时：303ms
+- 扫描 ~42536 行，GROUP BY 计算列 `(unixepoch(created_at)/N)*N` 无法走索引
+- 6 个月后预计 1.5-2s
+
+### [MEDIUM] GET /admin/api/usage/monthly
+
+- 耗时：163ms
+- 扫描 ~46469 行，`GROUP BY date(created_at)` 计算列需 TEMP B-TREE
+
+### [LOW] GET /admin/api/upgrade/status
+
+- 耗时：5ms，内存 + 单行 DB
+- 无问题
+
+### [LOW] GET /admin/api/recommended/providers
+
+- 耗时：8ms，纯内存操作
+- 无问题
+
+---
+
+## 3. CRUD 配置类
+
+### [MEDIUM] GET /admin/api/settings/db-size
+
+- 耗时：350-560ms
+- `calcDirSize()` 递归遍历 12500+ 个日志文件（`readdirSync` + `statSync`）
+- 建议：缓存结果 5-10 分钟
+
+### [LOW] GET /admin/api/providers
+
+- 耗时：8-10ms（偶发 340ms 抖动，疑似 WAL checkpoint）
+- N+1：每个 provider 查一次 `provider_model_info`（8+1=9 次 SQL）
+- 列表接口返回完整 api_key 明文（含解密开销）
+- 建议：合并为一条 SQL；列表返回 `api_key_preview`
+
+### [LOW] 其余 CRUD 端点
+
+- providers/mappings/groups/retry-rules/router-keys/settings/transform-rules
+- 全部 5-25ms，小表无性能问题
+
+---
+
+## 优化方案（按投入产出比排序）
+
+### P0：消除 /usage/windows 的 N+1
+
+当前：240 次循环查询 request_metrics
+方案：限制默认查询范围（最近 24 窗口）+ 窗口内嵌子查询
+预期：597ms → <50ms
+复杂度：低
+
+### P0：合并 metrics/summary 的双查询
+
+当前：getMetricsSummary() 和 getClientTypeBreakdown() 条件相同，串行两次扫描
+方案：单次查询，JS 层从 summary 结果聚合 client_type_breakdown
+预期：省 ~150ms
+复杂度：低
+
+### P1：monitor/active + recent 剥离大字段
+
+当前：列表 API 返回完整请求体（2.7MB）
+方案：列表只返回元数据，详情 API `/monitor/request/:id` 保留完整数据
+预期：2.7MB → <5KB，317ms → <10ms
+复杂度：低
+
+### P1：calcDirSize 加缓存
+
+当前：每次调用遍历 12500 个文件
+方案：结果缓存 5-10 分钟
+预期：350ms → <5ms
+复杂度：极低
+
+### P2：request_metrics 预聚合表（根本方案）
+
+新建 `metrics_daily` 预聚合表：
+
+```sql
+CREATE TABLE metrics_daily (
+  bucket_date TEXT,
+  provider_id TEXT,
+  backend_model TEXT,
+  api_type TEXT,
+  request_count INTEGER,
+  avg_ttft_ms REAL,
+  total_input_tokens INTEGER,
+  total_output_tokens INTEGER,
+  total_cache_read_tokens INTEGER,
+  total_duration_ms INTEGER,
+  PRIMARY KEY (bucket_date, provider_id, backend_model)
+);
+```
+
+> 7 天查询走聚合表，7 天内仍从明细表实时计算。
+> 所有 weekly/monthly/30d 查询受益。
+> 预期：所有 >100ms 的 metrics 查询降至 <20ms。
+> 复杂度：中（需定时刷新逻辑 + 迁移）
+
+### P3：backend_model 过滤改精确匹配
+
+前端 Logs 页面 backend_model 筛选改为下拉选择具体值，避免 `LIKE '%xxx%'` 全表扫描。
+复杂度：极低
+
+---
+
+## request_metrics 现有索引
+
+| 索引名 | 列 |
+|--------|-----|
+| `idx_metrics_time_provider_model` | `(created_at, provider_id, backend_model)` |
+| `idx_metrics_api_type_created_at` | `(api_type, created_at)` |
+| `idx_metrics_router_key` | `(router_key_id)` |
+| `idx_metrics_created_at_router_key` | `(created_at, router_key_id)` |
+| `idx_metrics_agg` | `(is_complete, created_at DESC, provider_id, backend_model)` |
+
+问题：`idx_metrics_agg` 以 `is_complete` 开头，metrics/summary 不过滤 is_complete 导致无法使用。考虑新建 `(created_at DESC, provider_id, backend_model, client_type)` 使 GROUP BY 走索引。

--- a/frontend/src/composables/useLogFilters.ts
+++ b/frontend/src/composables/useLogFilters.ts
@@ -5,6 +5,16 @@ import { api, getApiMessage } from "@/api/client";
 import type { Provider, Rule } from "@/types/mapping";
 import { toIsoStart, toIsoEnd } from "@/utils/format";
 
+/** 安全解析 mapping group 的 rule JSON，格式异常返回 null */
+function parseRuleJson(rule: string): Rule | null {
+  try {
+    return JSON.parse(rule) as Rule;
+  } catch {
+    /* rule JSON 格式异常，跳过该映射组 */
+    return null;
+  }
+}
+
 const PERIODS = [
   { label: "1h", value: "1h" },
   { label: "5h", value: "5h" },
@@ -104,13 +114,11 @@ export function useLogFilters() {
       const backendSet = new Set<string>();
       for (const g of groups) {
         if (g.client_model) clientSet.add(g.client_model);
-        try {
-          const rule: Rule = JSON.parse(g.rule);
+        const rule: Rule | null = parseRuleJson(g.rule);
+        if (rule) {
           for (const t of rule.targets ?? []) {
             if (t.backend_model) backendSet.add(t.backend_model);
           }
-        } catch {
-          /* rule 格式异常，跳过 */
         }
       }
       clientModelOptions.value = [...clientSet].sort();

--- a/frontend/src/composables/useLogFilters.ts
+++ b/frontend/src/composables/useLogFilters.ts
@@ -2,7 +2,7 @@ import { ref, computed, onMounted } from "vue";
 import { toast } from "vue-sonner";
 import { useI18n } from "vue-i18n";
 import { api, getApiMessage } from "@/api/client";
-import type { Provider } from "@/types/mapping";
+import type { Provider, Rule } from "@/types/mapping";
 import { toIsoStart, toIsoEnd } from "@/utils/format";
 
 const PERIODS = [
@@ -96,18 +96,25 @@ export function useLogFilters() {
     }
   }
 
+  /** 从映射组提取 client_model 和 backend_model 列表，避免扫描 metrics 大表 */
   async function loadModelOptions() {
     try {
-      const [summaryResult, availableModels] = await Promise.allSettled([
-        api.getMetricsSummary({ period: "30d" }),
-        api.getAvailableModels(),
-      ]);
-      clientModelOptions.value =
-        availableModels.status === "fulfilled" ? availableModels.value : [];
-      backendModelOptions.value =
-        summaryResult.status === "fulfilled"
-          ? [...new Set(summaryResult.value.rows.map((r) => r.backend_model))]
-          : [];
+      const groups = await api.getMappingGroups();
+      const clientSet = new Set<string>();
+      const backendSet = new Set<string>();
+      for (const g of groups) {
+        if (g.client_model) clientSet.add(g.client_model);
+        try {
+          const rule: Rule = JSON.parse(g.rule);
+          for (const t of rule.targets ?? []) {
+            if (t.backend_model) backendSet.add(t.backend_model);
+          }
+        } catch {
+          /* rule 格式异常，跳过 */
+        }
+      }
+      clientModelOptions.value = [...clientSet].sort();
+      backendModelOptions.value = [...backendSet].sort();
     } catch (e: unknown) {
       console.error("useLogFilters.loadModelOptions:", e);
       clientModelOptions.value = [];

--- a/router/src/db/logs.ts
+++ b/router/src/db/logs.ts
@@ -98,6 +98,7 @@ export interface RequestLogInsert {
   upstream_api_type?: string | null;
   upstream_base_url?: string | null;
   thinking_level?: string;
+  backend_model?: string | null;
 }
 
 export interface LogWriteContext {
@@ -124,9 +125,9 @@ function rawInsertRequestLog(
       is_stream, error_message, created_at, client_request, upstream_request, upstream_response,
       is_retry, is_failover, original_request_id, router_key_id, original_model, session_id, pipeline_snapshot,
       transport_kind, abort_reason, error_code, headers_sent, resilience_action, resilience_reason, mapping_reason, failover_trigger,
-      upstream_api_type, upstream_base_url, thinking_level)
+      upstream_api_type, upstream_base_url, thinking_level, backend_model)
      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
-      ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
     log.id, log.api_type, log.model, log.provider_id, log.status_code,
     log.client_status_code ?? null,
@@ -149,6 +150,7 @@ function rawInsertRequestLog(
     log.upstream_api_type ?? null,
     log.upstream_base_url ?? null,
     log.thinking_level ?? extractThinkingLevel(log.api_type, log.client_request ?? null),
+    log.backend_model ?? null,
   );
 }
 
@@ -206,8 +208,8 @@ function buildLogWhereClause(
     params.push(`%${options.client_model}%`);
   }
   if (options.backend_model) {
-    where += " AND rl.id IN (SELECT request_log_id FROM request_metrics WHERE backend_model LIKE ?)";
-    params.push(`%${options.backend_model}%`);
+    where += " AND rl.id IN (SELECT request_log_id FROM request_metrics WHERE backend_model = ?)";
+    params.push(options.backend_model);
   }
   if (options.router_key_id) {
     where += " AND rl.router_key_id = ?";

--- a/router/src/db/migrations/054_add_backend_model_index.sql
+++ b/router/src/db/migrations/054_add_backend_model_index.sql
@@ -1,0 +1,5 @@
+-- request_logs 增加 backend_model 列（第一阶段：写入，第二阶段：读取）
+ALTER TABLE request_logs ADD COLUMN backend_model TEXT;
+
+-- backend_model 精确过滤索引（logs 页面筛选 + metrics summary GROUP BY）
+CREATE INDEX IF NOT EXISTS idx_metrics_backend_model ON request_metrics(backend_model);

--- a/router/src/proxy/handler/failover-loop.ts
+++ b/router/src/proxy/handler/failover-loop.ts
@@ -576,6 +576,7 @@ export async function processResilienceResult(params: {
       mapping_reason: rCtx.mappingReason ?? null,
       upstream_api_type: resolvedEndpoint.api_type,
       upstream_base_url: resolvedEndpoint.base_url,
+      backend_model: resolved.backend_model,
     }, (matcher || logFileWriter) ? {
       matcher, logFileWriter, responseBody: null,
     } : undefined);
@@ -745,6 +746,7 @@ export async function executeFailoverLoop(
         pipelineSnapshot: iterationSnapshot.toJSON(),
         matcher, logFileWriter,
         mapping_reason: rCtx.mappingReason ?? null,
+        backend_model: resolved.backend_model,
       });
       excludeTargets.push(resolved);
       continue;
@@ -803,6 +805,7 @@ export async function executeFailoverLoop(
         pipelineSnapshot: iterationSnapshot.toJSON(),
         matcher, logFileWriter,
         mapping_reason: rCtx.mappingReason ?? null,
+        backend_model: resolved.backend_model,
       });
       excludeTargets.push(resolved);
       continue;

--- a/router/src/proxy/hooks/builtin/error-logging.ts
+++ b/router/src/proxy/hooks/builtin/error-logging.ts
@@ -67,6 +67,7 @@ export const errorLoggingHook: PipelineHook = {
         pipelineSnapshot: snapshot,
         matcher: matcher as RetryMatcher | null,
         logFileWriter: logFileWriter as LogFileWriter | null,
+        backend_model: ctx.resolved?.backend_model ?? null,
       });
     } else {
       // upstream error 路径：使用 insertRequestLog
@@ -88,6 +89,7 @@ export const errorLoggingHook: PipelineHook = {
         original_model: null,
         session_id: sessionId,
         pipeline_snapshot: snapshot,
+        backend_model: ctx.resolved?.backend_model ?? null,
       }, (matcher || logFileWriter) ? {
         matcher,
         logFileWriter: logFileWriter as LogFileWriter | null,

--- a/router/src/proxy/log-helpers.ts
+++ b/router/src/proxy/log-helpers.ts
@@ -45,6 +45,7 @@ export interface RequestLogParams extends LogRetryMeta {
   failover_trigger?: string | null;
   upstream_api_type?: string | null;
   upstream_base_url?: string | null;
+  backend_model?: string | null;
 }
 
 /** 插入成功请求日志，供 openai/anthropic 插件共享 */
@@ -57,7 +58,7 @@ export function insertSuccessLog(
     isRetry = false, isFailover = false, originalRequestId = null, routerKeyId = null, originalModel = null,
     sessionId = null, pipelineSnapshot = null, matcher, logFileWriter,
     transport_kind, abort_reason, error_code, headers_sent, resilience_action, resilience_reason, mapping_reason, failover_trigger,
-    upstream_api_type, upstream_base_url } = params;
+    upstream_api_type, upstream_base_url, backend_model } = params;
 
   const writeContext: LogWriteContext | undefined = (matcher || logFileWriter) ? {
     matcher,
@@ -86,6 +87,7 @@ export function insertSuccessLog(
     failover_trigger: failover_trigger ?? null,
     upstream_api_type: upstream_api_type ?? null,
     upstream_base_url: upstream_base_url ?? null,
+    backend_model: backend_model ?? null,
   }, writeContext);
 }
 
@@ -117,6 +119,7 @@ export interface RejectedLogParams extends LogRetryMeta {
   failover_trigger?: string | null;
   upstream_api_type?: string | null;
   upstream_base_url?: string | null;
+  backend_model?: string | null;
 }
 
 /** Log a request rejected before reaching upstream */
@@ -127,7 +130,7 @@ export function insertRejectedLog(params: RejectedLogParams): void {
     sessionId = null, pipelineSnapshot = null, matcher, logFileWriter,
     mapping_reason, transport_kind, abort_reason, error_code, headers_sent,
     resilience_action, resilience_reason, failover_trigger,
-    upstream_api_type, upstream_base_url } = params;
+    upstream_api_type, upstream_base_url, backend_model } = params;
 
   const writeContext: LogWriteContext | undefined = (matcher || logFileWriter) ? {
     matcher,
@@ -162,5 +165,6 @@ export function insertRejectedLog(params: RejectedLogParams): void {
     failover_trigger: failover_trigger ?? null,
     upstream_api_type: upstream_api_type ?? null,
     upstream_base_url: upstream_base_url ?? null,
+    backend_model: backend_model ?? null,
   }, writeContext);
 }

--- a/router/src/proxy/proxy-logging.ts
+++ b/router/src/proxy/proxy-logging.ts
@@ -147,6 +147,7 @@ export function logResilienceResult(
         router_key_id: params.routerKeyId, original_model: params.originalModel,
         session_id: params.sessionId,
         pipeline_snapshot: params.pipelineSnapshot ?? null,
+        backend_model: attempt.target.backend_model,
         ...diagnosticFields,
       }, attemptWriteContext);
     } else if (attempt.error) {
@@ -165,6 +166,7 @@ export function logResilienceResult(
         router_key_id: params.routerKeyId, original_model: params.originalModel,
         session_id: params.sessionId,
         pipeline_snapshot: params.pipelineSnapshot ?? null,
+        backend_model: attempt.target.backend_model,
         ...diagnosticFields,
       }, attemptWriteContext);
     } else if (attempt.statusCode !== UPSTREAM_SUCCESS) {
@@ -181,6 +183,7 @@ export function logResilienceResult(
         router_key_id: params.routerKeyId, original_model: params.originalModel,
         session_id: params.sessionId,
         pipeline_snapshot: params.pipelineSnapshot ?? null,
+        backend_model: attempt.target.backend_model,
         ...diagnosticFields,
       }, attemptWriteContext);
     } else {
@@ -202,6 +205,7 @@ export function logResilienceResult(
         pipelineSnapshot: params.pipelineSnapshot,
         matcher: params.matcher,
         logFileWriter: params.logFileWriter,
+        backend_model: attempt.target.backend_model,
         ...diagnosticFields,
       });
       lastSuccessLogId = attemptLogId;

--- a/router/tests/admin/logs-filter.test.ts
+++ b/router/tests/admin/logs-filter.test.ts
@@ -119,18 +119,18 @@ describe("Admin API: log filtering by client_model and backend_model", () => {
   });
 
   // ----------------------------------------------------------------
-  // Test 4: backend_model LIKE partial match
+  // Test 4: backend_model exact match
   // ----------------------------------------------------------------
-  it("test_backend_model_partial_match_returns_multiple_logs", async () => {
+  it("test_backend_model_exact_match_returns_log", async () => {
     const res = await app.inject({
       method: "GET",
-      url: "/admin/api/logs?backend_model=gpt-4o",
+      url: "/admin/api/logs?backend_model=gpt-4o-2024-08-06",
       headers: { cookie },
     });
     expect(res.statusCode).toBe(200);
     const body = res.json().data;
-    // Should match log-1 (gpt-4o-2024-08-06) and log-3 (gpt-4o-mini-2024-07-18)
-    expect(body.total).toBe(2);
+    expect(body.total).toBe(1);
+    expect(body.data[0].backend_model).toBe("gpt-4o-2024-08-06");
   });
 
   // ----------------------------------------------------------------
@@ -217,7 +217,7 @@ describe("Admin API: log filtering by client_model and backend_model", () => {
   it("test_grouped_view_respects_backend_model_filter", async () => {
     const res = await app.inject({
       method: "GET",
-      url: "/admin/api/logs?view=grouped&backend_model=claude",
+      url: "/admin/api/logs?view=grouped&backend_model=claude-3-opus-20240229",
       headers: { cookie },
     });
     expect(res.statusCode).toBe(200);

--- a/router/tests/db.test.ts
+++ b/router/tests/db.test.ts
@@ -39,7 +39,7 @@ describe("initDatabase", () => {
       .prepare("SELECT name FROM migrations")
       .all() as { name: string }[];
 
-  expect(rows.length).toBe(54);
+  expect(rows.length).toBe(55);
     expect(rows[0].name).toBe("001_init.sql");
     expect(rows[1].name).toBe("002_add_request_response_body.sql");
     expect(rows[2].name).toBe("003_add_full_request_chain_log.sql");

--- a/router/tests/metrics.test.ts
+++ b/router/tests/metrics.test.ts
@@ -29,7 +29,7 @@ describe("request_metrics migration and insertMetrics", () => {
       .prepare("SELECT name FROM migrations")
       .all() as { name: string }[];
 
-  expect(rows).toHaveLength(54);
+  expect(rows).toHaveLength(55);
     expect(rows[5].name).toBe("006_create_request_metrics.sql");
     expect(rows[6].name).toBe("007_add_retry_fields.sql");
     expect(rows[7].name).toBe("008_create_router_keys.sql");


### PR DESCRIPTION
## 变更

### 性能优化

- **前端 `useLogFilters.loadModelOptions()`**：从 `getMetricsSummary({ period: "30d" })`（1.76s）改为 `getMappingGroups()`（~5ms），减少 99.7% 耗时
- **后端 `buildLogWhereClause`**：backend_model 过滤从 `LIKE "%xxx%"` 改为 `= ?` 精确匹配 + 新增 `idx_metrics_backend_model` 索引

### 数据模型

- **迁移 054**：`ALTER TABLE request_logs ADD COLUMN backend_model TEXT`
- 所有 `insertRequestLog`/`insertSuccessLog`/`insertRejectedLog` 调用点写入 `backend_model`（11 处）

### 文档

- `docs/api-performance-analysis.md`：全量 API 性能分析 + 两阶段迁移计划

### 两阶段策略

| 阶段 | 内容 | 版本 |
|------|------|------|
| 第一阶段（本次） | 写入 backend_model 到 request_logs，读取路径不变 | v1.x |
| 第二阶段（下版本） | 读取切换到 `rl.backend_model`，去掉 JOIN request_metrics | v2.x |

## 变更文件

| 文件 | 变更 |
|------|------|
| `router/src/db/migrations/054_add_backend_model_index.sql` | 新增迁移 |
| `router/src/db/logs.ts` | 接口 + INSERT + 查询优化 |
| `router/src/proxy/handler/failover-loop.ts` | 3 处写入 backend_model |
| `router/src/proxy/proxy-logging.ts` | 4 处写入 backend_model |
| `router/src/proxy/log-helpers.ts` | 接口扩展 + 透传 |
| `router/src/proxy/hooks/builtin/error-logging.ts` | 2 处写入 backend_model |
| `frontend/src/composables/useLogFilters.ts` | 数据源替换 |
| `docs/api-performance-analysis.md` | 性能分析文档 |