### PR TITLE
fix(merge-skill): widen CI wait to 30min / 30s poll

### DIFF
--- a/.pi/skills/merge/merge.sh
+++ b/.pi/skills/merge/merge.sh
@@ -644,7 +644,7 @@ phase_publish() {
             local tag_sha
             tag_sha=$(git -C "${op_dir}" rev-parse "$TAG" 2>/dev/null || echo "")
             if [[ -n "$tag_sha" ]]; then
-                bash "$SCRIPT_DIR/wait-for-ci.sh" "$tag_sha" --timeout 900 --workflow "Release" --verify-release "$TAG" $gh_flag 2>&1 || {
+                bash "$SCRIPT_DIR/wait-for-ci.sh" "$tag_sha" --timeout 1800 --workflow "Release" --verify-release "$TAG" $gh_flag 2>&1 || {
                     local wait_exit=$?
                     if [[ $wait_exit -eq 1 ]]; then
                         echo -e "  ${RED}❌ Release CI 构建失败！查看日志: gh run view --log-failed${NC}"

--- a/.pi/skills/merge/wait-for-ci.sh
+++ b/.pi/skills/merge/wait-for-ci.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # wait-for-ci.sh — 等待 GitHub Actions CI 完成
 #
-# 用法: wait-for-ci.sh <commit-sha> [--timeout 600] [--workflow <name>] [--verify-release <tag> [--repo <owner/repo>]]
+# 用法: wait-for-ci.sh <commit-sha> [--timeout 1800] [--workflow <name>] [--verify-release <tag> [--repo <owner/repo>]]
 #
 # 场景 1: gh pr merge 后，push 到 main 触发 ci.yml
 # 场景 2: 推送修复后等待 CI 重新运行
@@ -25,10 +25,10 @@ _ci_log() {
     [[ -n "${MERGE_LOG_FILE:-}" ]] && echo "[$(date +%Y-%m-%dT%H:%M:%S)] [CI] $*" >> "$MERGE_LOG_FILE"
 }
 
-REF="${1:?Usage: wait-for-ci.sh <commit-sha> [--timeout 600] [--workflow <name>] [--verify-release <tag>]}"
+REF="${1:?Usage: wait-for-ci.sh <commit-sha> [--timeout 1800] [--workflow <name>] [--verify-release <tag>]}"
 shift || true
 
-TIMEOUT=600           # 默认 10 分钟
+TIMEOUT=1800          # 默认 30 分钟（Docker build 可能较久）
 WORKFLOW=""           # 可选过滤特定 workflow
 VERIFY_RELEASE_TAG="" # 可选：CI 通过后验证 Draft Release 产物
 GH_REPO=""            # 可选：gh --repo 参数
@@ -104,8 +104,8 @@ fi
 echo ""
 
 ELAPSED=0
-POLL_INTERVAL=15
-TRIGGER_WAIT=120   # CI 触发检测窗口：120s（8 次 × 15s）
+POLL_INTERVAL=30
+TRIGGER_WAIT=120   # CI 触发检测窗口：120s（4 次 × 30s）
 FIRST_POLL=true
 
 while true; do
@@ -202,7 +202,7 @@ while true; do
         echo ""
         echo "  建议:"
         echo "    1. 手动检查: gh run list --commit $REF"
-        echo "    2. 增加超时: wait-for-ci.sh $REF --timeout 1200"
+        echo "    2. 增加超时: wait-for-ci.sh $REF --timeout 3600"
         echo "    3. 确认通过后继续后续流程"
         exit 2  # exit 2 = timeout, AI 应询问用户
     fi


### PR DESCRIPTION
## 问题

Post-merge CI（含 Docker build job）实际耗时 routinely 超过 10 分钟，但 `wait-for-ci.sh` 默认 `TIMEOUT=600`（10 分钟）、`POLL_INTERVAL=15`，导致误判超时——本次 PR #202 合并时就因为 Docker build job 耗时长被旧脚本判为「Post-merge CI 失败」，实际 run 还在 `in_progress`（手动 `gh run watch` 确认最终 success）。

## 修改

\`frontend\` 无变更，只改 merge skill 的 CI 等待参数。

### \`wait-for-ci.sh\`
| 参数 | 旧值 | 新值 | 说明 |
|------|------|------|------|
| \`TIMEOUT\` 默认值 | 600s（10min） | 1800s（30min） | Docker build 常超 10min，30min 给充足余量 |
| \`POLL_INTERVAL\` | 15s | 30s | 降低 GitHub API 轮询频率 |
| \`TRIGGER_WAIT\` | 120s | 120s（不变） | 现在是 4 次轮询而非 8 次 |
| 用法/帮助文案中的 \`--timeout\` 示例 | 600 / 1200 | 1800 / 3600 | 与新默认值保持一致 |

### \`merge.sh\` 阶段 5
Release workflow 的 \`wait-for-ci.sh\` 调用从 \`--timeout 900\` 改为 \`--timeout 1800\`（Release 含 Docker build + npm publish，900s 偏紧）。

## 验证

- [x] \`bash -n wait-for-ci.sh\` 语法通过
- [x] 所有 \`--timeout\` 数值引用一致（用法注释、帮助文案、实际调用）
- [x] \`TRIGGER_WAIT=120\` 的「N 次 × Ns」注释同步更新

## 关联

- PR #202 的 post-merge CI 误判根因即此，已通过手动 \`gh run watch 27634609780\` 确认 CI 实际 success。