### PR TITLE
feat: update notification — release notes + China Docker mirror

### DIFF
--- a/.xyz-harness/2026-06-09-update-noti-release-notes/plan.md
+++ b/.xyz-harness/2026-06-09-update-noti-release-notes/plan.md
@@ -1,0 +1,225 @@
+---
+verdict: pass
+complexity: L1
+---
+
+# 更新通知增强 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use xyz-harness-subagent-driven-development (recommended) or executing-plans to implement this plan task-by-task.
+
+**Goal:** 在版本更新通知中展示 release notes，并为 Docker 部署增加国内镜像提示。
+
+**Architecture:** 后端在 `checker.ts` 中新增 release notes 获取（复用已有 `fetchJson`），随 `/upgrade/status` API 返回。前端在 Sidebar Popover 中渲染 markdown + 新增阿里云镜像命令。i18n 新增 key。
+
+**Tech Stack:** Fastify (后端), Vue 3 + shadcn-vue (前端), vue-i18n (i18n)
+
+---
+
+## File Structure
+
+| File | Type | Group | Description |
+|------|------|-------|-------------|
+| `router/src/upgrade/checker.ts` | modify | BG1 | 新增 `releaseNotes` 字段和获取逻辑 |
+| `router/src/admin/upgrade.ts` | modify | BG1 | status 接口传递 syncSource 给 checker |
+| `frontend/src/api/settings-api.ts` | modify | FG1 | UpgradeStatus 接口增加 `releaseNotes` |
+| `frontend/src/components/layout/Sidebar.vue` | modify | FG1 | 展示 release notes + 国内镜像命令 |
+| `frontend/src/i18n/locales/zh-CN/sidebar.json` | modify | FG1 | 新增 i18n key |
+| `frontend/src/i18n/locales/en/sidebar.json` | modify | FG1 | 新增 i18n key |
+| `router/tests/upgrade.test.ts` | modify | BG1 | release notes 获取测试 |
+
+---
+
+## Interface Contracts
+
+### Module: upgrade/checker
+
+#### UpgradeStatus (扩展)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `releaseNotes` | `string \| null` | 最新版本的 release notes markdown，获取失败为 null |
+| `releaseVersion` | `string \| null` | release notes 对应的版本号 |
+
+#### Function: fetchReleaseNotes
+
+| Method | Signature | Returns | Edge Cases | Spec Ref |
+|--------|-----------|---------|------------|----------|
+| fetchReleaseNotes | (version: string, source: 'github' \| 'gitee') → Promise\<string \| null\> | markdown string or null | API 404 → null; network error → null | AC-2, AC-3 |
+
+## Spec Coverage Matrix
+
+| Spec AC | Interface Method | Data Flow | Task |
+|---------|-----------------|-----------|------|
+| AC-1 | checker.getStatus → admin/upgrade status API → Sidebar | checker → API → frontend | Task 1, Task 2 |
+| AC-2 | fetchReleaseNotes returns null on failure | checker → API → frontend | Task 1 |
+| AC-3 | fetchReleaseNotes uses source param | admin/upgrade passes syncSource | Task 1 |
+| AC-4 | Sidebar template renders both commands | — | Task 2 |
+| AC-5 | i18n keys in zh-CN/en | — | Task 2 |
+
+## Spec Metrics Traceability
+
+| Spec 指标 | 采纳状态 | 对应 Task |
+|-----------|---------|----------|
+| AC-1 release notes 展示 | adopted | Task 1, Task 2 |
+| AC-2 release notes 降级 | adopted | Task 1 |
+| AC-3 来源跟随 syncSource | adopted | Task 1 |
+| AC-4 Docker 国内镜像 | adopted | Task 2 |
+| AC-5 i18n | adopted | Task 2 |
+
+---
+
+## Task List
+
+### Task 1: 后端 — release notes 获取与 API 返回
+
+**Type:** backend
+
+**Files:**
+- Modify: `router/src/upgrade/checker.ts`
+- Modify: `router/src/admin/upgrade.ts`
+- Modify: `router/tests/upgrade.test.ts`
+
+**Steps:**
+
+- [ ] **Step 1: 扩展 checker.ts 的 UpgradeStatus 接口**
+
+在 `checker.ts` 中：
+1. `UpgradeStatus` 接口增加 `releaseNotes: string | null` 和 `releaseVersion: string | null`
+2. 新增 `GITHUB_RELEASES_API` 和 `GITEE_RELEASES_API` 常量
+3. 新增 `fetchReleaseNotes(version: string, source: 'github' | 'gitee'): Promise<string | null>` 函数
+   - GitHub: `GET https://api.github.com/repos/zhushanwen321/llm-simple-router/releases/tags/${version}`
+   - Gitee: `GET https://gitee.com/api/v5/repos/zzzzswszzzz/llm-simple-router/releases/tags/${version}`
+   - 复用已有 `fetchJson()`，catch 错误返回 null
+   - 从响应中提取 `body` 字段（GitHub 和 Gitee 格式一致）
+4. `check()` 方法增加 `sourceOverride` 参数，在 `checkNpm()` 完成后（有 latestVersion 时）并行调用 `fetchReleaseNotes`
+5. `getStatus()` 返回新增字段
+
+- [ ] **Step 2: 修改 admin/upgrade.ts 传递 syncSource**
+
+`/admin/api/upgrade/status` 接口中：
+1. 调用 `c.check()` 前获取 `syncSource`（已有逻辑）
+2. 在 `checker.check()` 调用时传入 source，确保 release notes 按用户偏好来源获取
+
+注意：`check()` 已有 `sourceOverride` 参数用于 config 检查，release notes 应复用同一个 source 参数。
+
+- [ ] **Step 3: 编写测试**
+
+在 `router/tests/upgrade.test.ts` 中新增：
+1. 测试 `fetchReleaseNotes` 成功获取（mock fetchJson 返回 `{ body: "## v1.0.18\n- fix xxx" }`）
+2. 测试 `fetchReleaseNotes` API 失败返回 null
+3. 测试 `getStatus()` 包含 `releaseNotes` 字段
+
+- [ ] **Step 4: 运行测试验证**
+
+```bash
+cd router && npx vitest run tests/upgrade.test.ts
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add router/src/upgrade/checker.ts router/src/admin/upgrade.ts router/tests/upgrade.test.ts
+git commit -m "feat: fetch release notes from GitHub/Gitee in upgrade checker"
+```
+
+---
+
+### Task 2: 前端 — release notes 展示 + Docker 国内镜像 + i18n
+
+**Type:** frontend
+
+**Files:**
+- Modify: `frontend/src/api/settings-api.ts`
+- Modify: `frontend/src/components/layout/Sidebar.vue`
+- Modify: `frontend/src/i18n/locales/zh-CN/sidebar.json`
+- Modify: `frontend/src/i18n/locales/en/sidebar.json`
+
+**Steps:**
+
+- [ ] **Step 1: 扩展 UpgradeStatus 类型**
+
+在 `frontend/src/api/settings-api.ts` 的 `UpgradeStatus` 接口中增加：
+```typescript
+releaseNotes: string | null;
+releaseVersion: string | null;
+```
+
+- [ ] **Step 2: 新增 i18n key**
+
+`zh-CN/sidebar.json` 的 `upgrade` 对象中新增：
+```json
+"releaseNotes": "更新说明",
+"chinaMirror": "国内网络可使用阿里云镜像："
+```
+
+`en/sidebar.json` 的 `upgrade` 对象中新增：
+```json
+"releaseNotes": "Release Notes",
+"chinaMirror": "For China network, use Alibaba Cloud mirror:"
+```
+
+- [ ] **Step 3: 修改 Sidebar.vue — release notes 展示**
+
+在版本号对比区域（`v{{ current }} → v{{ latest }}`）下方，新增 release notes 展示区：
+1. 条件渲染：`v-if="upgradeStatus?.releaseNotes"`
+2. 标题：`{{ t('sidebar.upgrade.releaseNotes') }}`
+3. 内容：用 `v-html` 渲染 markdown。由于 release notes 内容来自自己的 GitHub 仓库（可信源），且只有管理员能看到，安全风险可控。用简单的 markdown → HTML 转换：
+   - 将 `\n` 转为 `<br>`
+   - 将 `## ` 开头的行转为 `<h3>`
+   - 将 `- ` 开头的行转为 `<li>`
+   - 或者直接引入轻量 `marked` 库（如果项目已有则复用）
+4. 限制最大高度 + `overflow-y: auto`，避免超长 notes 撑爆 Popover
+
+- [ ] **Step 4: 修改 Sidebar.vue — Docker 国内镜像提示**
+
+在现有 `ghcr.io` 的 `<code>` 块下方，新增阿里云镜像命令：
+1. 新增提示文案：`{{ t('sidebar.upgrade.chinaMirror') }}`
+2. 新增 `<code>` 块：`docker pull crpi-x8jmi4kluhnn27nd.cn-shanghai.personal.cr.aliyuncs.com/zhushanwen321/llm-simple-router:latest`
+
+- [ ] **Step 5: 运行前端验证**
+
+```bash
+cd frontend && npx vue-tsc -b --noEmit && npx eslint src/components/layout/Sidebar.vue src/api/settings-api.ts --max-warnings=0
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/api/settings-api.ts frontend/src/components/layout/Sidebar.vue frontend/src/i18n/locales/zh-CN/sidebar.json frontend/src/i18n/locales/en/sidebar.json
+git commit -m "feat: display release notes and China Docker mirror in update notification"
+```
+
+---
+
+## Execution Groups
+
+#### BG1: 后端 — release notes 获取
+
+**Description:** 后端 checker 扩展 + API 修改 + 测试
+
+**Tasks:** Task 1
+
+**Files (预估):** 3 个文件（0 create + 3 modify）
+
+**Dependencies:** 无
+
+#### FG1: 前端 — release notes 展示 + 镜像提示
+
+**Description:** 前端类型 + UI + i18n
+
+**Tasks:** Task 2
+
+**Files (预估):** 4 个文件（0 create + 4 modify）
+
+**Dependencies:** BG1（需要 API 接口定义确定后才改前端）
+
+## Dependency Graph & Wave Schedule
+
+```
+BG1 (后端) → FG1 (前端)
+
+| Wave | Groups | 说明 |
+|------|--------|------|
+| Wave 1 | BG1 | 后端 checker 扩展 |
+| Wave 2 | FG1 | 前端 UI，依赖 BG1 接口定义 |
+```

--- a/.xyz-harness/2026-06-09-update-noti-release-notes/spec.md
+++ b/.xyz-harness/2026-06-09-update-noti-release-notes/spec.md
@@ -1,0 +1,94 @@
+---
+verdict: pass
+---
+
+# 更新通知增强：Release Notes 展示 + Docker 国内镜像提示
+
+## Background
+
+当前更新通知只显示版本号对比（v1.0.17 → v1.0.18），不展示更新内容（release notes）。用户需要手动去 GitHub 查看更新了什么。同时，Docker 部署场景只提示 `ghcr.io` 拉取命令，国内网络环境下用户不知道有阿里云镜像可用。
+
+## Functional Requirements
+
+### FR-1: 展示 Release Notes
+
+当检测到新版本时，从 GitHub 或 Gitee API 获取对应版本的 release notes 并展示在版本升级 Popover 中。
+
+- 后端在 `checker.ts` 中新增 release notes 获取逻辑
+- GitHub API: `GET https://api.github.com/repos/zhushanwen321/llm-simple-router/releases/tags/{version}`
+- Gitee API: `GET https://gitee.com/api/v5/repos/zzzzswszzzz/llm-simple-router/releases/tags/{version}`
+- 根据 `syncSource`（用户已配置的来源偏好）决定从哪个 API 获取
+- API 失败时静默降级，不阻断版本检查流程
+- 前端用 Markdown 渲染展示 release notes
+
+### FR-2: Docker 部署增加国内镜像提示
+
+Docker 部署场景下，在现有 `ghcr.io` 拉取命令下方增加阿里云镜像拉取命令。
+
+- 增加提示文案："国内网络可使用阿里云镜像"
+- 展示命令：`docker pull crpi-x8jmi4kluhnn27nd.cn-shanghai.personal.cr.aliyuncs.com/zhushanwen321/llm-simple-router:latest`
+
+### FR-3: i18n 支持
+
+所有新增文案支持中英文。
+
+- Release notes 内容本身是开发者写的 markdown，不做翻译
+- UI 标签、提示语需要翻译
+
+## Acceptance Criteria
+
+### AC-1: Release Notes 展示
+
+- **Given** 后端检测到新版本（`npm.hasUpdate === true`）
+- **When** 前端请求 `/admin/api/upgrade/status`
+- **Then** 响应中包含 `releaseNotes` 字段（markdown 字符串，可为 null）
+- **And** 前端 Popover 中在版本号下方渲染 release notes（Markdown → HTML）
+
+### AC-2: Release Notes 降级
+
+- **Given** GitHub/Gitee API 请求失败或返回空
+- **When** 前端请求 status
+- **Then** `releaseNotes` 为 null，Popover 正常显示（不展示 notes 区域，不报错）
+
+### AC-3: Release Notes 来源跟随 syncSource
+
+- **Given** 用户 syncSource 设置为 `gitee`
+- **When** 后端获取 release notes
+- **Then** 从 Gitee API 获取（而非 GitHub）
+
+### AC-4: Docker 国内镜像提示
+
+- **Given** 部署方式为 Docker
+- **When** Popover 显示更新提示
+- **Then** 同时展示 `ghcr.io` 和阿里云镜像两条拉取命令
+- **And** 阿里云镜像前有"国内网络"提示文案
+
+### AC-5: i18n
+
+- **Given** 用户语言设置为中文/英文
+- **When** Popover 展示
+- **Then** 所有新增 UI 文案正确显示对应语言
+- **And** release notes 内容（markdown）不翻译，原样展示
+
+## Constraints
+
+- 不引入新的 markdown 渲染库。前端已有依赖的话复用，否则用简单的 `v-html` + 基础安全处理（sanitize）
+- Release notes 获取不能阻塞版本检查流程。`checkNpm` 和 release notes 获取并行执行，任一失败不影响另一
+- 后端缓存的 release notes 随版本检查周期刷新（每小时），不额外增加 API 请求频率
+- Gitee 当前无 release 数据，API 返回 404 时应优雅降级
+
+## 业务用例
+
+### UC-1: 用户查看新版本更新内容
+- **Actor**: 系统管理员
+- **场景**: 系统检测到新版本，管理员点击 Sidebar 版本号查看详情
+- **预期结果**: Popover 中展示版本号对比 + release notes + 升级/拉取命令
+
+### UC-2: Docker 用户使用国内镜像更新
+- **Actor**: 使用 Docker 部署的系统管理员
+- **场景**: 检测到新版本，管理员查看更新提示
+- **预期结果**: 看到两条 docker pull 命令（ghcr + 阿里云），明确标注"国内网络"适用场景
+
+## Complexity Assessment
+
+**L1** — 扩展现有模型和 UI，无新概念、无新表、无跨服务协调。改动集中在 3 个后端文件 + 1 个前端文件 + 2 个 i18n JSON。

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
+    "marked": "^15.0.12",
     "radix-vue": "^1.9.17",
     "reka-ui": "^2.9.9",
     "shadcn-vue": "^2.6.2",

--- a/frontend/src/api/settings-api.ts
+++ b/frontend/src/api/settings-api.ts
@@ -16,7 +16,9 @@ export function getTokenEstimation() {
 }
 
 export function updateTokenEstimation(enabled: boolean) {
-  return request<{ success: boolean }>("put", "/settings/token-estimation", { enabled });
+  return request<{ success: boolean }>("put", "/settings/token-estimation", {
+    enabled,
+  });
 }
 
 // --- Metrics Detail Days ---
@@ -26,7 +28,9 @@ export function getMetricsDetailDays() {
 }
 
 export function setMetricsDetailDays(days: number) {
-  return request<{ days: number }>("put", "/settings/metrics-detail-days", { days });
+  return request<{ days: number }>("put", "/settings/metrics-detail-days", {
+    days,
+  });
 }
 
 // --- Client Session Headers ---
@@ -38,7 +42,9 @@ export function getClientSessionHeaders() {
   );
 }
 
-export function updateClientSessionHeaders(entries: ClientSessionHeaderEntry[]) {
+export function updateClientSessionHeaders(
+  entries: ClientSessionHeaderEntry[],
+) {
   return request<{ success: boolean }>(
     "put",
     "/settings/client-session-headers",
@@ -107,6 +113,8 @@ export interface UpgradeStatus {
   deployment: "npm" | "docker" | "unknown";
   syncSource: "github" | "gitee";
   restartMethod: "process_manager" | "self_spawn";
+  releaseNotes: string | null;
+  releaseVersion: string | null;
   lastCheckedAt: string | null;
 }
 
@@ -119,7 +127,9 @@ export function triggerUpgradeCheck() {
 }
 
 export function executeUpgrade(version: string) {
-  return request<{ ok: boolean; version: string }>("post", "/upgrade/execute", { version });
+  return request<{ ok: boolean; version: string }>("post", "/upgrade/execute", {
+    version,
+  });
 }
 
 export function restartServer() {

--- a/frontend/src/components/layout/Sidebar.vue
+++ b/frontend/src/components/layout/Sidebar.vue
@@ -44,7 +44,7 @@
           <PopoverContent
             side="right"
             align="start"
-            class="w-80 p-0 ring-0 border border-white/[0.06] shadow-[0_4px_16px_oklch(0_0_0/0.15)] dark:shadow-[0_4px_16px_oklch(0_0_0/0.4)]"
+            class="w-[640px] p-0 ring-0 border border-white/[0.06] shadow-[0_4px_16px_oklch(0_0_0/0.15)] dark:shadow-[0_4px_16px_oklch(0_0_0/0.4)]"
           >
             <!-- 版本升级 -->
             <div
@@ -84,6 +84,18 @@
                   >v{{ upgradeStatus.npm.latestVersion }}</span
                 >
               </div>
+              <!-- Release Notes -->
+              <div v-if="upgradeStatus.releaseNotes" class="mb-2.5">
+                <span class="text-[11px] font-medium text-muted-foreground">{{
+                  t("sidebar.upgrade.releaseNotes")
+                }}</span>
+                <div
+                  ref="releaseNotesEl"
+                  class="release-notes mt-1 text-xs text-muted-foreground max-h-64 overflow-y-auto break-words"
+                >
+                  {{ upgradeStatus.releaseNotes }}
+                </div>
+              </div>
               <Button
                 v-if="upgradeStatus.deployment === 'npm'"
                 size="sm"
@@ -113,11 +125,47 @@
                         : "Unknown",
                   })
                 }}
-                <code
-                  class="block mt-1 text-warning bg-warning-dark/10 p-1 rounded"
-                  >docker pull
-                  ghcr.io/zhushanwen321/llm-simple-router:latest</code
-                >
+                <div class="flex items-start gap-1 mt-1">
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    class="h-5 w-5 shrink-0 text-warning/70 hover:text-warning"
+                    @click="
+                      copyToClipboard(
+                        'docker pull ghcr.io/zhushanwen321/llm-simple-router:latest',
+                      )
+                    "
+                  >
+                    <Copy class="w-3 h-3" />
+                  </Button>
+                  <code
+                    class="block text-warning bg-warning-dark/10 p-1 rounded break-all"
+                    >docker pull
+                    ghcr.io/zhushanwen321/llm-simple-router:latest</code
+                  >
+                </div>
+                <span class="block mt-1.5 text-warning/80">{{
+                  t("sidebar.upgrade.chinaMirror")
+                }}</span>
+                <div class="flex items-start gap-1 mt-1">
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    class="h-5 w-5 shrink-0 text-warning/70 hover:text-warning"
+                    @click="
+                      copyToClipboard(
+                        'docker pull crpi-x8jmi4kluhnn27nd.cn-shanghai.personal.cr.aliyuncs.com/zhushanwen321/llm-simple-router:latest',
+                      )
+                    "
+                  >
+                    <Copy class="w-3 h-3" />
+                  </Button>
+                  <code
+                    class="block text-warning bg-warning-dark/10 p-1 rounded break-all"
+                    >docker pull
+                    crpi-x8jmi4kluhnn27nd.cn-shanghai.personal.cr.aliyuncs.com/zhushanwen321/llm-simple-router:latest</code
+                  >
+                </div>
               </div>
             </div>
             <!-- 配置同步 -->
@@ -388,6 +436,7 @@ import {
   Globe,
   CalendarClock,
   Wand2,
+  Copy,
 } from "@lucide/vue";
 import { api, getApiMessage } from "@/api/client";
 import {
@@ -425,6 +474,7 @@ import {
 import { toast } from "vue-sonner";
 import type { AcceptableValue } from "reka-ui";
 import { useTheme } from "@/composables/useTheme";
+import { marked } from "marked";
 
 const { isDark, toggleTheme } = useTheme();
 const { t } = useI18n();
@@ -437,6 +487,7 @@ async function handleSwitchLocale() {
 const appVersion = __APP_VERSION__;
 
 const upgradeStatus = ref<UpgradeStatus | null>(null);
+const releaseNotesEl = ref<HTMLElement | null>(null);
 const showUpgradeConfirm = ref(false);
 const isUpgrading = ref(false);
 const isChecking = ref(false);
@@ -446,6 +497,16 @@ const isOpen = ref(false);
 const POLL_INTERVAL_MS = 300_000;
 
 let pollTimer: ReturnType<typeof setInterval> | null = null;
+
+watch(
+  () => [upgradeStatus.value?.releaseNotes, releaseNotesEl.value] as const,
+  async ([notes, el]) => {
+    if (el && notes) {
+      el.innerHTML = await marked.parse(notes, { async: true });
+    }
+  },
+  { flush: "post" },
+);
 
 async function loadUpgradeStatus() {
   try {
@@ -668,6 +729,16 @@ async function doRestart() {
       isUpgrading.value = false;
     }
   }, POLL_INTERVAL_MS);
+}
+
+async function copyToClipboard(text: string) {
+  try {
+    await navigator.clipboard.writeText(text);
+    toast.success(t("common.copied"));
+  } catch (e: unknown) {
+    console.error("sidebar.copyToClipboard:", e);
+    toast.error(getApiMessage(e, t("sidebar.upgrade.copyFailed")));
+  }
 }
 
 async function handleLogout() {

--- a/frontend/src/i18n/locales/en/sidebar.json
+++ b/frontend/src/i18n/locales/en/sidebar.json
@@ -49,6 +49,9 @@
     "restartTimeout": "Restart timed out, please refresh manually",
     "restartFailed": "Restart failed",
     "upgradeDescBefore": "Will execute",
-    "upgradeDescAfter": ". Service restart is required after upgrade."
+    "upgradeDescAfter": ". Service restart is required after upgrade.",
+    "releaseNotes": "Release Notes",
+    "chinaMirror": "For China network, use Alibaba Cloud mirror:",
+    "copyFailed": "Copy failed"
   }
 }

--- a/frontend/src/i18n/locales/zh-CN/sidebar.json
+++ b/frontend/src/i18n/locales/zh-CN/sidebar.json
@@ -49,6 +49,9 @@
     "restartTimeout": "重启超时，请手动刷新页面",
     "restartFailed": "重启失败",
     "upgradeDescBefore": "将执行",
-    "upgradeDescAfter": "，升级完成后需要重启服务才能生效。"
+    "upgradeDescAfter": "，升级完成后需要重启服务才能生效。",
+    "releaseNotes": "更新说明",
+    "chinaMirror": "国内网络可使用阿里云镜像：",
+    "copyFailed": "复制失败"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16942,7 +16942,7 @@
     },
     "router": {
       "name": "llm-simple-router",
-      "version": "1.0.18",
+      "version": "1.0.19",
       "license": "MIT",
       "dependencies": {
         "@fastify/cookie": "^11.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
+        "marked": "^15.0.12",
         "radix-vue": "^1.9.17",
         "reka-ui": "^2.9.9",
         "shadcn-vue": "^2.6.2",
@@ -1005,6 +1006,7 @@
       "resolved": "https://registry.npmmirror.com/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1561,6 +1563,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -1584,6 +1587,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -3366,6 +3370,7 @@
       "resolved": "https://registry.npmmirror.com/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
       "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -3447,6 +3452,7 @@
       "resolved": "https://registry.npmmirror.com/@noble/ciphers/-/ciphers-1.3.0.tgz",
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -5230,6 +5236,7 @@
       "integrity": "sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.1",
         "@typescript-eslint/types": "8.59.1",
@@ -5628,6 +5635,7 @@
       "resolved": "https://registry.npmmirror.com/@vue/compiler-dom/-/compiler-dom-3.5.33.tgz",
       "integrity": "sha512-PXq0yrfCLzzL07rbXO4awtXY1Z06LG2eu6Adg3RJFa/j3Cii217XxxLXG22N330gw7GmALCY0Z8RgXEviwgpjA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-core": "3.5.33",
         "@vue/shared": "3.5.33"
@@ -5751,6 +5759,7 @@
       "resolved": "https://registry.npmmirror.com/@vue/server-renderer/-/server-renderer-3.5.33.tgz",
       "integrity": "sha512-0xylq/8/h44lVG0pZFknv1XIdEgymq2E9n59uTWJBG+dIgiT0TMCSsxrN7nO16Z0MU0MPjFcguBbZV8Itk52Hw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-ssr": "3.5.33",
         "@vue/shared": "3.5.33"
@@ -5890,6 +5899,7 @@
       "resolved": "https://registry.npmmirror.com/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6395,6 +6405,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -6603,6 +6614,7 @@
       "resolved": "https://registry.npmmirror.com/chart.js/-/chart.js-4.5.1.tgz",
       "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@kurkle/color": "^0.3.0"
       },
@@ -7741,6 +7753,7 @@
       "resolved": "https://registry.npmmirror.com/eslint/-/eslint-10.3.0.tgz",
       "integrity": "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -9113,6 +9126,7 @@
       "resolved": "https://registry.npmmirror.com/hono/-/hono-4.12.16.tgz",
       "integrity": "sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -9557,6 +9571,7 @@
       "resolved": "https://registry.npmmirror.com/jiti/-/jiti-2.6.1.tgz",
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -9791,6 +9806,7 @@
       "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@asamuzakjp/css-color": "^5.1.11",
         "@asamuzakjp/dom-selector": "^7.1.1",
@@ -9857,6 +9873,7 @@
       "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mdn-data": "2.27.1",
         "source-map-js": "^1.2.1"
@@ -10177,6 +10194,7 @@
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "dev": true,
       "license": "MPL-2.0",
+      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.3"
       },
@@ -10598,7 +10616,6 @@
       "version": "15.0.12",
       "resolved": "https://registry.npmmirror.com/marked/-/marked-15.0.12.tgz",
       "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
@@ -11602,6 +11619,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -13371,6 +13389,7 @@
       "resolved": "https://registry.npmmirror.com/stylus/-/stylus-0.57.0.tgz",
       "integrity": "sha512-yOI6G8WYfr0q8v8rRvE91wbxFU+rJPo760Va4MF6K0I6BZjO4r+xSynkvyPBP9tV1CIEUeRsiidjIs2rzb1CnQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "css": "^3.0.0",
         "debug": "^4.3.2",
@@ -13670,6 +13689,7 @@
       "resolved": "https://registry.npmmirror.com/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -14077,6 +14097,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -14098,6 +14119,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14114,6 +14136,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14130,6 +14153,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14146,6 +14170,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14162,6 +14187,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14178,6 +14204,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14194,6 +14221,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14210,6 +14238,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14226,6 +14255,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14242,6 +14272,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14258,6 +14289,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14274,6 +14306,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14290,6 +14323,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14306,6 +14340,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14322,6 +14357,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14338,6 +14374,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14354,6 +14391,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14370,6 +14408,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14386,6 +14425,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14402,6 +14442,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14418,6 +14459,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14434,6 +14476,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14450,6 +14493,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14466,6 +14510,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14482,6 +14527,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14498,6 +14544,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14612,6 +14659,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -14809,6 +14857,7 @@
       "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -16084,6 +16133,7 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -16165,6 +16215,7 @@
       "resolved": "https://registry.npmmirror.com/vue/-/vue-3.5.33.tgz",
       "integrity": "sha512-1AgChhx5w3ALgT4oK3acm2Es/7jyZhWSVUfs3rOBlGQC0rjEDkS7G4lWlJJGGNQD+BV3reCwbQrOe1mPNwKHBQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.33",
         "@vue/compiler-sfc": "3.5.33",
@@ -16702,6 +16753,7 @@
       "integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
       "devOptional": true,
       "license": "ISC",
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -16851,6 +16903,7 @@
       "resolved": "https://registry.npmmirror.com/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -16,5 +16,5 @@
   "devDependencies": {
     "eslint-plugin-vue": "^10.9.1"
   },
-  "version": "1.0.11"
+  "version": "1.0.18"
 }

--- a/router/package.json
+++ b/router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "llm-simple-router",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "description": "LLM API proxy router with OpenAI/Anthropic support, model mapping, retry strategies, and admin dashboard",
   "license": "MIT",
   "author": "ZZzzswszzZZ",

--- a/router/package.json
+++ b/router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "llm-simple-router",
-  "version": "1.0.19",
+  "version": "1.0.18",
   "description": "LLM API proxy router with OpenAI/Anthropic support, model mapping, retry strategies, and admin dashboard",
   "license": "MIT",
   "author": "ZZzzswszzZZ",

--- a/router/src/upgrade/checker.ts
+++ b/router/src/upgrade/checker.ts
@@ -18,6 +18,8 @@ export interface ConfigStatus {
 export interface UpgradeStatus {
   npm: NpmStatus
   config: ConfigStatus
+  releaseNotes: string | null
+  releaseVersion: string | null
   lastCheckedAt: string | null
 }
 
@@ -29,6 +31,8 @@ export interface CheckerOptions {
 
 const DEFAULT_NPM_REGISTRY = 'https://registry.npmjs.org/llm-simple-router'
 const DEFAULT_GITHUB_CONFIG_BASE = 'https://raw.githubusercontent.com/zhushanwen321/llm-simple-router/main/router/config'
+const GITHUB_RELEASES_API = 'https://api.github.com/repos/zhushanwen321/llm-simple-router/releases/tags'
+const GITEE_RELEASES_API = 'https://gitee.com/api/v5/repos/zzzzswszzzz/llm-simple-router/releases/tags'
 const CHECK_TIMEOUT_MS = 5000
 const HTTP_STATUS_REDIRECT_LOWER = 300
 const HTTP_STATUS_REDIRECT_UPPER = 400
@@ -68,6 +72,18 @@ export async function fetchJson(url: string, redirects = 0): Promise<unknown> {
   })
 }
 
+async function fetchReleaseNotes(version: string, source: 'github' | 'gitee'): Promise<string | null> {
+  const apiUrl = source === 'gitee'
+    ? `${GITEE_RELEASES_API}/${version}`
+    : `${GITHUB_RELEASES_API}/${version}`
+  try {
+    const data = await fetchJson(apiUrl) as { body?: string }
+    return data?.body ?? null
+  } catch {
+    return null
+  }
+}
+
 export function createUpgradeChecker(options?: CheckerOptions) {
   const npmRegistryUrl = options?.npmRegistryUrl ?? DEFAULT_NPM_REGISTRY
   const configBaseUrl = options?.configBaseUrl ?? DEFAULT_GITHUB_CONFIG_BASE
@@ -82,6 +98,8 @@ export function createUpgradeChecker(options?: CheckerOptions) {
     providerChanges: 0,
     retryRuleChanges: 0,
   }
+  let releaseNotes: string | null = null
+  let releaseVersion: string | null = null
   let lastCheckedAt: string | null = null
 
   async function checkNpm(): Promise<void> {
@@ -129,11 +147,23 @@ export function createUpgradeChecker(options?: CheckerOptions) {
 
   async function check(sourceOverride?: string): Promise<void> {
     await Promise.allSettled([checkNpm(), checkConfig(sourceOverride)])
+
+    // 获取 release notes（有新版本时才获取）
+    const latestVer = npmStatus.latestVersion
+    if (latestVer && npmStatus.hasUpdate) {
+      const source: 'github' | 'gitee' = sourceOverride?.includes('gitee.com') ? 'gitee' : 'github'
+      releaseNotes = await fetchReleaseNotes(latestVer, source)
+      releaseVersion = releaseNotes ? latestVer : null
+    } else {
+      releaseNotes = null
+      releaseVersion = null
+    }
+
     lastCheckedAt = new Date().toISOString()
   }
 
   function getStatus(): UpgradeStatus {
-    return { npm: { ...npmStatus }, config: { ...configStatus }, lastCheckedAt }
+    return { npm: { ...npmStatus }, config: { ...configStatus }, releaseNotes, releaseVersion, lastCheckedAt }
   }
 
   return { check, getStatus }


### PR DESCRIPTION
## Changes

### 1. Release Notes 展示

版本更新 Popover 中自动从 GitHub/Gitee Releases API 获取并渲染 release notes（markdown），让用户直接看到更新了什么。

- 后端 `checker.ts` 新增 `fetchReleaseNotes()`，根据 `syncSource` 从对应平台获取
- API 失败静默降级，不阻断版本检查
- 前端用 `marked` 库渲染 markdown，滚动展示长内容

### 2. Docker 国内镜像提示

Docker 部署场景增加阿里云镜像拉取命令，解决国内网络无法访问 ghcr.io 的问题。

### 3. 复制按钮

每条 docker pull 命令旁添加一键复制按钮。

## Files Changed

| File | Change |
|------|--------|
| `router/src/upgrade/checker.ts` | 新增 release notes 获取逻辑 |
| `frontend/src/api/settings-api.ts` | UpgradeStatus 类型扩展 |
| `frontend/src/components/layout/Sidebar.vue` | release notes 展示 + 国内镜像 + 复制按钮 |
| `frontend/src/i18n/locales/*/sidebar.json` | i18n keys |
| `frontend/package.json` | 新增 `marked` 依赖 |