### PR TITLE
fix(cascading-select): Teleport submenu to body for overflow-safe positioning

### DIFF
--- a/frontend/src/components/ui/cascading-select/CascadingSelect.vue
+++ b/frontend/src/components/ui/cascading-select/CascadingSelect.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed } from "vue";
+import { ref, computed, nextTick } from "vue";
 import { useI18n } from "vue-i18n";
 import { ChevronDown, ChevronRight } from "@lucide/vue";
 import {
@@ -35,8 +35,55 @@ const emit = defineEmits<{
   "update:modelValue": [value: CascadingSelectedValue];
 }>();
 
+const LEAVE_DELAY_MS = 150;
+const SUBMENU_GAP_PX = 2;
+
 const open = ref(false);
 const hoveredGroupKey = ref<string | null>(null);
+const groupRefs = ref<Map<string, HTMLElement>>(new Map());
+const submenuPosition = ref({ top: 0, left: 0 });
+let leaveTimer: ReturnType<typeof setTimeout> | null = null;
+
+function setGroupRef(key: string, el: unknown) {
+  if (el) groupRefs.value.set(key, el as HTMLElement);
+  else groupRefs.value.delete(key);
+}
+
+function onGroupEnter(groupKey: string) {
+  if (leaveTimer) {
+    clearTimeout(leaveTimer);
+    leaveTimer = null;
+  }
+  hoveredGroupKey.value = groupKey;
+  nextTick(() => positionSubmenu(groupKey));
+}
+
+function onGroupLeave() {
+  leaveTimer = setTimeout(() => {
+    hoveredGroupKey.value = null;
+  }, LEAVE_DELAY_MS);
+}
+
+function onSubmenuEnter() {
+  if (leaveTimer) {
+    clearTimeout(leaveTimer);
+    leaveTimer = null;
+  }
+}
+
+function onSubmenuLeave() {
+  hoveredGroupKey.value = null;
+}
+
+function positionSubmenu(groupKey: string) {
+  const el = groupRefs.value.get(groupKey);
+  if (!el) return;
+  const rect = el.getBoundingClientRect();
+  submenuPosition.value = {
+    top: rect.top,
+    left: rect.right + SUBMENU_GAP_PX,
+  };
+}
 
 const displayText = computed(() => {
   if (!props.modelValue) return "";
@@ -90,12 +137,14 @@ function onOpenChange(val: boolean) {
       <div
         v-for="group in groups"
         :key="group.key"
+        :ref="(el) => setGroupRef(group.key, el)"
         class="relative flex cursor-pointer items-center justify-between rounded-sm px-2 py-1.5 text-sm hover:bg-accent hover:text-accent-foreground"
         :class="{
           'bg-accent text-accent-foreground z-10':
             hoveredGroupKey === group.key,
         }"
-        @mouseenter="hoveredGroupKey = group.key"
+        @mouseenter="onGroupEnter(group.key)"
+        @mouseleave="onGroupLeave"
       >
         <span class="truncate max-w-40">{{ group.label }}</span>
         <span
@@ -104,23 +153,34 @@ function onOpenChange(val: boolean) {
           >{{ group.badge }}</span
         >
         <ChevronRight class="ml-1 h-4 w-4 shrink-0 opacity-50" />
+      </div>
 
-        <!-- Level 2 -->
+      <!-- Level 2: Teleported to body to avoid overflow clipping -->
+      <Teleport to="body">
         <div
-          v-if="hoveredGroupKey === group.key && group.options.length > 0"
-          class="absolute left-full top-0 ml-0.5 min-w-48 max-h-[80vh] overflow-y-auto rounded-md bg-popover p-1 text-popover-foreground shadow-md"
-          @mouseenter="hoveredGroupKey = group.key"
+          v-if="
+            hoveredGroupKey &&
+            groups.find((g) => g.key === hoveredGroupKey)?.options.length
+          "
+          class="fixed z-[201] min-w-48 max-h-[80vh] overflow-y-auto rounded-md bg-popover p-1 text-popover-foreground shadow-md"
+          :style="{
+            top: `${submenuPosition.top}px`,
+            left: `${submenuPosition.left}px`,
+          }"
+          @mouseenter="onSubmenuEnter"
+          @mouseleave="onSubmenuLeave"
         >
           <div
-            v-for="option in group.options"
+            v-for="option in groups.find((g) => g.key === hoveredGroupKey)
+              ?.options ?? []"
             :key="option.value"
             class="flex cursor-pointer items-center justify-between gap-2 rounded-sm px-2 py-1.5 text-sm hover:bg-accent hover:text-accent-foreground"
             :class="{
               'bg-accent text-accent-foreground':
-                modelValue?.groupKey === group.key &&
+                modelValue?.groupKey === hoveredGroupKey &&
                 modelValue?.value === option.value,
             }"
-            @click="selectOption(group.key, option.value)"
+            @click="selectOption(hoveredGroupKey!, option.value)"
           >
             <span class="truncate">{{ option.label }}</span>
             <span
@@ -130,7 +190,7 @@ function onOpenChange(val: boolean) {
             >
           </div>
         </div>
-      </div>
+      </Teleport>
 
       <div
         v-if="groups.length === 0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1006,6 +1006,7 @@
       "resolved": "https://registry.npmmirror.com/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1562,6 +1563,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -1585,6 +1587,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -3367,6 +3370,7 @@
       "resolved": "https://registry.npmmirror.com/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
       "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -3448,6 +3452,7 @@
       "resolved": "https://registry.npmmirror.com/@noble/ciphers/-/ciphers-1.3.0.tgz",
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -5231,6 +5236,7 @@
       "integrity": "sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.1",
         "@typescript-eslint/types": "8.59.1",
@@ -5629,6 +5635,7 @@
       "resolved": "https://registry.npmmirror.com/@vue/compiler-dom/-/compiler-dom-3.5.33.tgz",
       "integrity": "sha512-PXq0yrfCLzzL07rbXO4awtXY1Z06LG2eu6Adg3RJFa/j3Cii217XxxLXG22N330gw7GmALCY0Z8RgXEviwgpjA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-core": "3.5.33",
         "@vue/shared": "3.5.33"
@@ -5752,6 +5759,7 @@
       "resolved": "https://registry.npmmirror.com/@vue/server-renderer/-/server-renderer-3.5.33.tgz",
       "integrity": "sha512-0xylq/8/h44lVG0pZFknv1XIdEgymq2E9n59uTWJBG+dIgiT0TMCSsxrN7nO16Z0MU0MPjFcguBbZV8Itk52Hw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-ssr": "3.5.33",
         "@vue/shared": "3.5.33"
@@ -5891,6 +5899,7 @@
       "resolved": "https://registry.npmmirror.com/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6396,6 +6405,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -6604,6 +6614,7 @@
       "resolved": "https://registry.npmmirror.com/chart.js/-/chart.js-4.5.1.tgz",
       "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@kurkle/color": "^0.3.0"
       },
@@ -7742,6 +7753,7 @@
       "resolved": "https://registry.npmmirror.com/eslint/-/eslint-10.3.0.tgz",
       "integrity": "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -9114,6 +9126,7 @@
       "resolved": "https://registry.npmmirror.com/hono/-/hono-4.12.16.tgz",
       "integrity": "sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -9558,6 +9571,7 @@
       "resolved": "https://registry.npmmirror.com/jiti/-/jiti-2.6.1.tgz",
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -9792,6 +9806,7 @@
       "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@asamuzakjp/css-color": "^5.1.11",
         "@asamuzakjp/dom-selector": "^7.1.1",
@@ -9858,6 +9873,7 @@
       "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mdn-data": "2.27.1",
         "source-map-js": "^1.2.1"
@@ -10178,6 +10194,7 @@
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "dev": true,
       "license": "MPL-2.0",
+      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.3"
       },
@@ -11602,6 +11619,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -13371,6 +13389,7 @@
       "resolved": "https://registry.npmmirror.com/stylus/-/stylus-0.57.0.tgz",
       "integrity": "sha512-yOI6G8WYfr0q8v8rRvE91wbxFU+rJPo760Va4MF6K0I6BZjO4r+xSynkvyPBP9tV1CIEUeRsiidjIs2rzb1CnQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "css": "^3.0.0",
         "debug": "^4.3.2",
@@ -13670,6 +13689,7 @@
       "resolved": "https://registry.npmmirror.com/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -14077,6 +14097,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -14098,6 +14119,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14114,6 +14136,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14130,6 +14153,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14146,6 +14170,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14162,6 +14187,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14178,6 +14204,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14194,6 +14221,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14210,6 +14238,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14226,6 +14255,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14242,6 +14272,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14258,6 +14289,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14274,6 +14306,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14290,6 +14323,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14306,6 +14340,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14322,6 +14357,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14338,6 +14374,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14354,6 +14391,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14370,6 +14408,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14386,6 +14425,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14402,6 +14442,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14418,6 +14459,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14434,6 +14476,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14450,6 +14493,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14466,6 +14510,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14482,6 +14527,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14498,6 +14544,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14612,6 +14659,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -14809,6 +14857,7 @@
       "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -16084,6 +16133,7 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -16165,6 +16215,7 @@
       "resolved": "https://registry.npmmirror.com/vue/-/vue-3.5.33.tgz",
       "integrity": "sha512-1AgChhx5w3ALgT4oK3acm2Es/7jyZhWSVUfs3rOBlGQC0rjEDkS7G4lWlJJGGNQD+BV3reCwbQrOe1mPNwKHBQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.33",
         "@vue/compiler-sfc": "3.5.33",
@@ -16702,6 +16753,7 @@
       "integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
       "devOptional": true,
       "license": "ISC",
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -16851,6 +16903,7 @@
       "resolved": "https://registry.npmmirror.com/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
## 问题

commit 1714e839 为级联选择器的 PopoverContent 添加了 ，解决了 provider 超过 15 个时一级列表无法滚动的问题。但 CSS 规范规定：当一个轴为非  时，另一个轴的  会被强制计算为 。这导致 Level 2 子菜单（）被裁切，完全不可见。

## 修复

Teleport Level 2 子菜单到 body，使用  +  定位。两个需求彻底解耦：

- **一级列表滚动**：PopoverContent 保留 
- **二级菜单显示**：Teleport 到 body，不受任何 ancestor overflow 影响

## 变更

- ：Teleport + fixed 定位 + hover bridge（150ms 延迟）+ 提取常量

## 验证

- vue-tsc: 0 errors
- eslint: 0 errors 0 warnings
- 147 test files passed, 1797 tests passed
- Frontend build: success