### PR TITLE
fix(cascading-select): use reka-ui pointerDownOutside API to prevent submenu click being swallowed

### DIFF
--- a/frontend/src/components/ui/cascading-select/CascadingSelect.vue
+++ b/frontend/src/components/ui/cascading-select/CascadingSelect.vue
@@ -8,6 +8,7 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import type { CascadingGroup, CascadingSelectedValue } from "./types";
+import type { PointerDownOutsideEvent } from "reka-ui";
 
 const { t } = useI18n();
 
@@ -36,7 +37,6 @@ const emit = defineEmits<{
 }>();
 
 const LEAVE_DELAY_MS = 150;
-const SUBMENU_GAP_PX = 2;
 
 const open = ref(false);
 const hoveredGroupKey = ref<string | null>(null);
@@ -72,7 +72,9 @@ function onSubmenuEnter() {
 }
 
 function onSubmenuLeave() {
-  hoveredGroupKey.value = null;
+  leaveTimer = setTimeout(() => {
+    hoveredGroupKey.value = null;
+  }, LEAVE_DELAY_MS);
 }
 
 function positionSubmenu(groupKey: string) {
@@ -81,8 +83,21 @@ function positionSubmenu(groupKey: string) {
   const rect = el.getBoundingClientRect();
   submenuPosition.value = {
     top: rect.top,
-    left: rect.right + SUBMENU_GAP_PX,
+    left: rect.right,
   };
+}
+
+/**
+ * reka-ui DismissableLayer 检测 pointerdown outside 时会关闭 Popover。
+ * 子菜单 Teleport 到 body 后不在 [data-dismissable-layer] 内，
+ * 被误判为外部点击。用 reka-ui 提供的 pointerDownOutside 事件，
+ * 当点击目标在子菜单内时 preventDefault() 阻止关闭。
+ */
+function onPointerDownOutside(e: PointerDownOutsideEvent) {
+  const target = e.detail.originalEvent.target as HTMLElement | undefined;
+  if (target?.closest("[data-cascade-submenu]")) {
+    e.preventDefault();
+  }
 }
 
 const displayText = computed(() => {
@@ -133,6 +148,7 @@ function onOpenChange(val: boolean) {
       :align="'start'"
       :side-offset="4"
       class="z-[200] w-auto min-w-56 max-h-[80vh] overflow-y-auto p-1"
+      @pointer-down-outside="onPointerDownOutside"
     >
       <div
         v-for="group in groups"
@@ -162,6 +178,7 @@ function onOpenChange(val: boolean) {
             hoveredGroupKey &&
             groups.find((g) => g.key === hoveredGroupKey)?.options.length
           "
+          data-cascade-submenu
           class="fixed z-[201] min-w-48 max-h-[80vh] overflow-y-auto rounded-md bg-popover p-1 text-popover-foreground shadow-md"
           :style="{
             top: `${submenuPosition.top}px`,


### PR DESCRIPTION
## Problem

After PR #205 (Teleport submenu to body for overflow-safe clicking), selecting a model from the cascading dropdown doesn't work after the first selection. The click on a submenu item is silently swallowed.

## Root Cause

reka-ui's  (used internally by PopoverContent) listens for  on the document to detect 'outside' clicks. After the Teleport, the submenu is no longer inside the  element, so every click on a submenu item is treated as an 'outside click':

1.  fires on submenu item
2. reka-ui detects it's outside 
3. Popover closes → `hoveredGroupKey = null` → submenu unmounts
4. `click` event never fires → selection never updates

Previous fix attempts (#202, #205, #207) addressed symptoms without tracing the full event propagation chain through reka-ui's DismissableLayer.

## Fix

Use reka-ui's **public API** — the `@pointer-down-outside` event on PopoverContent — with `preventDefault()` when the click target is inside the submenu. This is the framework-provided mechanism for customizing dismiss behavior.



Also removes the 2px gap between group items and submenu (`SUBMENU_GAP_PX` 2 → 0) to eliminate the dead zone where the mouse could trigger a leave event during hover transitions.

## Why this is different from previous fixes

| Approach | Level | Durability |
|---|---|---|
| `@pointerdown.stop` (considered) | DOM event propagation | Breaks if reka-ui changes detection method |
| `@pointer-down-outside` + `preventDefault()` (this PR) | reka-ui's DismissableLayer protocol | Framework public API with type contract |

## Verification

- vue-tsc: 0 errors
- eslint: 0 errors 0 warnings
- 152 test files passed, 1834 tests passed
- Frontend build: success