### PR TITLE
fix(ai-retry-rule): 修复 full-endpoint base_url + null upstream_path 的 404

### DIFF
--- a/router/src/admin/retry-rules.ts
+++ b/router/src/admin/retry-rules.ts
@@ -16,7 +16,7 @@ import { getActiveRetryRules } from "../db/retry-rules.js";
 import { getRequestLogById } from "../db/logs.js";
 import { getProviderById } from "../db/providers.js";
 import { getSetting } from "../db/settings.js";
-import { decrypt } from "../utils/crypto.js";
+import { resolveEndpoint } from "../proxy/routing/resolve-endpoint.js";
 import type { StateRegistry } from "../core/registry.js";
 import { HTTP_OK, HTTP_BAD_REQUEST, HTTP_CREATED, HTTP_NOT_FOUND } from "../core/constants.js";
 import { API_CODE, apiError } from "./api-response.js";
@@ -427,14 +427,16 @@ export const adminRetryRuleRoutes: FastifyPluginCallback<RetryRuleRoutesOptions>
       return reply.send({ success: false, error: "AI provider not found" });
     }
 
-    // 6. Decrypt API key
+    // 6. Resolve openai endpoint (兼容 legacy 字段与 ADR 0006 endpoints 数组) + decrypt api key
+    // AI 生成固定走 openai chat 格式，与 resolveEndpoint 的消费者一致，
+    // 避免直读 provider.base_url/upstream_path 旧字段在 endpoints 配置形态下拿到空值。
     const encryptionKey = getSetting(db, "encryption_key");
     if (!encryptionKey) {
       return reply.send({ success: false, error: "Encryption key not set" });
     }
-    let apiKey: string;
+    let endpoint: { base_url: string; upstream_path: string | null; api_key: string };
     try {
-      apiKey = decrypt(provider.api_key, encryptionKey);
+      endpoint = resolveEndpoint(provider, "openai", encryptionKey);
     } catch {
       return reply.send({ success: false, error: "Failed to decrypt API key" });
     }
@@ -448,9 +450,9 @@ export const adminRetryRuleRoutes: FastifyPluginCallback<RetryRuleRoutesOptions>
     let llmResult: { content: string };
     try {
       llmResult = await callLLM({
-        baseUrl: provider.base_url,
-        upstreamPath: provider.upstream_path,
-        apiKey,
+        baseUrl: endpoint.base_url,
+        upstreamPath: endpoint.upstream_path,
+        apiKey: endpoint.api_key,
         model: aiConfig.model,
         messages: [
           { role: "system", content: systemPrompt },

--- a/router/src/utils/llm-client.ts
+++ b/router/src/utils/llm-client.ts
@@ -1,5 +1,6 @@
 import { request as httpRequest } from "http";
 import { request as httpsRequest } from "https";
+import { buildUpstreamUrl } from "../proxy/transport/shared.js";
 
 const DEFAULT_STATUS_CODE = 502;
 const HTTP_OK = 200;
@@ -39,8 +40,12 @@ interface ChatCompletionResponse {
 }
 
 export function callLLM(options: CallLLMOptions): Promise<CallLLMResult> {
+  // 复用代理层 buildUpstreamUrl，确保与正常代理请求使用同一套 URL 拼接逻辑，
+  // 兼容 base_url 已含完整 endpoint 而 upstream_path 为空的 provider 配置。
+  // 若用 new URL(path, baseUrl)，当 path 为绝对路径时会丢弃 baseUrl 的 path 部分，
+  // 导致 https://host/zen/go/v1/chat/completions + 默认 path → https://host/v1/chat/completions (404)。
   const path = options.upstreamPath ?? DEFAULT_UPSTREAM_PATH;
-  const url = new URL(path, options.baseUrl);
+  const url = new URL(buildUpstreamUrl(options.baseUrl, path));
 
   const requestBody: Record<string, unknown> = {
     model: options.model,
@@ -90,7 +95,7 @@ export function callLLM(options: CallLLMOptions): Promise<CallLLMResult> {
         const statusCode = res.statusCode ?? DEFAULT_STATUS_CODE;
 
         if (statusCode < HTTP_OK || statusCode >= HTTP_MULTIPLE_CHOICES) {
-          reject(new Error(`LLM API error: status code ${statusCode}`));
+          reject(new Error(`LLM API error: status ${statusCode} from ${url.href}`));
           return;
         }
 

--- a/router/tests/ai-retry-rule.test.ts
+++ b/router/tests/ai-retry-rule.test.ts
@@ -42,6 +42,27 @@ function createMockLLMServer(
   });
 }
 
+/** Mock LLM server that captures the request path — 用于验证 callLLM 的 URL 拼接 */
+function createMockLLMServerWithCapture(
+  response: Record<string, unknown>,
+  capturePath?: { value: string },
+): Promise<{ server: Server; port: number }> {
+  const server = createServer((req, res) => {
+    if (capturePath && req.url) {
+      capturePath.value = req.url;
+    }
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(JSON.stringify(response));
+  });
+  return new Promise((resolve) => {
+    server.listen(0, () => {
+      const addr = server.address();
+      const port = typeof addr === "object" && addr ? addr.port : 0;
+      resolve({ server, port });
+    });
+  });
+}
+
 function closeMockServer(server: Server): Promise<void> {
   return new Promise((resolve) => {
     server.close(() => resolve());
@@ -948,6 +969,167 @@ describe("AI Retry Rule", () => {
       const responseBodySection = userMessage!.content.split("Response Body:\n")[1];
       expect(responseBodySection).toBeDefined();
       expect(responseBodySection!.length).toBeLessThanOrEqual(4000);
+    } finally {
+      await closeMockServer(mockLLM.server);
+    }
+  });
+
+  // ===== URL 拼接修复 (callLLM 复用 buildUpstreamUrl) =====
+
+  const VALID_RULE_RESPONSE = {
+    choices: [
+      {
+        message: {
+          content: JSON.stringify({
+            summary: "检测到 503 过载",
+            name: "URL Test 503 Retry",
+            status_code: 503,
+            body_pattern: "overloaded",
+            retry_strategy: "exponential",
+            retry_delay_ms: 5000,
+            max_retries: 10,
+            max_delay_ms: 60000,
+          }),
+        },
+      },
+    ],
+  };
+
+  /** 简化：插入错误日志 + 配 AI config 指向 providerId */
+  async function setupErrorLogAndConfig(providerId: string, logId: string) {
+    await app.inject({
+      method: "PUT",
+      url: "/admin/api/proxy-enhancement",
+      headers: { cookie, "content-type": "application/json" },
+      payload: {
+        tool_call_loop_enabled: false,
+        stream_loop_enabled: false,
+        tool_round_limit_enabled: true,
+        tool_error_logging_enabled: false,
+        ai_retry_config: { provider_id: providerId, model: "test-model" },
+      },
+    });
+    insertRequestLog(db, {
+      id: logId,
+      api_type: "openai",
+      model: "test-model",
+      provider_id: providerId,
+      status_code: 503,
+      latency_ms: 32,
+      is_stream: 0,
+      error_message: "overloaded",
+      created_at: new Date().toISOString(),
+    });
+  }
+
+  it("TC-URL-1: upstream_path=null + base_url 含完整 endpoint → 复用 base_url (复现 nuc5 opencode 404)", async () => {
+    const capturedPath = { value: "" };
+    const mockLLM = await createMockLLMServerWithCapture(VALID_RULE_RESPONSE, capturedPath);
+    try {
+      // base_url 已含完整 endpoint，upstream_path 不传（默认 null）
+      const providerId = createProvider(db, {
+        name: "Opencode Go",
+        api_type: "openai",
+        base_url: `http://127.0.0.1:${mockLLM.port}/zen/go/v1/chat/completions`,
+        api_key: encryptedApiKey,
+        is_active: 1,
+        max_concurrency: 10,
+        queue_timeout_ms: 30000,
+        max_queue_size: 100,
+      });
+
+      await setupErrorLogAndConfig(providerId, "url-test-log-1");
+
+      const res = await app.inject({
+        method: "POST",
+        url: "/admin/api/retry-rules/ai-generate",
+        headers: { cookie, "content-type": "application/json" },
+        payload: { log_id: "url-test-log-1" },
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.data.success).toBe(true);
+      // 关键断言：请求打到了 base_url 的完整 path，而非被 new URL 截断为 /v1/chat/completions
+      expect(capturedPath.value).toBe("/zen/go/v1/chat/completions");
+    } finally {
+      await closeMockServer(mockLLM.server);
+    }
+  });
+
+  it("TC-URL-2: upstream_path=null + base_url 仅 origin → 追加默认 /v1/chat/completions (回归保护)", async () => {
+    const capturedPath = { value: "" };
+    const mockLLM = await createMockLLMServerWithCapture(VALID_RULE_RESPONSE, capturedPath);
+    try {
+      // base_url 仅 origin（如 https://api.deepseek.com），upstream_path 不传（默认 null）
+      const providerId = createProvider(db, {
+        name: "DeepSeek Origin Only",
+        api_type: "openai",
+        base_url: `http://127.0.0.1:${mockLLM.port}`,
+        api_key: encryptedApiKey,
+        is_active: 1,
+        max_concurrency: 10,
+        queue_timeout_ms: 30000,
+        max_queue_size: 100,
+      });
+
+      await setupErrorLogAndConfig(providerId, "url-test-log-2");
+
+      const res = await app.inject({
+        method: "POST",
+        url: "/admin/api/retry-rules/ai-generate",
+        headers: { cookie, "content-type": "application/json" },
+        payload: { log_id: "url-test-log-2" },
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.data.success).toBe(true);
+      // 默认 path 被追加
+      expect(capturedPath.value).toBe("/v1/chat/completions");
+    } finally {
+      await closeMockServer(mockLLM.server);
+    }
+  });
+
+  it("TC-EP-1: provider 仅配 endpoints 数组 (ADR 0006) → resolveEndpoint 正确解析 openai endpoint", async () => {
+    const capturedPath = { value: "" };
+    const mockLLM = await createMockLLMServerWithCapture(VALID_RULE_RESPONSE, capturedPath);
+    try {
+      // 旧字段 base_url/upstream_path 为占位空值，真实端点只在 endpoints 数组里
+      const providerId = createProvider(db, {
+        name: "Multi Endpoint Provider",
+        api_type: "openai",
+        base_url: "",
+        upstream_path: null,
+        api_key: encryptedApiKey,
+        is_active: 1,
+        max_concurrency: 10,
+        queue_timeout_ms: 30000,
+        max_queue_size: 100,
+        endpoints: JSON.stringify([
+          {
+            api_type: "openai",
+            base_url: `http://127.0.0.1:${mockLLM.port}/zen/go/v1/chat/completions`,
+            upstream_path: null,
+          },
+        ]),
+      });
+
+      await setupErrorLogAndConfig(providerId, "ep-test-log-1");
+
+      const res = await app.inject({
+        method: "POST",
+        url: "/admin/api/retry-rules/ai-generate",
+        headers: { cookie, "content-type": "application/json" },
+        payload: { log_id: "ep-test-log-1" },
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.data.success).toBe(true);
+      // resolveEndpoint 应从 endpoints 数组取出 openai endpoint 的 base_url
+      expect(capturedPath.value).toBe("/zen/go/v1/chat/completions");
     } finally {
       await closeMockServer(mockLLM.server);
     }


### PR DESCRIPTION
## 问题

在请求明细日志页点「AI 生成重试规则」，后端返回成功但前端 modal 不弹出。实际后端返回：

\`\`\`json
{ "code": 0, "message": "ok", "data": { "success": false, "error": "LLM call failed: LLM API error: status code 404" } }
\`\`\`

## 根因

\`callLLM\`（router/src/utils/llm-client.ts）用 \`new URL(path, baseUrl)\` 拼接 URL，而代理层用的是 \`buildUpstreamUrl\`。**两套 URL 拼接逻辑行为分歧**。

对「base_url 已含完整 endpoint + upstream_path 为 null」的 provider（如 nuc5 部署的 opencode，base_url = \`https://opencode.ai/zen/go/v1/chat/completions\`）：

| | 结果 |
|---|---|
| 代理层 buildUpstreamUrl | ✅ \`https://opencode.ai/zen/go/v1/chat/completions\` |
| callLLM 的 new URL | ❌ \`https://opencode.ai/v1/chat/completions\` → 404 |

\`new URL("/v1/chat/completions", base)\` 中第一个参数是绝对路径，URL 规范丢弃 base 的 path，导致 endpoint 被截断。

## 修复

**第 1 层（根因）**：\`callLLM\` 复用代理层 \`buildUpstreamUrl\`，消除 URL 拼接逻辑重复。一个 provider 能正常代理就一定能用于 AI 生成。

**第 2 层（ADR 0006 对齐）**：ai-generate 端点改走 \`resolveEndpoint(provider, \"openai\", key)\`，不再直读 legacy 字段 \`provider.base_url\`/\`upstream_path\`。兼容 \`endpoints\` 数组配置形态，顺带把 api_key 解密收敛到 \`resolveEndpoint\` 内部。

**第 3 层（诊断）**：LLM 4xx/5xx 错误消息带上实际请求的 URL（\`status 404 from <url>\`），避免下次同类问题再花一小时排查。

## 改动文件

- \`router/src/utils/llm-client.ts\` — 复用 buildUpstreamUrl + 错误带 URL
- \`router/src/admin/retry-rules.ts\` — resolveEndpoint 替代直读 legacy 字段
- \`router/tests/ai-retry-rule.test.ts\` — 新增 TC-URL-1/2、TC-EP-1

## 验证

- [x] 新增测试回退验证：TC-URL-1 回退 \`buildUpstreamUrl\` 改动后红，精确复现 \`/v1/chat/completions\` 截断
- [x] ai-retry-rule.test.ts：18/18 通过
- [x] 全量测试：1837 通过 / 5 跳过
- [x] 后端 ESLint：零警告
- [x] 后端 tsc build：通过

## 测试覆盖

| 用例 | 场景 | 断言 |
|------|------|------|
| TC-URL-1 | upstream_path=null + base_url 含完整 endpoint（复现 nuc5） | 请求打到完整 path \`/zen/go/v1/chat/completions\` |
| TC-URL-2 | upstream_path=null + base_url 仅 origin（回归保护） | 追加默认 \`/v1/chat/completions\` |
| TC-EP-1 | provider 仅配 endpoints 数组（ADR 0006） | resolveEndpoint 正确解析 openai endpoint |

## 不做的事

- 不在 callLLM 加 \`if (upstreamPath == null)\` 特判（会复制 KNOWN_API_SUFFIXES 知识）
- 不把 buildUpstreamUrl 搬到 utils/（它是 transport 层原语，callLLM 依赖 proxy/transport/shared.js 是合理归位）

## 合并方式

按项目规范，base=main 用 **Create a merge commit**（--no-ff）。